### PR TITLE
Extract source color from image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,6 @@
         "Prisma.prisma",
         "rust-lang.rust-analyzer",
         "ms-playwright.playwright",
-        "serayuzgur.crates",
         "Vue.volar",
         "unifiedjs.vscode-mdx"
       ]

--- a/apps/personal-website/src/components/source-color.vue
+++ b/apps/personal-website/src/components/source-color.vue
@@ -2,42 +2,58 @@
   <div class="relative">
     <button
       id="source-color"
-      :style="{ backgroundColor: $sourceColor.value }"
-      class="size-8 block rounded-full ring-4 ring-tertiary/80 ring-offset-3 hover:size-10 active:size-10 duration-300 cursor-pointer"
-      @click="openMenu"
-    ></button>
+      class="size-10 block rounded-full ring-4 ring-tertiary/80 ring-offset-3 duration-300 cursor-pointer"
+      @click="toggleMenu"
+      :style="{
+        backgroundColor: $sourceColor.value,
+      }"
+    >
+      <img
+        :src="sourceImage"
+        alt="source image"
+        class="size-full rounded-full [[src='']]:hidden"
+      />
+    </button>
     <md-menu ref="menu" id="source-color-menu" anchor="source-color">
-      <div class="relative p-4">
-        <label for="source-color-image" class="w-full h-6 block">
-          <img
-            :src="sourceImage"
-            alt="source image"
-            class="object-cover size-full"
+      <div class="px-4 py-2 space-y-2">
+        <div class="relative">
+          <label
+            for="source-color-image"
+            :style="{
+              borderColor: $sourceColor.value,
+            }"
+            class="w-full aspect-square block cursor-pointer border rounded"
+          >
+            <img
+              :src="sourceImage"
+              alt="source image"
+              class="object-cover size-full [[src='']]:hidden"
+            />
+          </label>
+          <input
+            type="file"
+            name="source-color-image"
+            id="source-color-image"
+            accept="image/*"
+            @change="handleImageChange"
+            class="sr-only size-auto inset-4"
           />
-        </label>
-        <input
-          type="file"
-          name="source-color-image"
-          id="source-color-image"
-          accept="image/*"
-          @change="handleImageChange"
-          class="sr-only size-auto inset-4"
-        />
-      </div>
-      <div class="relative p-4">
-        <label
-          for="source-color-picker"
-          class="w-full h-6 block"
-          :style="{ backgroundColor: $sourceColor.value }"
-        ></label>
-        <input
-          type="color"
-          name="source-color-picker"
-          id="source-color-picker"
-          v-model="sourceColor"
-          @change="reload"
-          class="sr-only size-auto inset-4"
-        />
+        </div>
+        <div class="relative">
+          <label
+            for="source-color-picker"
+            class="w-full h-6 block cursor-pointer rounded"
+            :style="{ backgroundColor: $sourceColor.value }"
+          ></label>
+          <input
+            type="color"
+            name="source-color-picker"
+            id="source-color-picker"
+            v-model="sourceColor"
+            @change="handleColorChange"
+            class="sr-only size-auto inset-4"
+          />
+        </div>
       </div>
     </md-menu>
   </div>
@@ -51,16 +67,23 @@ import { useVModel } from '@nanostores/vue';
 import { sourceColorFromImageBytes } from '@rainforest-dev/rainforest-ui';
 import { $sourceColor } from '@stores';
 import { useLocalStorage } from '@vueuse/core';
-import { effect, useTemplateRef } from 'vue';
+import { useTemplateRef } from 'vue';
 
 const menu = useTemplateRef<MdMenu>('menu');
-const openMenu = () => {
-  if (menu.value) menu.value.open = true;
+const toggleMenu = () => {
+  if (menu.value) menu.value.open = !menu.value.open;
 };
 const sourceColor = useVModel($sourceColor);
 const sourceImage = useLocalStorage('source-image', '');
+console.log(sourceImage.value);
 
 const reload = () => location.reload();
+
+const handleColorChange = () => {
+  if (sourceImage.value) sourceImage.value = '';
+  reload();
+};
+
 const handleImageChange = (event: Event) => {
   const file = (event.target as HTMLInputElement).files?.[0];
   if (file) {

--- a/apps/personal-website/src/components/source-color.vue
+++ b/apps/personal-website/src/components/source-color.vue
@@ -1,25 +1,91 @@
 <template>
-  <div>
-    <input
-      type="color"
-      name="source-color"
+  <div class="relative">
+    <button
       id="source-color"
-      v-model="sourceColor"
-      @change="reload"
-      class="sr-only"
-    />
-    <label
-      for="source-color"
       :style="{ backgroundColor: $sourceColor.value }"
-      class="size-8 block rounded-full ring-1 ring-offset-2"
-    ></label>
+      class="size-8 block rounded-full ring-4 ring-tertiary/80 ring-offset-3 hover:size-10 active:size-10 duration-300 cursor-pointer"
+      @click="openMenu"
+    ></button>
+    <md-menu ref="menu" id="source-color-menu" anchor="source-color">
+      <div class="relative p-4">
+        <label for="source-color-image" class="w-full h-6 block">
+          <img
+            :src="sourceImage"
+            alt="source image"
+            class="object-cover size-full"
+          />
+        </label>
+        <input
+          type="file"
+          name="source-color-image"
+          id="source-color-image"
+          accept="image/*"
+          @change="handleImageChange"
+          class="sr-only size-auto inset-4"
+        />
+      </div>
+      <div class="relative p-4">
+        <label
+          for="source-color-picker"
+          class="w-full h-6 block"
+          :style="{ backgroundColor: $sourceColor.value }"
+        ></label>
+        <input
+          type="color"
+          name="source-color-picker"
+          id="source-color-picker"
+          v-model="sourceColor"
+          @change="reload"
+          class="sr-only size-auto inset-4"
+        />
+      </div>
+    </md-menu>
   </div>
 </template>
 <script lang="ts" setup>
+import { hexFromArgb } from '@material/material-color-utilities';
+import '@material/web/menu/menu';
+import { MdMenu } from '@material/web/menu/menu';
+import '@material/web/menu/menu-item';
 import { useVModel } from '@nanostores/vue';
+import { sourceColorFromImageBytes } from '@rainforest-dev/rainforest-ui';
 import { $sourceColor } from '@stores';
+import { useLocalStorage } from '@vueuse/core';
+import { effect, useTemplateRef } from 'vue';
 
+const menu = useTemplateRef<MdMenu>('menu');
+const openMenu = () => {
+  if (menu.value) menu.value.open = true;
+};
 const sourceColor = useVModel($sourceColor);
+const sourceImage = useLocalStorage('source-image', '');
 
 const reload = () => location.reload();
+const handleImageChange = (event: Event) => {
+  const file = (event.target as HTMLInputElement).files?.[0];
+  if (file) {
+    const reader = new FileReader();
+    reader.onload = async () => {
+      sourceImage.value = reader.result as string;
+
+      const img = new Image();
+      img.src = sourceImage.value;
+      await new Promise((resolve) => (img.onload = resolve));
+      const canvas = document.createElement('canvas');
+      const ctx = canvas.getContext('2d');
+      canvas.width = img.width;
+      canvas.height = img.height;
+      ctx?.drawImage(img, 0, 0);
+      const imageData = ctx?.getImageData(0, 0, img.width, img.height);
+      if (!imageData) return;
+      const argb = sourceColorFromImageBytes(imageData.data);
+      const color = hexFromArgb(argb);
+      if (color && color !== sourceColor.value) {
+        sourceColor.value = color;
+        reload();
+      }
+    };
+    reader.readAsDataURL(file);
+  }
+};
 </script>

--- a/apps/personal-website/src/stores/color-system.ts
+++ b/apps/personal-website/src/stores/color-system.ts
@@ -61,5 +61,5 @@ export const updateColorScheme = (scheme: boolean) => {
 export const persistentKey = 'source-color';
 export const $sourceColor = persistentAtom<string>(
   persistentKey,
-  defaultSourceColor
+  Cookies.get(persistentKey) || defaultSourceColor
 );

--- a/libs/rainforest-ui/src/utils/theme.ts
+++ b/libs/rainforest-ui/src/utils/theme.ts
@@ -1,8 +1,10 @@
 import {
+  argbFromRgb,
   clampDouble,
   type DynamicScheme,
   Hct,
   hexFromArgb,
+  QuantizerCelebi,
   SchemeContent,
   SchemeExpressive,
   SchemeFidelity,
@@ -12,6 +14,7 @@ import {
   SchemeRainbow,
   SchemeTonalSpot,
   SchemeVibrant,
+  Score,
   type TonalPalette,
 } from '@material/material-color-utilities';
 
@@ -233,3 +236,31 @@ export const applyTheme = (theme: Theme, options?: IApplyThemeOptions) => {
     }
   `;
 };
+
+/**
+ * Get the source color from image bytes.
+ *
+ * @param imageBytes The image bytes
+ * @return Source color - the color most suitable for creating a UI theme
+ */
+export function sourceColorFromImageBytes(imageBytes: Uint8ClampedArray) {
+  // Convert Image data to Pixel Array
+  const pixels: number[] = [];
+  for (let i = 0; i < imageBytes.length; i += 4) {
+    const r = imageBytes[i];
+    const g = imageBytes[i + 1];
+    const b = imageBytes[i + 2];
+    const a = imageBytes[i + 3];
+    if (a < 255) {
+      continue;
+    }
+    const argb = argbFromRgb(r, g, b);
+    pixels.push(argb);
+  }
+
+  // Convert Pixels to Material Colors
+  const result = QuantizerCelebi.quantize(pixels, 128);
+  const ranked = Score.score(result);
+  const top = ranked[0];
+  return top;
+}


### PR DESCRIPTION
This pull request includes several changes to improve the color picking functionality, update dependencies, and enhance the theme utilities. The most important changes are grouped by theme below.

### Color Picker Enhancements:
* [`apps/personal-website/src/components/source-color.vue`](diffhunk://#diff-731f0083619208138761492ccc4992d33ac3b6408ebbb8aa0700b6cba1c445b9L2-R113): Replaced the color input with a button and added a menu for selecting a color or an image. Implemented functions to handle color and image changes, including extracting the dominant color from the image for theme updates.

### Dependency Updates:
* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L27): Removed the `serayuzgur.crates` extension from the list of extensions.

### Theme Utility Enhancements:
* [`libs/rainforest-ui/src/utils/theme.ts`](diffhunk://#diff-9b841847e1c95de01a346d17c269bf53d4d9baf3271c6aa015bf0a4153ef4c7aR2-R7): Added the `argbFromRgb`, `QuantizerCelebi`, and `Score` imports. Introduced the `sourceColorFromImageBytes` function to extract the most suitable color from image bytes for creating a UI theme. [[1]](diffhunk://#diff-9b841847e1c95de01a346d17c269bf53d4d9baf3271c6aa015bf0a4153ef4c7aR2-R7) [[2]](diffhunk://#diff-9b841847e1c95de01a346d17c269bf53d4d9baf3271c6aa015bf0a4153ef4c7aR17) [[3]](diffhunk://#diff-9b841847e1c95de01a346d17c269bf53d4d9baf3271c6aa015bf0a4153ef4c7aR239-R266)

### Persistent Color Scheme:
* [`apps/personal-website/src/stores/color-system.ts`](diffhunk://#diff-0a3c23628b729860d8b04a5e7d79a5d6e3e93b30eeeff23b4927416bcd80555aL64-R64): Updated the `$sourceColor` persistent atom to use the value from cookies if available.