### PR TITLE
fix(personal-website): enable eager loading for profile images in her…

### DIFF
--- a/apps/personal-website/src/components/home/hero/one-column.astro
+++ b/apps/personal-website/src/components/home/hero/one-column.astro
@@ -23,6 +23,7 @@ const translatePath = useTranslatedPath(lang);
       <Picture
         src={props.profile}
         alt="profile"
+        loading="eager"
         pictureAttributes={{
           class:
             'h-full z-10 absolute -bottom-10 md:-bottom-20 left-1/2 -translate-x-1/2 ',

--- a/apps/personal-website/src/components/home/hero/three-columns.astro
+++ b/apps/personal-website/src/components/home/hero/three-columns.astro
@@ -50,6 +50,7 @@ const translatePath = useTranslatedPath(lang);
   <Picture
     src={props.profile}
     alt="profile"
+    loading="eager"
     pictureAttributes={{
       class: 'self-end -mb-10 h-[120%] w-full',
     }}


### PR DESCRIPTION
…o components

This pull request includes changes to the `apps/personal-website` project, specifically to the `home/hero` component files. The changes focus on improving the loading behavior of images by setting the `loading` attribute to "eager".

Changes to image loading behavior:

* [`apps/personal-website/src/components/home/hero/one-column.astro`](diffhunk://#diff-169592a6f87849fdb85e35ffe8615ed8ef387e077458883d38bf5b99ed611d0dR26): Added `loading="eager"` attribute to the `Picture` component to ensure the profile image loads eagerly.
* [`apps/personal-website/src/components/home/hero/three-columns.astro`](diffhunk://#diff-da567af54bf8d165a60ba5bcc55d7f1c0e92632b95a591c3f3f0f132a720124eR53): Added `loading="eager"` attribute to the `Picture` component to ensure the profile image loads eagerly.