### PR TITLE
feat(personal-website): add multilingual support for blog metadata an…

### DIFF
--- a/apps/personal-website/locales/en/blog.json
+++ b/apps/personal-website/locales/en/blog.json
@@ -1,0 +1,4 @@
+{
+  "metadata-title": "Rainforest's Blog",
+  "metadata-description": "Explore the latest in web technology trends and hands-on experiences with homelab setups."
+}

--- a/apps/personal-website/locales/zh/blog.json
+++ b/apps/personal-website/locales/zh/blog.json
@@ -1,0 +1,4 @@
+{
+  "metadata-title": "鄭羽霖的部落格",
+  "metadata-description": "探索最新網路技術趨勢及實踐 HomeLab 設置。"
+}

--- a/apps/personal-website/package.json
+++ b/apps/personal-website/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@astrojs/mdx": "^4.0.3",
     "@astrojs/react": "4.1.0",
+    "@astrojs/rss": "^4.0.11",
     "@astrojs/sitemap": "^3.2.1",
     "@astrojs/vercel": "8.0.1",
     "@astrojs/vue": "5.0.2",

--- a/apps/personal-website/src/layouts/head.astro
+++ b/apps/personal-website/src/layouts/head.astro
@@ -3,8 +3,11 @@ import SpeedInsights from '@vercel/speed-insights/astro';
 
 import type { HeadProps as Props } from './types';
 
-const _imageUrl = new URL('/images/thumbnail/1.jpg', Astro.url.origin);
-const { title, description, imageUrl = _imageUrl } = Astro.props;
+const {
+  title,
+  description,
+  imageUrl = new URL('/images/thumbnail/1.jpg', Astro.site),
+} = Astro.props;
 const url = Astro.url.toString();
 
 const icons = [
@@ -88,6 +91,13 @@ const googleFontsLink = `https://fonts.googleapis.com/css2?family=Material+Symbo
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
   <link rel="dns-prefetch" href="https://fonts.gstatic.com" crossorigin />
   <link rel="dns-prefetch" href="https://fonts.googleapis.com" crossorigin />
+
+  <link
+    rel="alternate"
+    type="application/rss+xml"
+    title={title}
+    href={new URL('rss.xml', Astro.site)}
+  />
 
   <SpeedInsights />
   <slot />

--- a/apps/personal-website/src/pages/[lang]/rss.xml.ts
+++ b/apps/personal-website/src/pages/[lang]/rss.xml.ts
@@ -1,0 +1,20 @@
+import rss from '@astrojs/rss';
+import { useTranslation } from '@utils';
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+
+export const GET: APIRoute = async ({ site, params: { lang = 'en' } }) => {
+  const blog = await getCollection('blog');
+  const { t } = await useTranslation(lang, 'blog');
+  return rss({
+    title: t('metadata-title'),
+    description: t('metadata-description'),
+    site: site!,
+    items: blog.map((post) => ({
+      title: post.data.title,
+      description: post.data.description,
+      pubDate: post.data.pubDate,
+      link: `/blog/${post.id}`,
+    })),
+  });
+};

--- a/apps/personal-website/src/pages/blog/index.astro
+++ b/apps/personal-website/src/pages/blog/index.astro
@@ -6,6 +6,7 @@ import {
   getGitHubUrl,
   getLinkedInUrl,
   useTranslatedPath,
+  useTranslation,
 } from '@utils';
 import { info } from '@utils/constants';
 import { Image } from 'astro:assets';
@@ -14,10 +15,15 @@ import { getCollection } from 'astro:content';
 const posts = (await getCollection('blog')).sort(
   (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
 );
+const { t } = await useTranslation('en', 'blog');
 const translatePath = useTranslatedPath(Astro.currentLocale);
 ---
 
-<Layout title="Blogs" viewTransition={{ enabled: true }}>
+<Layout
+  title={t('metadata-title')}
+  description={t('metadata-description')}
+  viewTransition={{ enabled: true }}
+>
   <script>
     import '@material/web/iconbutton/icon-button';
   </script>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       '@astrojs/react':
         specifier: 4.1.0
         version: 4.1.0(@types/node@22.10.1)(@types/react-dom@19.0.1)(@types/react@19.0.1)(jiti@2.4.1)(less@4.1.3)(lightningcss@1.28.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.83.0)(stylus@0.64.0)(terser@5.36.0)(yaml@2.6.1)
+      '@astrojs/rss':
+        specifier: ^4.0.11
+        version: 4.0.11
       '@astrojs/sitemap':
         specifier: ^3.2.1
         version: 3.2.1
@@ -328,6 +331,9 @@ packages:
       '@types/react-dom': ^17.0.17 || ^18.0.6 || ^19.0.0
       react: ^17.0.2 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.2 || ^18.0.0 || ^19.0.0
+
+  '@astrojs/rss@4.0.11':
+    resolution: {integrity: sha512-3e3H8i6kc97KGnn9iaZBJpIkdoQi8MmR5zH5R+dWsfCM44lLTszOqy1OBfGGxDt56mpQkYVtZJWoxMyWuUZBfw==}
 
   '@astrojs/sitemap@3.2.1':
     resolution: {integrity: sha512-uxMfO8f7pALq0ADL6Lk68UV6dNYjJ2xGUzyjjVj60JLBs5a6smtlkBYv3tQ0DzoqwS7c9n4FUx5lgv0yPo/fgA==}
@@ -4730,6 +4736,10 @@ packages:
   fast-uri@3.0.3:
     resolution: {integrity: sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==}
 
+  fast-xml-parser@4.5.1:
+    resolution: {integrity: sha512-y655CeyUQ+jj7KBbYMc4FG01V8ZQqjN+gDYGJ50RtfsUB8iG9AmwmwoAgeKLJdmueKKMrH1RJ7yXHTSoczdv5w==}
+    hasBin: true
+
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
 
@@ -7712,6 +7722,9 @@ packages:
   strip-literal@2.1.1:
     resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
 
+  strnum@1.0.5:
+    resolution: {integrity: sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==}
+
   strtok3@6.3.0:
     resolution: {integrity: sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==}
     engines: {node: '>=10'}
@@ -8987,6 +9000,11 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  '@astrojs/rss@4.0.11':
+    dependencies:
+      fast-xml-parser: 4.5.1
+      kleur: 4.1.5
 
   '@astrojs/sitemap@3.2.1':
     dependencies:
@@ -14662,6 +14680,10 @@ snapshots:
 
   fast-uri@3.0.3: {}
 
+  fast-xml-parser@4.5.1:
+    dependencies:
+      strnum: 1.0.5
+
   fastq@1.17.1:
     dependencies:
       reusify: 1.0.4
@@ -18188,6 +18210,8 @@ snapshots:
   strip-literal@2.1.1:
     dependencies:
       js-tokens: 9.0.1
+
+  strnum@1.0.5: {}
 
   strtok3@6.3.0:
     dependencies:


### PR DESCRIPTION
…d implement RSS feed

This pull request includes several changes to the `personal-website` project, focusing on adding RSS feed functionality, updating dependencies, and improving localization. The most important changes are grouped by theme below.

### RSS Feed Functionality:

* Added RSS feed generation using `@astrojs/rss` in `rss.xml.ts` file. ([apps/personal-website/src/pages/[lang]/rss.xml.tsR1-R20](diffhunk://#diff-f1cda9c0abbfd070d28d948b84b2f39c2fc67697c9c337c1a5be3bf2f28a5d0bR1-R20))
* Included RSS feed link in the head layout.

### Localization:

* Added English metadata for the blog in `blog.json`.
* Added Chinese metadata for the blog in `blog.json`.

### Code Improvements:

* Refactored `head.astro` to use `Astro.site` for the image URL.
* Updated `index.astro` to use localized metadata for the blog page.