### PR TITLE
feat(personal-website): add language picker component and refactor na…

### DIFF
--- a/apps/personal-website/src/components/home/language-picker.vue
+++ b/apps/personal-website/src/components/home/language-picker.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="relative">
+    <md-icon-button
+      ref="anchor"
+      aria-label="language-picker"
+      @click="menu.open = !menu?.open"
+    >
+      <md-icon
+        :class="
+          clsx(
+            'text-on-surface-variant md:text-surface xl:text-on-surface',
+            page > 0 ? 'md:text-on-surface' : 'md:text-surface'
+          )
+        "
+        >language</md-icon
+      >
+    </md-icon-button>
+    <md-menu ref="menu" :anchorElement="anchor">
+      <md-menu-item v-for="{ label, href, key } in langs">
+        <a slot="headline" :href="href" @click="cacheLocale(key)">{{
+          label
+        }}</a>
+      </md-menu-item>
+    </md-menu>
+  </div>
+</template>
+<script lang="ts" setup>
+import { Corner, MdMenu } from '@material/web/menu/menu';
+import { computed, useTemplateRef } from 'vue';
+import Cookies from 'js-cookie';
+import { isServerSide, persistentLocaleKey } from '@utils';
+import { useWindowScroll } from '@vueuse/core';
+import clsx from 'clsx';
+import { MdIconButton } from '@material/web/iconbutton/icon-button';
+
+interface ILink {
+  key: string;
+  label: string;
+  href: string;
+}
+export interface IProps {
+  langs: ILink[];
+}
+
+const { langs } = defineProps<IProps>();
+
+const anchor = useTemplateRef<MdIconButton>('anchor');
+const menu = useTemplateRef<MdMenu>('menu');
+
+const cacheLocale = (locale: string) => {
+  Cookies.set(persistentLocaleKey, locale, {
+    path: '/',
+  });
+};
+
+const { y } = useWindowScroll();
+const page = computed(() => {
+  return isServerSide ? 0 : y.value / window.innerHeight;
+});
+</script>

--- a/apps/personal-website/src/components/home/nav.vue
+++ b/apps/personal-website/src/components/home/nav.vue
@@ -14,40 +14,18 @@
           <a :href="href" @click="removeUrlHashAfterNavigation">{{ label }}</a>
         </li>
       </ul>
-      <div class="relative">
-        <md-icon-button
-          id="language-picker-anchor"
-          aria-label="language-picker"
-          @click="menu.open = !menu?.open"
-        >
-          <md-icon
-            :class="
-              clsx(
-                'xl:text-on-surface',
-                page > 0 ? 'text-on-surface' : 'text-surface'
-              )
-            "
-            >language</md-icon
-          >
-        </md-icon-button>
-        <md-menu ref="menu" anchor="language-picker-anchor">
-          <md-menu-item v-for="{ label, href, key } in langs">
-            <a slot="headline" :href="href" @click="cacheLocale(key)">{{
-              label
-            }}</a>
-          </md-menu-item>
-        </md-menu>
-      </div>
+      <LanguagePicker :langs="langs" />
     </div>
     <div class="md:hidden block">
       <aside
         :class="
           clsx(
-            'fixed inset-0 bg-surface-variant text-on-surface-variant',
+            'fixed inset-0 bg-surface-variant text-on-surface-variant px-4',
             open ? 'flex-center flex-col gap-10' : 'hidden'
           )
         "
       >
+        <LanguagePicker :langs="langs" />
         <template v-for="section in sections">
           <div class="flex-col-center gap-4 capitalize">
             <h2 class="text-xl font-semibold">{{ section.title }}</h2>
@@ -81,36 +59,30 @@
 <script lang="ts" setup>
 import '@material/web/iconbutton/icon-button';
 import '@material/web/icon/icon';
-import { MdMenu } from '@material/web/menu/menu';
 import '@material/web/menu/menu-item';
 
-import { computed, ref, useTemplateRef } from 'vue';
+import { computed, ref } from 'vue';
 import clsx from 'clsx';
 import { useWindowScroll } from '@vueuse/core';
-import {
-  isServerSide,
-  persistentLocaleKey,
-  removeUrlHashAfterNavigation,
-} from '@utils';
-import Cookies from 'js-cookie';
+import { isServerSide, removeUrlHashAfterNavigation } from '@utils';
+import LanguagePicker, {
+  IProps as ILanguagePickerProps,
+} from './language-picker.vue';
 
 interface ILink {
   label: string;
   href: string;
 }
 
-interface IProps {
+type Props = {
   anchors: ILink[];
-  langs: (ILink & { key: string })[];
   sections: {
     title: string;
     links: ILink[];
   }[];
-}
+} & ILanguagePickerProps;
 
-const { anchors, langs, sections } = defineProps<IProps>();
-
-const menu = useTemplateRef<MdMenu>('menu');
+const { anchors, langs, sections } = defineProps<Props>();
 
 const open = ref(false);
 
@@ -118,10 +90,4 @@ const { y } = useWindowScroll();
 const page = computed(() => {
   return isServerSide ? 0 : y.value / window.innerHeight;
 });
-
-const cacheLocale = (locale: string) => {
-  Cookies.set(persistentLocaleKey, locale, {
-    path: '/',
-  });
-};
 </script>


### PR DESCRIPTION
…vigation to use it

This pull request refactors the language picker functionality in the personal website project by creating a dedicated `LanguagePicker` component and integrating it into the existing navigation component. The changes improve code organization and reusability.

Key changes include:

### Creation of `LanguagePicker` component:
* [`apps/personal-website/src/components/home/language-picker.vue`](diffhunk://#diff-6a801cffa131d3ecabcbc469002bc4966788c68292d0e2f0c2d0af51088d35deR1-R60): Added a new `LanguagePicker` component to handle the language selection logic and UI.

### Integration of `LanguagePicker` component:
* [`apps/personal-website/src/components/home/nav.vue`](diffhunk://#diff-c6b2fc153d0a6936305f76f465d528acfc82510ef74b9f50d9380e89ceafefc3L17-R28): Replaced the inline language picker code with the new `LanguagePicker` component in the navigation component.
* [`apps/personal-website/src/components/home/nav.vue`](diffhunk://#diff-c6b2fc153d0a6936305f76f465d528acfc82510ef74b9f50d9380e89ceafefc3L84-L126): Updated imports and removed redundant code related to the language picker in the navigation component.