### PR TITLE
refactor(personal-website): move SourceColor to global layout

### DIFF
--- a/apps/personal-website/src/layouts/blog.astro
+++ b/apps/personal-website/src/layouts/blog.astro
@@ -6,8 +6,6 @@ import clsx from 'clsx';
 // import { getEntry } from 'astro:content';
 import { format } from 'date-fns';
 
-import { SourceColor } from '@/components';
-
 import BaseLayout from './index.astro';
 
 type Props = CollectionEntry<'blog'>;
@@ -62,9 +60,6 @@ const {
       <slot />
     </div>
   </article>
-  <div class="fixed right-10 bottom-10 z-10">
-    <SourceColor client:only="vue" />
-  </div>
   <section class="container pb-20">
     <Comments />
   </section>

--- a/apps/personal-website/src/layouts/index.astro
+++ b/apps/personal-website/src/layouts/index.astro
@@ -1,7 +1,7 @@
 ---
 import '../app.css';
 
-import { ThemeProvider } from '@components';
+import { SourceColor, ThemeProvider } from '@components';
 import { ClientRouter } from 'astro:transitions';
 import { dir as _dir } from 'i18next';
 
@@ -22,5 +22,8 @@ const dir = _dir(lang);
   </Head>
   <body>
     <slot />
+    <div class="fixed right-10 bottom-10 z-10 print:hidden">
+      <SourceColor client:only="vue" />
+    </div>
   </body>
 </html>

--- a/apps/personal-website/src/pages/[lang]/index.astro
+++ b/apps/personal-website/src/pages/[lang]/index.astro
@@ -1,5 +1,4 @@
 ---
-import { SourceColor } from '@components';
 import {
   ContactForm,
   Footer,
@@ -95,9 +94,6 @@ const skills = (
         <ContactForm id="contact-form-menu" />
       </Fragment>
     </Nav>
-    <div class="fixed right-10 bottom-10 z-10">
-      <SourceColor client:only="vue" />
-    </div>
     <!-- hero -->
     <section class="flex-center container h-screen xl:flex hidden">
       <ThreeColumns {...heroProps} />

--- a/apps/personal-website/src/pages/settings.astro
+++ b/apps/personal-website/src/pages/settings.astro
@@ -1,11 +1,10 @@
 ---
-import { ColorSystem, SourceColor } from '@components';
+import { ColorSystem } from '@components';
 import Layout from '@layouts/index.astro';
 ---
 
 <Layout title="Settings">
   <main class="container flex-col-center gap-3 py-10">
-    <SourceColor client:only="vue" />
     <div class="flex flex-col lg:flex-row size-full">
       <div class="w-full bg-surface p-8 border" data-scheme="light">
         <ColorSystem client:load />


### PR DESCRIPTION
This pull request includes changes to the `apps/personal-website` project, focusing on the removal and relocation of the `SourceColor` component. The most important changes include the removal of `SourceColor` from certain files and its addition to others, ensuring a consistent layout and functionality across the site.

Changes to `SourceColor` component usage:

* [`apps/personal-website/src/layouts/blog.astro`](diffhunk://#diff-a9d2364f96a6f1c2bc8f3d7b60bdde8a8d0fb9f7ab0bc7b12d26534feda4ece2L9-L10): Removed the import and usage of `SourceColor` component. [[1]](diffhunk://#diff-a9d2364f96a6f1c2bc8f3d7b60bdde8a8d0fb9f7ab0bc7b12d26534feda4ece2L9-L10) [[2]](diffhunk://#diff-a9d2364f96a6f1c2bc8f3d7b60bdde8a8d0fb9f7ab0bc7b12d26534feda4ece2L65-L67)
* [`apps/personal-website/src/layouts/index.astro`](diffhunk://#diff-74c7ee4a7eae11a47de3355776c4464e8c86493f029d548eb9ece882650f182bL4-R4): Added the `SourceColor` component to the layout file, ensuring it is displayed in a fixed position on the page. [[1]](diffhunk://#diff-74c7ee4a7eae11a47de3355776c4464e8c86493f029d548eb9ece882650f182bL4-R4) [[2]](diffhunk://#diff-74c7ee4a7eae11a47de3355776c4464e8c86493f029d548eb9ece882650f182bR25-R27)
* `apps/personal-website/src/pages/[lang]/index.astro`: Removed the import and usage of `SourceColor` component. ([apps/personal-website/src/pages/[lang]/index.astroL2](diffhunk://#diff-b9321249bbd5c7372164ed109bde596ed7afca7143e64d3237a9588480a0d0b9L2), [apps/personal-website/src/pages/[lang]/index.astroL98-L100](diffhunk://#diff-b9321249bbd5c7372164ed109bde596ed7afca7143e64d3237a9588480a0d0b9L98-L100))
* [`apps/personal-website/src/pages/settings.astro`](diffhunk://#diff-0e4f12bbb0958f333a5fb3a90468d3a6be54b51312126c406d6b62be876199d7L2-L8): Removed the `SourceColor` component from the settings page.