### PR TITLE
Bugfix 202412

### DIFF
--- a/apps/personal-website/src/components/home/experiences/index.astro
+++ b/apps/personal-website/src/components/home/experiences/index.astro
@@ -18,7 +18,7 @@ const experiences = (
   import '@material/web/chips/filter-chip';
 </script>
 <Fragment>
-  <div class="size-full sm:h-4/5 sm:overflow-auto grow-1">
+  <div class="size-full">
     <ul
       id="experiences"
       class="flex flex-col gap-4 sm:gap-5 relative

--- a/apps/personal-website/src/components/home/hero/three-columns.astro
+++ b/apps/personal-website/src/components/home/hero/three-columns.astro
@@ -52,9 +52,9 @@ const translatePath = useTranslatedPath(lang);
     alt="profile"
     loading="eager"
     pictureAttributes={{
-      class: 'self-end -mb-10 h-[120%] w-fit',
+      class: 'self-end -mb-10 h-[120%] w-full',
     }}
-    class="object-cover object-center h-full w-max"
+    class="object-cover object-center h-full w-max mx-auto"
     densities={[0.1, 0.5, 1]}
   />
   <div class="flex flex-col justify-center text-surface gap-6">

--- a/apps/personal-website/src/components/source-color.vue
+++ b/apps/personal-website/src/components/source-color.vue
@@ -51,7 +51,7 @@
             id="source-color-picker"
             v-model="sourceColor"
             @change="handleColorChange"
-            class="sr-only size-auto inset-4"
+            class="sr-only size-auto inset-0"
           />
         </div>
       </div>

--- a/apps/personal-website/src/pages/[lang]/index.astro
+++ b/apps/personal-website/src/pages/[lang]/index.astro
@@ -108,7 +108,7 @@ const skills = await getCollection('skills', (item) =>
       <OneColumns {...heroProps} />
     </section>
     <!-- experience -->
-    <section id="experience" class="py-10 sm:h-screen">
+    <section id="experience" class="py-10">
       <div class="container flex-col-center size-full">
         <h2 class="text-4xl mb-10">{t('experience')}</h2>
         <!-- <Experience client:only="react" {...experienceProps} /> -->

--- a/apps/personal-website/src/pages/[lang]/index.astro
+++ b/apps/personal-website/src/pages/[lang]/index.astro
@@ -111,7 +111,6 @@ const skills = await getCollection('skills', (item) =>
     <section id="experience" class="py-10">
       <div class="container flex-col-center size-full">
         <h2 class="text-4xl mb-10">{t('experience')}</h2>
-        <!-- <Experience client:only="react" {...experienceProps} /> -->
         <Experiences />
       </div>
     </section>


### PR DESCRIPTION
This pull request includes several changes to the `apps/personal-website` project, focusing on layout adjustments and styling improvements across multiple components. The most important changes are summarized below:

### Layout Adjustments:

* [`apps/personal-website/src/components/home/experiences/index.astro`](diffhunk://#diff-9c215ff050094f6a5835f0a1e07476e5a025b8ca1f0b18a01a29907cb6e0991aL21-R21): Removed height and overflow styling from the experiences container to ensure it takes up the full available space.
* `apps/personal-website/src/pages/[lang]/index.astro`: Simplified the experience section by removing the height constraint to allow for more flexible content display. ([apps/personal-website/src/pages/[lang]/index.astroL111-L114](diffhunk://#diff-b9321249bbd5c7372164ed109bde596ed7afca7143e64d3237a9588480a0d0b9L111-L114))

### Styling Improvements:

* [`apps/personal-website/src/components/home/hero/three-columns.astro`](diffhunk://#diff-da567af54bf8d165a60ba5bcc55d7f1c0e92632b95a591c3f3f0f132a720124eL55-R57): Adjusted image and container classes to improve the layout and centering of the profile picture.
* [`apps/personal-website/src/components/source-color.vue`](diffhunk://#diff-731f0083619208138761492ccc4992d33ac3b6408ebbb8aa0700b6cba1c445b9L54-R54): Modified the `inset` class to ensure the color picker is properly positioned.