### PR TITLE
fix(personal-website): remove densities from hero image components fo…

### DIFF
--- a/apps/personal-website/src/components/home/hero/one-column.astro
+++ b/apps/personal-website/src/components/home/hero/one-column.astro
@@ -28,7 +28,6 @@ const translatePath = useTranslatedPath(lang);
             'h-full z-10 absolute -bottom-10 md:-bottom-20 left-1/2 -translate-x-1/2 ',
         }}
         class="object-cover object-top -skew-y-12 size-full"
-        densities={[1.5, 2]}
       />
     </div>
     <div

--- a/apps/personal-website/src/components/home/hero/three-columns.astro
+++ b/apps/personal-website/src/components/home/hero/three-columns.astro
@@ -54,7 +54,6 @@ const translatePath = useTranslatedPath(lang);
       class: 'self-end -mb-10 h-[120%] w-full',
     }}
     class="object-cover object-center h-full w-max mx-auto"
-    densities={[1.5, 2]}
   />
   <div class="flex flex-col justify-center text-surface gap-6">
     <ul class="list-disc">


### PR DESCRIPTION
…r optimization

This pull request includes small changes to the `apps/personal-website` project. The changes involve removing the `densities` property from image components in two files to simplify the codebase.

Codebase simplification:

* [`apps/personal-website/src/components/home/hero/one-column.astro`](diffhunk://#diff-169592a6f87849fdb85e35ffe8615ed8ef387e077458883d38bf5b99ed611d0dL31): Removed the `densities` property from the image component.
* [`apps/personal-website/src/components/home/hero/three-columns.astro`](diffhunk://#diff-da567af54bf8d165a60ba5bcc55d7f1c0e92632b95a591c3f3f0f132a720124eL57): Removed the `densities` property from the image component.