### PR TITLE
Bugfix 202502

### DIFF
--- a/apps/personal-website/src/components/home/fab.vue
+++ b/apps/personal-website/src/components/home/fab.vue
@@ -64,10 +64,10 @@ import { info } from '@utils/constants';
 const menu = useTemplateRef<MdMenu>('menu');
 
 const { y } = useWindowScroll();
-const page = computed(() => {
-  return isServerSide ? 0 : y.value / window.innerHeight;
+const isAtTop = computed(() => {
+  return isServerSide ? true : Math.round(y.value / window.innerHeight);
 });
-const isChatBubbleEnabled = computed(() => page.value <= 0);
+const isChatBubbleEnabled = computed(() => isAtTop.value);
 
 const handleClick = () => {
   if (isChatBubbleEnabled.value) {

--- a/apps/personal-website/src/components/home/hero/one-column.astro
+++ b/apps/personal-website/src/components/home/hero/one-column.astro
@@ -7,6 +7,8 @@ import type { IHeroProps as Props } from '@types';
 import { useTranslatedPath, useTranslation } from '@utils';
 import { Picture } from 'astro:assets';
 
+import ThemeColorModifier from './theme-color-modifier.vue';
+
 const props = Astro.props;
 const year = props.dateOfBirth.getFullYear();
 
@@ -67,6 +69,7 @@ const translatePath = useTranslatedPath(lang);
     </div>
   </div>
 </div>
+<ThemeColorModifier client:load />
 
 <script>
   import { MdFilledButton } from '@material/web/button/filled-button';

--- a/apps/personal-website/src/components/home/hero/theme-color-modifier.vue
+++ b/apps/personal-website/src/components/home/hero/theme-color-modifier.vue
@@ -1,0 +1,56 @@
+<template>
+  <div class="hidden"></div>
+</template>
+<script lang="ts" setup>
+import useThemeColorMeta from '@/hooks/use-theme-color-meta';
+import { isServerSide } from '@/utils';
+import { useWindowScroll } from '@vueuse/core';
+import { computed, onMounted, onUnmounted, watchEffect } from 'vue';
+
+const { y } = useWindowScroll();
+const isAtTop = computed(() => {
+  return isServerSide ? true : Math.round(y.value / window.innerHeight) === 0;
+});
+
+const mediaQueryList = computed(() => {
+  const breakpointXl = getComputedStyle(
+    document.documentElement
+  ).getPropertyValue('--breakpoint-xl');
+  return window.matchMedia(`(min-width: ${breakpointXl})`);
+});
+const { updateThemeColor, reset } = useThemeColorMeta();
+const handleThemeColor = () => {
+  if (isAtTop.value) {
+    updateThemeColor(
+      window
+        .getComputedStyle(document.body)
+        .getPropertyValue('--md-sys-color-inverse-surface')
+    );
+  } else {
+    reset();
+  }
+};
+watchEffect(() => {
+  if (isServerSide) return;
+  if (mediaQueryList.value.matches) return;
+  handleThemeColor();
+});
+
+const handleResize = (e: MediaQueryListEvent) => {
+  if (e.matches) {
+    reset();
+  } else {
+    handleThemeColor();
+  }
+};
+
+onMounted(() => {
+  mediaQueryList.value.addEventListener('change', handleResize);
+});
+onUnmounted(() => {
+  mediaQueryList.value.removeEventListener('change', handleResize);
+});
+</script>
+<style>
+@reference 'tailwindcss';
+</style>

--- a/apps/personal-website/src/components/home/language-picker.vue
+++ b/apps/personal-website/src/components/home/language-picker.vue
@@ -1,15 +1,11 @@
 <template>
   <div class="relative">
-    <md-icon-button
-      ref="anchor"
-      aria-label="language-picker"
-      @click="menu.open = !menu?.open"
-    >
+    <md-icon-button ref="anchor" aria-label="language-picker" @click="toggle">
       <md-icon
         :class="
           clsx(
-            'text-on-surface-variant md:text-surface xl:text-on-surface',
-            page > 0 ? 'md:text-on-surface' : 'md:text-surface'
+            'text-on-surface-variant xl:text-on-surface',
+            !isAtTop ? 'md:text-on-surface' : 'md:text-surface'
           )
         "
         >language</md-icon
@@ -47,6 +43,12 @@ const { langs } = defineProps<IProps>();
 const anchor = useTemplateRef<MdIconButton>('anchor');
 const menu = useTemplateRef<MdMenu>('menu');
 
+const toggle = () => {
+  if (menu.value) {
+    menu.value.open = !menu.value.open;
+  }
+};
+
 const cacheLocale = (locale: string) => {
   Cookies.set(persistentLocaleKey, locale, {
     path: '/',
@@ -54,7 +56,7 @@ const cacheLocale = (locale: string) => {
 };
 
 const { y } = useWindowScroll();
-const page = computed(() => {
-  return isServerSide ? 0 : y.value / window.innerHeight;
+const isAtTop = computed(() => {
+  return isServerSide ? true : Math.round(y.value / window.innerHeight) === 0;
 });
 </script>

--- a/apps/personal-website/src/hooks/use-theme-color-meta.ts
+++ b/apps/personal-website/src/hooks/use-theme-color-meta.ts
@@ -1,0 +1,48 @@
+import { usePreferredColorScheme } from '@vueuse/core';
+import { ref } from 'vue';
+
+export default function useThemeColorMeta() {
+  const preferredColor = usePreferredColorScheme();
+  const media =
+    preferredColor.value === 'no-preference'
+      ? ''
+      : `(prefers-color-scheme: ${preferredColor.value})`;
+  const snapshot = ref<string>();
+  const metaRef = ref<HTMLMetaElement>();
+
+  const updateThemeColor = (color: string) => {
+    metaRef.value = document.querySelector(
+      `meta[name="theme-color"][media="${media}"]`
+    ) as HTMLMetaElement;
+    if (!metaRef.value) {
+      const newMetaTag = document.createElement('meta');
+      newMetaTag.setAttribute('name', 'theme-color');
+      newMetaTag.setAttribute('content', color);
+      if (media) {
+        newMetaTag.setAttribute('media', media);
+      }
+      document.head.appendChild(newMetaTag);
+      metaRef.value = newMetaTag;
+    } else {
+      if (!snapshot.value) snapshot.value = metaRef.value.content;
+      metaRef.value.setAttribute('content', color);
+    }
+  };
+
+  const reset = () => {
+    if (snapshot.value) {
+      if (metaRef.value) {
+        metaRef.value.setAttribute('content', snapshot.value);
+      }
+    } else {
+      if (metaRef.value) {
+        document.head.removeChild(metaRef.value);
+      }
+    }
+  };
+
+  return {
+    updateThemeColor,
+    reset,
+  };
+}

--- a/apps/personal-website/src/pages/blog/index.astro
+++ b/apps/personal-website/src/pages/blog/index.astro
@@ -48,7 +48,7 @@ const translatePath = useTranslatedPath(Astro.currentLocale);
     </div>
   </nav>
   <main class="container py-10">
-    <h1 class="text-9xl text-center mb-10">Rainforest Cheng</h1>
+    <h1 class="text-5xl md:text-9xl text-center mb-10">Rainforest Cheng</h1>
     <div
       class="grid grid-flow-row grid-cols-1 sm:grid-cols-3 md:grid-cols-3 lg:grid-cols-5 gap-5 auto-rows-max *:px-4 *:py-3 *:border border"
     >


### PR DESCRIPTION
This pull request includes several changes to improve the user experience and code maintainability of the personal website. The most important changes include the introduction of a new `ThemeColorModifier` component, refactoring of the scroll-based logic, and updates to the theme color handling.

### Introduction of `ThemeColorModifier` component:
* Added a new `ThemeColorModifier` component to dynamically update the theme color based on the scroll position. (`apps/personal-website/src/components/home/hero/theme-color-modifier.vue`)

### Refactoring of scroll-based logic:
* Replaced the `page` computed property with `isAtTop` to determine if the user is at the top of the page. This change was applied across multiple components including `fab.vue`, `language-picker.vue`, and `nav.vue`. (`apps/personal-website/src/components/home/fab.vue`) [[1]](diffhunk://#diff-1dd56ddd72974743f1e79efccc8daa8563a7de54c2a07f41151d361046a24806L67-R70) (`apps/personal-website/src/components/home/language-picker.vue`) [[2]](diffhunk://#diff-6a801cffa131d3ecabcbc469002bc4966788c68292d0e2f0c2d0af51088d35deL3-R8) (`apps/personal-website/src/components/home/nav.vue`) [[3]](diffhunk://#diff-c6b2fc153d0a6936305f76f465d528acfc82510ef74b9f50d9380e89ceafefc3L6-R6)

### Updates to theme color handling:
* Introduced `useThemeColorMeta` hook to manage the meta theme color dynamically based on the preferred color scheme and scroll position. This hook is utilized in the `nav.vue` and `ThemeColorModifier` components. (`apps/personal-website/src/hooks/use-theme-color-meta.ts`) [[1]](diffhunk://#diff-f078e06e4f1a67fec831c36a55d70a7f566690204904b18d8a387c9c886eca5bR1-R48) (`apps/personal-website/src/components/home/nav.vue`) [[2]](diffhunk://#diff-c6b2fc153d0a6936305f76f465d528acfc82510ef74b9f50d9380e89ceafefc3L68-R75)

### Minor UI adjustments:
* Adjusted the font size of the blog page title for better responsiveness. (`apps/personal-website/src/pages/blog/index.astro`)
* Added the `ThemeColorModifier` component to the `hero/one-column.astro` file to ensure it is loaded on the client side. (`apps/personal-website/src/components/home/hero/one-column.astro`) [[1]](diffhunk://#diff-169592a6f87849fdb85e35ffe8615ed8ef387e077458883d38bf5b99ed611d0dR10-R11) [[2]](diffhunk://#diff-169592a6f87849fdb85e35ffe8615ed8ef387e077458883d38bf5b99ed611d0dR72)