### PR TITLE
fix(personal-website): improve timeline layout; adjust item alignment…

### DIFF
--- a/apps/personal-website/src/components/home/timeline.tsx
+++ b/apps/personal-website/src/components/home/timeline.tsx
@@ -35,15 +35,15 @@ export default function Timeline({ items = [] }: IProps) {
       {items.map((item) => (
         <li
           key={`${item.organization}_${item.position}`}
-          className="flex flex-col *:flex-1 pl-[1em]
-                      sm:pl-0 sm:flex-row sm:odd:flex-row-reverse sm:odd:*:last:text-right sm:even:*:first:text-right sm:gap-10"
+          className="flex flex-col *:flex-1 pl-[1em] relative
+                      sm:pl-0 sm:flex-row sm:items-center sm:odd:flex-row-reverse sm:odd:*:last:text-right sm:even:*:first:text-right sm:gap-10"
         >
+          <div className="text-xs sm:text-base">{item.date}</div>
           <div
             className="absolute size-2 bg-on-background rounded-full 
                           left-0 -translate-x-1/2 top-7 
-                          sm:left-1/2 sm:-translate-x-1/2"
+                          sm:top-auto sm:left-1/2 sm:-translate-x-1/2"
           />
-          <div className="text-xs sm:text-base">{item.date}</div>
           <div>
             <h3 className="sm:text-2xl">{item.organization}</h3>
             <p className="text-sm sm:text-lg text-primary/85">


### PR DESCRIPTION
… and add relative positioning
This pull request includes updates to the `Timeline` component in the `apps/personal-website/src/components/home/timeline.tsx` file. The changes focus on improving the layout and positioning of items within the timeline.

Key changes include:

* Updated the `className` property for the list item (`<li>`) elements to include `relative` positioning and `sm:items-center` for better alignment on small screens.
* Moved the date display from below the timeline marker to above it and added a new `div` for the date with `text-xs` and `sm:text-base` classes for responsive text sizing.
* Adjusted the positioning of the timeline marker (`<div className="absolute size-2 ...">`) to ensure it aligns correctly on different screen sizes.