### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -28,5 +28,6 @@
     "@nxtensions/astro:preview": { "dependsOn": ["build"] }
   },
   "defaultProject": "personal-website",
-  "nxCloudAccessToken": "YmUzODk4MDAtNDliZS00ZmE1LWFiOTMtYzBiMWJhNDUzNDg5fHJlYWQtd3JpdGU="
+  "nxCloudAccessToken": "YmUzODk4MDAtNDliZS00ZmE1LWFiOTMtYzBiMWJhNDUzNDg5fHJlYWQtd3JpdGU=",
+  "nxCloudId": "672343b2c27b012e2c0fdcc7"
 }

--- a/nx.json
+++ b/nx.json
@@ -11,18 +11,8 @@
   },
   "plugins": [
     "@nxtensions/astro",
-    {
-      "plugin": "@nx/playwright/plugin",
-      "options": {
-        "targetName": "e2e"
-      }
-    },
-    {
-      "plugin": "@nx/eslint/plugin",
-      "options": {
-        "targetName": "lint"
-      }
-    },
+    { "plugin": "@nx/playwright/plugin", "options": { "targetName": "e2e" } },
+    { "plugin": "@nx/eslint/plugin", "options": { "targetName": "lint" } },
     "@monodon/rust"
   ],
   "targetDefaults": {
@@ -35,9 +25,8 @@
       "inputs": ["production", "^production"],
       "cache": true
     },
-    "@nxtensions/astro:preview": {
-      "dependsOn": ["build"]
-    }
+    "@nxtensions/astro:preview": { "dependsOn": ["build"] }
   },
-  "defaultProject": "personal-website"
+  "defaultProject": "personal-website",
+  "nxCloudAccessToken": "YmUzODk4MDAtNDliZS00ZmE1LWFiOTMtYzBiMWJhNDUzNDg5fHJlYWQtd3JpdGU="
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 
    
This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to 
https://cloud.nx.app/orgs/64c50ba0f8d8c4ec261f79df/workspaces/672343b2c27b012e2c0fdcc7

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.