### PR TITLE
Refactor metadata

### DIFF
--- a/apps/personal-website/src/layouts/blog.astro
+++ b/apps/personal-website/src/layouts/blog.astro
@@ -10,7 +10,13 @@ import BaseLayout from './index.astro';
 
 type Props = CollectionEntry<'blog'>;
 const id = Astro.props.id;
-const { title, pubDate, author: _author, image } = Astro.props.data;
+const {
+  title,
+  description,
+  pubDate,
+  author: _author,
+  image,
+} = Astro.props.data;
 // const author = (await getEntry(_author.collection, _author.id))?.data;
 ---
 
@@ -19,7 +25,12 @@ const { title, pubDate, author: _author, image } = Astro.props.data;
   import '@material/web/icon/icon';
 </script>
 
-<BaseLayout title={title} viewTransition={{ enabled: true }}>
+<BaseLayout
+  title={title}
+  description={description}
+  imageUrl={image?.src}
+  viewTransition={{ enabled: true }}
+>
   {
     image?.src && (
       <Image

--- a/apps/personal-website/src/layouts/head.astro
+++ b/apps/personal-website/src/layouts/head.astro
@@ -1,0 +1,91 @@
+---
+import SpeedInsights from '@vercel/speed-insights/astro';
+
+import type { HeadProps as Props } from './types';
+
+const _imageUrl = new URL(Astro.url.origin, '/images/thumbnail/1.jpg');
+const { title, description, imageUrl = _imageUrl } = Astro.props;
+const url = Astro.url.toString();
+
+const icons = [
+  'arrow_back',
+  'arrow_upward',
+  'chat_bubble',
+  'close',
+  'home',
+  'image',
+  'language',
+  'mail',
+  'menu',
+  'open_in_new',
+];
+const googleFontsLink = `https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=${icons
+  .sort((a, b) => a.localeCompare(b))
+  .join(',')}&display=block`;
+---
+
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width" />
+<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+<meta name="generator" content={Astro.generator} />
+<meta name="theme-color" content="currentColor" />
+<link rel="sitemap" href="/sitemap-index.xml" />
+
+<!-- Open Graph and Twitter Card Metadata  -->
+<title>{title}</title>
+<meta name="title" content={title} />
+<meta property="og:title" content={title} />
+<meta property="twitter:title" content={title} />
+
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Rainforest Tools" />
+<meta property="og:url" content={url} />
+<meta property="twitter:card" content="summary_large_image" />
+<meta property="twitter:site" content="@rainforesttools" />
+<meta property="twitter:url" content={url} />
+
+{
+  description && (
+    <>
+      <meta name="description" content={description} />
+      <meta property="og:description" content={description} />
+      <meta property="twitter:description" content={description} />
+    </>
+  )
+}
+{
+  imageUrl && (
+    <>
+      <meta property="og:image" content={imageUrl} />
+      <meta property="twitter:image" content={imageUrl} />
+    </>
+  )
+}
+
+<!-- Google Fonts -->
+<link
+  rel="preload"
+  href={googleFontsLink}
+  as="style"
+  onload="this.onload=null;this.rel='stylesheet'"
+/>
+<link
+  rel="preload"
+  href="https://fonts.googleapis.com/css2?family=Lora&display=swap"
+  as="style"
+  onload="this.onload=null;this.rel='stylesheet'"
+/>
+<noscript>
+  <link rel="stylesheet" href={googleFontsLink} />
+  <link
+    rel="stylesheet"
+    href="https://fonts.googleapis.com/css2?family=Lora&display=swap"
+  />
+</noscript>
+
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
+<link rel="dns-prefetch" href="https://fonts.gstatic.com" crossorigin />
+<link rel="dns-prefetch" href="https://fonts.googleapis.com" crossorigin />
+
+<SpeedInsights />

--- a/apps/personal-website/src/layouts/head.astro
+++ b/apps/personal-website/src/layouts/head.astro
@@ -3,7 +3,7 @@ import SpeedInsights from '@vercel/speed-insights/astro';
 
 import type { HeadProps as Props } from './types';
 
-const _imageUrl = new URL(Astro.url.origin, '/images/thumbnail/1.jpg');
+const _imageUrl = new URL('/images/thumbnail/1.jpg', Astro.url.origin);
 const { title, description, imageUrl = _imageUrl } = Astro.props;
 const url = Astro.url.toString();
 
@@ -24,68 +24,71 @@ const googleFontsLink = `https://fonts.googleapis.com/css2?family=Material+Symbo
   .join(',')}&display=block`;
 ---
 
-<meta charset="UTF-8" />
-<meta name="viewport" content="width=device-width" />
-<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-<meta name="generator" content={Astro.generator} />
-<meta name="theme-color" content="currentColor" />
-<link rel="sitemap" href="/sitemap-index.xml" />
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <meta name="generator" content={Astro.generator} />
+  <meta name="theme-color" content="currentColor" />
+  <link rel="sitemap" href="/sitemap-index.xml" />
 
-<!-- Open Graph and Twitter Card Metadata  -->
-<title>{title}</title>
-<meta name="title" content={title} />
-<meta property="og:title" content={title} />
-<meta property="twitter:title" content={title} />
+  <!-- Open Graph and Twitter Card Metadata  -->
+  <title>{title}</title>
+  <meta name="title" content={title} />
+  <meta property="og:title" content={title} />
+  <meta property="twitter:title" content={title} />
 
-<meta property="og:type" content="website" />
-<meta property="og:site_name" content="Rainforest Tools" />
-<meta property="og:url" content={url} />
-<meta property="twitter:card" content="summary_large_image" />
-<meta property="twitter:site" content="@rainforesttools" />
-<meta property="twitter:url" content={url} />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Rainforest Tools" />
+  <meta property="og:url" content={url} />
+  <meta property="twitter:card" content="summary_large_image" />
+  <meta property="twitter:site" content="@rainforesttools" />
+  <meta property="twitter:url" content={url} />
 
-{
-  description && (
-    <>
-      <meta name="description" content={description} />
-      <meta property="og:description" content={description} />
-      <meta property="twitter:description" content={description} />
-    </>
-  )
-}
-{
-  imageUrl && (
-    <>
-      <meta property="og:image" content={imageUrl} />
-      <meta property="twitter:image" content={imageUrl} />
-    </>
-  )
-}
+  {
+    description && (
+      <>
+        <meta name="description" content={description} />
+        <meta property="og:description" content={description} />
+        <meta property="twitter:description" content={description} />
+      </>
+    )
+  }
+  {
+    imageUrl && (
+      <>
+        <meta property="og:image" content={imageUrl} />
+        <meta property="twitter:image" content={imageUrl} />
+      </>
+    )
+  }
 
-<!-- Google Fonts -->
-<link
-  rel="preload"
-  href={googleFontsLink}
-  as="style"
-  onload="this.onload=null;this.rel='stylesheet'"
-/>
-<link
-  rel="preload"
-  href="https://fonts.googleapis.com/css2?family=Lora&display=swap"
-  as="style"
-  onload="this.onload=null;this.rel='stylesheet'"
-/>
-<noscript>
-  <link rel="stylesheet" href={googleFontsLink} />
+  <!-- Google Fonts -->
   <link
-    rel="stylesheet"
-    href="https://fonts.googleapis.com/css2?family=Lora&display=swap"
+    rel="preload"
+    href={googleFontsLink}
+    as="style"
+    onload="this.onload=null;this.rel='stylesheet'"
   />
-</noscript>
+  <link
+    rel="preload"
+    href="https://fonts.googleapis.com/css2?family=Lora&display=swap"
+    as="style"
+    onload="this.onload=null;this.rel='stylesheet'"
+  />
+  <noscript>
+    <link rel="stylesheet" href={googleFontsLink} />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Lora&display=swap"
+    />
+  </noscript>
 
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
-<link rel="dns-prefetch" href="https://fonts.gstatic.com" crossorigin />
-<link rel="dns-prefetch" href="https://fonts.googleapis.com" crossorigin />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
+  <link rel="dns-prefetch" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="dns-prefetch" href="https://fonts.googleapis.com" crossorigin />
 
-<SpeedInsights />
+  <SpeedInsights />
+  <slot />
+</head>

--- a/apps/personal-website/src/layouts/index.astro
+++ b/apps/personal-website/src/layouts/index.astro
@@ -2,91 +2,22 @@
 import '../app.css';
 
 import { ThemeProvider } from '@components';
-import SpeedInsights from '@vercel/speed-insights/astro';
 import { ClientRouter } from 'astro:transitions';
 import { dir as _dir } from 'i18next';
 
+import Head from './head.astro';
 import type { Props } from './types';
 
-const { title, description, viewTransition = { enabled: false } } = Astro.props;
+const { viewTransition = { enabled: false }, ...rest } = Astro.props;
 
 const lang = Astro.currentLocale;
 const dir = _dir(lang);
-
-const url = Astro.url.toString();
-
-const icons = [
-  'arrow_back',
-  'arrow_upward',
-  'chat_bubble',
-  'close',
-  'home',
-  'image',
-  'language',
-  'mail',
-  'menu',
-  'open_in_new',
-];
-const googleFontsLink = `https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=${icons
-  .sort((a, b) => a.localeCompare(b))
-  .join(',')}&display=block`;
 ---
 
 <!doctype html>
 <html lang={lang} dir={dir}>
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="generator" content={Astro.generator} />
-    <meta name="theme-color" content="currentColor" />
-    <link rel="sitemap" href="/sitemap-index.xml" />
-
-    <!-- Google Fonts -->
-    <link
-      rel="preload"
-      href={googleFontsLink}
-      as="style"
-      onload="this.onload=null;this.rel='stylesheet'"
-    />
-    <link
-      rel="preload"
-      href="https://fonts.googleapis.com/css2?family=Lora&display=swap"
-      as="style"
-      onload="this.onload=null;this.rel='stylesheet'"
-    />
-    <noscript>
-      <link rel="stylesheet" href={googleFontsLink} />
-      <link
-        rel="stylesheet"
-        href="https://fonts.googleapis.com/css2?family=Lora&display=swap"
-      />
-    </noscript>
-
-    <title>{title}</title>
-    <meta name="title" content={title} />
-    <meta name="description" content={description} />
-
-    <!-- Open Graph / Facebook -->
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content={url} />
-    <meta property="og:title" content={title} />
-    <meta property="og:description" content={description} />
-    <meta property="og:image" content="/images/thumbnail/1.jpg" />
-
-    <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image" />
-    <meta property="twitter:url" content={url} />
-    <meta property="twitter:title" content={title} />
-    <meta property="twitter:description" content={description} />
-    <meta property="twitter:image" content="/images/thumbnail/1.jpg" />
-
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
-    <link rel="dns-prefetch" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="dns-prefetch" href="https://fonts.googleapis.com" crossorigin />
-
-    <SpeedInsights />
+    <Head {...rest} />
     <ThemeProvider server:defer />
     {viewTransition.enabled && <ClientRouter />}
   </head>

--- a/apps/personal-website/src/layouts/index.astro
+++ b/apps/personal-website/src/layouts/index.astro
@@ -16,11 +16,10 @@ const dir = _dir(lang);
 
 <!doctype html>
 <html lang={lang} dir={dir}>
-  <head>
-    <Head {...rest} />
+  <Head {...rest}>
     <ThemeProvider server:defer />
     {viewTransition.enabled && <ClientRouter />}
-  </head>
+  </Head>
   <body>
     <slot />
   </body>

--- a/apps/personal-website/src/layouts/types.ts
+++ b/apps/personal-website/src/layouts/types.ts
@@ -1,6 +1,10 @@
-export interface Props {
+export type HeadProps = {
   title: string;
   description?: string;
+  imageUrl?: string;
+};
+
+export interface Props extends HeadProps {
   viewTransition?: {
     enabled: boolean;
   };

--- a/apps/personal-website/src/pages/index.astro
+++ b/apps/personal-website/src/pages/index.astro
@@ -1,1 +1,3 @@
-<meta http-equiv="refresh" content="0;url=/en/" />
+---
+return Astro.redirect('/en/');
+---

--- a/apps/personal-website/src/pages/resume.astro
+++ b/apps/personal-website/src/pages/resume.astro
@@ -1,1 +1,3 @@
-<meta http-equiv="refresh" content="0;url=/en/resume" />
+---
+return Astro.redirect('/en/resume');
+---


### PR DESCRIPTION
This pull request includes several enhancements and refactorings to the personal website's layout and metadata handling. The changes focus on improving the blog layout, adding metadata to the head component, and refactoring the index layout.

### Enhancements to Blog Layout:
* [`apps/personal-website/src/layouts/blog.astro`](diffhunk://#diff-a9d2364f96a6f1c2bc8f3d7b60bdde8a8d0fb9f7ab0bc7b12d26534feda4ece2L13-R19): Added `description` to the destructured properties from `Astro.props.data` and passed it to `BaseLayout`. [[1]](diffhunk://#diff-a9d2364f96a6f1c2bc8f3d7b60bdde8a8d0fb9f7ab0bc7b12d26534feda4ece2L13-R19) [[2]](diffhunk://#diff-a9d2364f96a6f1c2bc8f3d7b60bdde8a8d0fb9f7ab0bc7b12d26534feda4ece2L22-R33)

### Enhancements to Head Component:
* [`apps/personal-website/src/layouts/head.astro`](diffhunk://#diff-8276cc7e87429fc317e2d59a06fc30f2e78f04c28514ea319c55121c95243510R1-R94): Introduced a new head component that includes metadata for Open Graph, Twitter Card, and Google Fonts.

### Refactoring of Index Layout:
* [`apps/personal-website/src/layouts/index.astro`](diffhunk://#diff-74c7ee4a7eae11a47de3355776c4464e8c86493f029d548eb9ece882650f182bL5-R22): Removed metadata and Google Fonts link from the index layout and replaced them with the new `Head` component.

### Type Definitions Update:
* [`apps/personal-website/src/layouts/types.ts`](diffhunk://#diff-7f4857978a2bb3003effb62607510ca867db489eda809a643d462684ca3d98ebL1-R7): Updated the `Props` interface to include `HeadProps` and added `imageUrl` as an optional property.

### Redirect Handling:
* `apps/personal-website/src/pages/index.astro` and `apps/personal-website/src/pages/resume.astro`: Replaced meta refresh tags with `Astro.redirect` for better handling of redirects. [[1]](diffhunk://#diff-92926fb376ff2fd5bb11add5bca8da35ebd5e3779bb2cdbe68a34b1033a53493L1-R3) [[2]](diffhunk://#diff-5caf04a61d393b54e1e77304fed0e9333a5e48dcba80c7a45b8369818a53db32L1-R3)