### PR TITLE
fix: simplify condition in watchEffect for theme color update

### DIFF
--- a/apps/personal-website/src/components/home/nav.vue
+++ b/apps/personal-website/src/components/home/nav.vue
@@ -100,7 +100,7 @@ const { updateThemeColor, reset } = useThemeColorMeta();
 
 watchEffect(() => {
   if (isServerSide) return;
-  if (open.value || isAtTop.value) {
+  if (open.value) {
     const color = window
       .getComputedStyle(document.body)
       .getPropertyValue('--md-sys-color-surface');


### PR DESCRIPTION
This pull request includes a small change to the `apps/personal-website/src/components/home/nav.vue` file. The change modifies the condition in a `watchEffect` function to update the theme color only when the `open` value is true, removing the additional check for `isAtTop.value`.

* [`apps/personal-website/src/components/home/nav.vue`](diffhunk://#diff-c6b2fc153d0a6936305f76f465d528acfc82510ef74b9f50d9380e89ceafefc3L103-R103): Modified the condition in `watchEffect` to update the theme color based solely on `open.value`.