### PR TITLE
fix(personal-website): adjust scroll behavior in main section; change…

### DIFF
--- a/apps/personal-website/src/pages/index.astro
+++ b/apps/personal-website/src/pages/index.astro
@@ -67,7 +67,7 @@ import { getBrandIconName } from '../utils';
       @apply snap-y snap-mandatory scroll-smooth;
     }
     main > section {
-      @apply snap-always snap-center;
+      @apply snap-always snap-start;
     }
     @media (width < 80rem) {
       html,


### PR DESCRIPTION
This pull request includes a small change to the `apps/personal-website/src/pages/index.astro` file. The change modifies the snapping behavior of sections within the main element to start snapping at the beginning instead of the center.

* [`apps/personal-website/src/pages/index.astro`](diffhunk://#diff-92926fb376ff2fd5bb11add5bca8da35ebd5e3779bb2cdbe68a34b1033a53493L70-R70): Changed `@apply snap-always snap-center` to `@apply snap-always snap-start` for the `main > section` selector.