### PR TITLE
fix(personal-website): enhance ATS-friendly resume component styling …

### DIFF
--- a/apps/personal-website/src/components/resume/ats-friendly.astro
+++ b/apps/personal-website/src/components/resume/ats-friendly.astro
@@ -11,9 +11,9 @@ const skills = _skills;
 ---
 
 <article
-  class="size-full bg-background py-10 px-20 print:p-0 print:bg-none
+  class="size-full bg-background text-on-background py-10 px-20
                 prose prose-sm max-w-none
-                prose-headings:m-0 prose-h2:mb-3 prose-li:m-0 prose-p:mt-0 prose-p:mb-2"
+                prose-headings:text-on-background prose-a:text-on-background prose-li:text-on-background prose-headings:m-0 prose-h2:mb-3 prose-li:m-0 prose-p:mt-0 prose-p:mb-2"
 >
   <section>
     <h1>{info.name.formal.first} {info.name.formal.last}</h1>

--- a/apps/personal-website/src/pages/resume.astro
+++ b/apps/personal-website/src/pages/resume.astro
@@ -1,17 +1,25 @@
 ---
-import { ATSFriendly } from '../components/resume';
 import Layout from '../layouts/index.astro';
+import { ATSFriendly } from '../components/resume';
 import { resume } from '../utils/constants';
 ---
 
 <Layout title="Resume | Rainforest">
   <main
-    class="w-screen h-screen overflow-scroll flex-col-center p-10 print:justify-start print:items-start bg-on-background"
+    class="w-screen h-screen flex-col-center p-10 bg-on-background overflow-scroll
+            print:justify-start print:items-start print:p-0 print:overflow-visible"
   >
     <div
-      class="w-[1050px] h-[1485px] my-auto scale-40 sm:scale-50 md:scale-75 lg:scale-100"
+      class="w-[1050px] h-[1485px] origin-top scale-30 sm:scale-50 md:scale-75 lg:scale-100
+              print:scale-100 print:origin-top-left"
     >
       <ATSFriendly {...resume} />
     </div>
   </main>
+  <style media="print">
+    @page {
+      size: A4;
+      margin: 0 !important;
+    }
+  </style>
 </Layout>


### PR DESCRIPTION
…and layout for better print support
This pull request includes updates to the styling and layout of the resume page on the personal website. The changes improve the visual consistency and print formatting of the resume.

Styling improvements:

* [`apps/personal-website/src/components/resume/ats-friendly.astro`](diffhunk://#diff-83d2275b1f23e7362028fa0ef648c687afa99b8001f72dc5307395ba0d253e46L14-R16): Updated class attributes to ensure consistent text colors for various elements (`prose-headings`, `prose-a`, `prose-li`) within the resume section.

Layout and print formatting:

* `apps/personal-website/src/pages/resume.astro`: 
  * Moved the import statement for `ATSFriendly` to maintain alphabetical order.
  * Adjusted the main container and inner div classes to improve scaling and positioning for both screen and print views.
  * Added a print-specific style block to set the page size to A4 and remove margins for a cleaner print layout.