### PR TITLE
Bottom navigation in blog page

### DIFF
--- a/apps/personal-website/src/components/blog/index.ts
+++ b/apps/personal-website/src/components/blog/index.ts
@@ -1,3 +1,4 @@
 export { default as Baseline } from './baseline.astro';
 export { default as Comments } from './comments.astro';
+export { default as Navigation } from './navigation.astro';
 export { default as Post } from './post.astro';

--- a/apps/personal-website/src/components/blog/navigation.astro
+++ b/apps/personal-website/src/components/blog/navigation.astro
@@ -1,0 +1,45 @@
+---
+import clsx from 'clsx';
+
+interface Props {
+  links?: {
+    label: string;
+    path: string;
+  }[];
+}
+const {
+  links = [
+    {
+      label: 'Blogs',
+      path: '/blog',
+    },
+    {
+      label: 'Posts',
+      path: '/posts',
+    },
+  ],
+} = Astro.props;
+const pathname = new URL(Astro.request.url).pathname;
+---
+
+<div class="h-10 bg-surface-container-high rounded-full shadow-lg">
+  {
+    links.map((link) => (
+      <a
+        href={link.path}
+        class={clsx(
+          'px-4 py-2 rounded-full flex-center inline-flex relative z-0',
+          pathname === link.path && 'text-on-primary'
+        )}
+      >
+        {pathname === link.path && (
+          <span
+            class="absolute inset-0 rounded-full bg-primary"
+            transition:name="active-link"
+          />
+        )}
+        <span class="z-10">{link.label}</span>
+      </a>
+    ))
+  }
+</div>

--- a/apps/personal-website/src/pages/blog/index.astro
+++ b/apps/personal-website/src/pages/blog/index.astro
@@ -12,6 +12,8 @@ import { info } from '@utils/constants';
 import { Image } from 'astro:assets';
 import { getCollection } from 'astro:content';
 
+import { Navigation } from '@/components/blog';
+
 const posts = (await getCollection('blog')).sort(
   (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
 );
@@ -79,6 +81,9 @@ const translatePath = useTranslatedPath(Astro.currentLocale);
           </a>
         ))
       }
+    </div>
+    <div class="fixed bottom-10 left-1/2 -translate-x-1/2">
+      <Navigation />
     </div>
     <div class="fixed right-10 bottom-10 z-10">
       <SourceColor client:only="vue" />

--- a/apps/personal-website/src/pages/blog/index.astro
+++ b/apps/personal-website/src/pages/blog/index.astro
@@ -60,10 +60,13 @@ const translatePath = useTranslatedPath(Astro.currentLocale);
       {
         posts.map(({ data: post, id }) => (
           <a
-            class="inline-flex flex-col gap-4 md:first:col-span-full md:first:flex-row-center @container prose-sm max-w-none bg-surface-container-high rounded-lg overflow-hidden hover:shadow"
             href={translatePath(`/blog/${id}`)}
+            class="
+              md:first:col-span-full lg:first:h-[30dvh] md:first:h-[20dvh] bg-surface-container-high rounded-lg overflow-hidden hover:shadow 
+              @container prose-sm max-w-none
+              flex gap-4 flex-col md:first:flex-row-center"
           >
-            <div class="@2xl:w-1/3 w-full @2xl:max-w-96 aspect-square flex-center grow-0">
+            <div class="md:@2xl:h-full @2xl:w-auto w-full aspect-square flex-center">
               {post.image?.src ? (
                 <Image
                   width={128}

--- a/apps/personal-website/src/pages/blog/index.astro
+++ b/apps/personal-website/src/pages/blog/index.astro
@@ -14,9 +14,12 @@ import { getCollection } from 'astro:content';
 
 import { Navigation } from '@/components/blog';
 
-const posts = (await getCollection('blog')).sort(
-  (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
-);
+const posts = (
+  await getCollection(
+    'blog',
+    (entry) => !entry.data.tags.includes('type:quick-post')
+  )
+).sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 const { t } = await useTranslation('en', 'blog');
 const translatePath = useTranslatedPath(Astro.currentLocale);
 ---

--- a/apps/personal-website/src/pages/posts/index.astro
+++ b/apps/personal-website/src/pages/posts/index.astro
@@ -1,5 +1,5 @@
 ---
-import { Post } from '@components/blog';
+import { Navigation, Post } from '@components/blog';
 import Layout from '@layouts/index.astro';
 import { getCollection } from 'astro:content';
 
@@ -8,7 +8,7 @@ const posts = await getCollection('blog', ({ data }) =>
 );
 ---
 
-<Layout title="Quick Posts">
+<Layout title="Quick Posts" viewTransition={{ enabled: true }}>
   <main class="container py-10 space-y-8">
     {
       posts
@@ -20,5 +20,8 @@ const posts = await getCollection('blog', ({ data }) =>
         })
         .map((post) => <Post {...post} />)
     }
+    <div class="fixed bottom-10 left-1/2 -translate-x-1/2">
+      <Navigation />
+    </div>
   </main>
 </Layout>


### PR DESCRIPTION
This pull request introduces a new `Navigation` component to the blog and posts pages of the personal website and includes several updates to the layout and filtering of blog posts. The most important changes are summarized below:

### New Navigation Component:

* Added a new `Navigation` component to the `apps/personal-website/src/components/blog/navigation.astro` file. This component dynamically generates navigation links based on the current URL path.
* Exported the new `Navigation` component in the `apps/personal-website/src/components/blog/index.ts` file.

### Integration of Navigation Component:

* Integrated the `Navigation` component into the blog page by importing it and adding it to the layout. [[1]](diffhunk://#diff-57d8c7d678008da110dbbbfd740b9fd3e66e602b05b92ec368caf20eb19cbe4cL15-R22) [[2]](diffhunk://#diff-57d8c7d678008da110dbbbfd740b9fd3e66e602b05b92ec368caf20eb19cbe4cR91-R93)
* Integrated the `Navigation` component into the posts page by importing it and adding it to the layout. [[1]](diffhunk://#diff-e911407ce7d8f267f9b777361d1f9eb21408534fe506ade3f98022ab67d99730L2-R2) [[2]](diffhunk://#diff-e911407ce7d8f267f9b777361d1f9eb21408534fe506ade3f98022ab67d99730R23-R25)

### Layout and Filtering Updates:

* Updated the blog page to exclude posts with the tag `type:quick-post` from the main blog collection.
* Enhanced the layout of the blog page by adjusting the class names for better responsiveness and visual hierarchy.
* Enabled view transitions for the posts page layout for a smoother user experience.