### PR TITLE
refactor: streamline theme color handling and improve event listener …

### DIFF
--- a/apps/personal-website/src/components/home/hero/theme-color-modifier.vue
+++ b/apps/personal-website/src/components/home/hero/theme-color-modifier.vue
@@ -20,6 +20,8 @@ const mediaQueryList = computed(() => {
 });
 const { updateThemeColor, reset } = useThemeColorMeta();
 const handleThemeColor = () => {
+  if (isServerSide) return;
+  if (mediaQueryList.value.matches) return;
   if (isAtTop.value) {
     updateThemeColor(
       window
@@ -30,11 +32,7 @@ const handleThemeColor = () => {
     reset();
   }
 };
-watchEffect(() => {
-  if (isServerSide) return;
-  if (mediaQueryList.value.matches) return;
-  handleThemeColor();
-});
+watchEffect(handleThemeColor);
 
 const handleResize = (e: MediaQueryListEvent) => {
   if (e.matches) {
@@ -46,9 +44,15 @@ const handleResize = (e: MediaQueryListEvent) => {
 
 onMounted(() => {
   mediaQueryList.value.addEventListener('change', handleResize);
+  window
+    .matchMedia('(prefers-color-scheme: dark)')
+    .addEventListener('change', handleThemeColor);
 });
 onUnmounted(() => {
   mediaQueryList.value.removeEventListener('change', handleResize);
+  window
+    .matchMedia('(prefers-color-scheme: dark)')
+    .removeEventListener('change', handleThemeColor);
 });
 </script>
 <style>

--- a/apps/personal-website/src/hooks/use-theme-color-meta.ts
+++ b/apps/personal-website/src/hooks/use-theme-color-meta.ts
@@ -1,25 +1,33 @@
-import { usePreferredColorScheme } from '@vueuse/core';
-import { ref } from 'vue';
+import { usePreferredDark } from '@vueuse/core';
+import { computed, ref, watch } from 'vue';
 
 export default function useThemeColorMeta() {
-  const preferredColor = usePreferredColorScheme();
-  const media =
-    preferredColor.value === 'no-preference'
-      ? ''
-      : `(prefers-color-scheme: ${preferredColor.value})`;
+  const isDark = usePreferredDark();
+  const media = computed(
+    () => `(prefers-color-scheme: ${isDark.value ? 'dark' : 'light'})`
+  );
   const snapshot = ref<string>();
   const metaRef = ref<HTMLMetaElement>();
 
+  watch(media, () => {
+    reset();
+    metaRef.value = undefined;
+    snapshot.value = undefined;
+  });
+
   const updateThemeColor = (color: string) => {
-    metaRef.value = document.querySelector(
-      `meta[name="theme-color"][media="${media}"]`
+    const metaTag = document.querySelector(
+      `meta[name="theme-color"][media="${media.value}"]`
     ) as HTMLMetaElement;
+    if (metaRef.value !== metaTag) {
+      metaRef.value = metaTag;
+    }
     if (!metaRef.value) {
       const newMetaTag = document.createElement('meta');
       newMetaTag.setAttribute('name', 'theme-color');
       newMetaTag.setAttribute('content', color);
       if (media) {
-        newMetaTag.setAttribute('media', media);
+        newMetaTag.setAttribute('media', media.value);
       }
       document.head.appendChild(newMetaTag);
       metaRef.value = newMetaTag;


### PR DESCRIPTION
This pull request includes several changes to the theme color handling in the `apps/personal-website` project. The changes aim to improve the handling of theme color updates based on user preferences and media queries.

### Theme Color Handling Improvements:

* [`apps/personal-website/src/components/home/hero/theme-color-modifier.vue`](diffhunk://#diff-12e676fae15ea1db3ab48f50d77c853679dd6ed5c54143e2029d290a437cb266R23-R24): Added checks for server-side rendering and media query matches to the `handleThemeColor` function, and simplified the `watchEffect` usage. Additionally, added event listeners for changes in the preferred color scheme. [[1]](diffhunk://#diff-12e676fae15ea1db3ab48f50d77c853679dd6ed5c54143e2029d290a437cb266R23-R24) [[2]](diffhunk://#diff-12e676fae15ea1db3ab48f50d77c853679dd6ed5c54143e2029d290a437cb266L33-R35) [[3]](diffhunk://#diff-12e676fae15ea1db3ab48f50d77c853679dd6ed5c54143e2029d290a437cb266R47-R55)

### Hook Updates:

* [`apps/personal-website/src/hooks/use-theme-color-meta.ts`](diffhunk://#diff-f078e06e4f1a67fec831c36a55d70a7f566690204904b18d8a387c9c886eca5bL1-R30): Replaced `usePreferredColorScheme` with `usePreferredDark` for better handling of dark mode preferences. Updated the `media` variable to be a computed property and added a `watch` to reset the theme color meta when the media query changes. Simplified the `updateThemeColor` function to use the computed `media` value.