### PR TITLE
feat(personal-website): personal context MCP server (mcp.rainforest.tools)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ storybook-static
 
 # Dev secrets
 deploy/.env.dev
+
+# superpowers git worktrees
+.worktrees/

--- a/apps/personal-website/package.json
+++ b/apps/personal-website/package.json
@@ -21,6 +21,7 @@
     "@material/material-color-utilities": "catalog:",
     "@material/web": "^2.4.1",
     "@mlc-ai/web-llm": "^0.2.80",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@nanostores/lit": "^0.2.3",
     "@nanostores/persistent": "^1.2.0",
     "@nanostores/react": "^1.0.0",
@@ -41,13 +42,15 @@
     "lit": "catalog:",
     "lodash-es": "^4.17.23",
     "marked": "^17.0.1",
+    "mcp-handler": "^1.1.0",
     "nanostores": "^1.1.0",
     "react": "catalog:",
     "react-dom": "catalog:",
     "rehype-katex": "^7.0.1",
     "remark-math": "^6.0.0",
     "tailwindcss": "catalog:",
-    "vue": "^3.5.32"
+    "vue": "^3.5.32",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",

--- a/apps/personal-website/src/mcp/profile-data.fixtures.ts
+++ b/apps/personal-website/src/mcp/profile-data.fixtures.ts
@@ -1,0 +1,79 @@
+export const organizationFixtures = [
+  { id: 'en/codegreen', collection: 'organizations' as const, data: { name: 'CodeGreen', language: 'en', link: 'https://www.codegreen.org' } },
+  { id: 'en/jubo', collection: 'organizations' as const, data: { name: 'Jubo', language: 'en' } },
+  { id: 'en/master', collection: 'organizations' as const, data: { name: 'Master University', language: 'en' } },
+];
+
+export const experienceFixtures = [
+  {
+    id: 'en/6',
+    collection: 'experiences' as const,
+    data: {
+      type: 'job' as const,
+      language: 'en',
+      organization: { collection: 'organizations' as const, id: 'en/codegreen' },
+      position: 'Senior Frontend Engineer',
+      startAt: new Date('2022-07-01'),
+      endAt: new Date('2024-10-01'),
+      technologies: [] as string[],
+      projects: [{ collection: 'projects' as const, id: 'en/opencgt' }],
+    },
+    body: 'Worked at a startup from the ground up.',
+  },
+  {
+    id: 'en/5',
+    collection: 'experiences' as const,
+    data: {
+      type: 'job' as const,
+      language: 'en',
+      organization: { collection: 'organizations' as const, id: 'en/jubo' },
+      position: 'Software Intern',
+      startAt: new Date('2020-12-01'),
+      endAt: new Date('2021-06-01'),
+      technologies: ['react', 'flutter'],
+      projects: [] as { collection: 'projects'; id: string }[],
+    },
+    body: 'Maintained long-term care applications.',
+  },
+  {
+    id: 'en/2',
+    collection: 'experiences' as const,
+    data: {
+      type: 'education' as const,
+      language: 'en',
+      organization: { collection: 'organizations' as const, id: 'en/master' },
+      position: 'Master of Computer Science',
+      startAt: new Date('2018-09-01'),
+      endAt: new Date('2020-06-01'),
+      technologies: [] as string[],
+      projects: [] as { collection: 'projects'; id: string }[],
+    },
+    body: 'Graduate studies.',
+  },
+];
+
+export const projectFixtures = [
+  {
+    id: 'en/opencgt',
+    collection: 'projects' as const,
+    data: {
+      name: 'OpenCGT',
+      language: 'en',
+      technologies: ['nextjs', 'auth0', 'mui', 'playwright', 'vitest'],
+      organization: { collection: 'organizations' as const, id: 'en/codegreen' },
+      experience: { collection: 'experiences' as const, id: 'en/6' },
+    },
+    body: 'Led frontend development for a B2B product.',
+  },
+];
+
+export const skillFixtures = [
+  { id: 'en/ts', collection: 'skills' as const, data: { name: 'TypeScript', icon: 'typescript', tags: ['languages'] }, body: '' },
+];
+
+export const fixturesByCollection = {
+  organizations: organizationFixtures,
+  experiences: experienceFixtures,
+  projects: projectFixtures,
+  skills: skillFixtures,
+};

--- a/apps/personal-website/src/mcp/profile-data.test.ts
+++ b/apps/personal-website/src/mcp/profile-data.test.ts
@@ -1,0 +1,64 @@
+import type { Mock } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { fixturesByCollection } from './profile-data.fixtures';
+
+// Vitest hoists vi.mock above all imports regardless of source position, so this runs
+// before the `astro:content` import below takes effect.
+vi.mock('astro:content', () => ({
+  getCollection: vi.fn(),
+  getEntry: vi.fn(),
+}));
+
+import { getCollection, getEntry } from 'astro:content';
+
+import { getWorkExperience } from './profile-data';
+
+/**
+ * Resolves the (collection, id) pair from either of Astro's two `getEntry` call shapes:
+ * a single `{ collection, id }` reference object, or two separate string arguments.
+ */
+function toCollectionAndId(a: unknown, b: unknown): [string, string] {
+  if (typeof a === 'string') return [a, b as string];
+  const ref = a as { collection: string; id: string };
+  return [ref.collection, ref.id];
+}
+
+beforeEach(() => {
+  (getCollection as Mock).mockImplementation(async (name: string, filter?: (e: unknown) => boolean) => {
+    const entries = fixturesByCollection[name as keyof typeof fixturesByCollection] ?? [];
+    return filter ? entries.filter(filter) : entries;
+  });
+  (getEntry as Mock).mockImplementation(async (a: unknown, b?: unknown) => {
+    const [collection, id] = toCollectionAndId(a, b);
+    const entries = fixturesByCollection[collection as keyof typeof fixturesByCollection] ?? [];
+    return entries.find((e) => e.id === id);
+  });
+});
+
+describe('getWorkExperience', () => {
+  it('returns only job-type entries for the given language', async () => {
+    const jobs = await getWorkExperience({ lang: 'en' });
+    expect(jobs.length).toBeGreaterThan(0);
+    for (const job of jobs) {
+      expect(job.language).toBe('en');
+    }
+    const codegreen = jobs.find((j) => j.id === 'en/6');
+    expect(codegreen).toBeDefined();
+    expect(codegreen?.position).toBe('Senior Frontend Engineer');
+    expect(codegreen?.organization).toEqual({
+      id: 'en/codegreen',
+      name: 'CodeGreen',
+      link: 'https://www.codegreen.org',
+    });
+    // en/6 declares no `technologies` field directly — this asserts it's merged
+    // in from its linked projects (en/opencgt uses auth0), not left empty.
+    expect(codegreen?.technologies).toContain('auth0');
+  });
+
+  it('filters by technology across the experience or its projects', async () => {
+    const jobs = await getWorkExperience({ lang: 'en', technology: 'auth0' });
+    // 'en/6' has no direct technologies field, but its project 'en/opencgt' uses auth0
+    expect(jobs.some((j) => j.id === 'en/6')).toBe(true);
+  });
+});

--- a/apps/personal-website/src/mcp/profile-data.test.ts
+++ b/apps/personal-website/src/mcp/profile-data.test.ts
@@ -12,7 +12,14 @@ vi.mock('astro:content', () => ({
 
 import { getCollection, getEntry } from 'astro:content';
 
-import { getWorkExperience } from './profile-data';
+import {
+  getEducation,
+  getProfileSummary,
+  getProjects,
+  getSkills,
+  getWorkExperience,
+  searchByTechnology,
+} from './profile-data';
 
 /**
  * Resolves the (collection, id) pair from either of Astro's two `getEntry` call shapes:
@@ -60,5 +67,66 @@ describe('getWorkExperience', () => {
     const jobs = await getWorkExperience({ lang: 'en', technology: 'auth0' });
     // 'en/6' has no direct technologies field, but its project 'en/opencgt' uses auth0
     expect(jobs.some((j) => j.id === 'en/6')).toBe(true);
+  });
+});
+
+describe('getEducation', () => {
+  it('returns only education-type entries', async () => {
+    const education = await getEducation({ lang: 'en' });
+    expect(education.length).toBeGreaterThan(0);
+    for (const entry of education) {
+      expect(entry.type).toBe('education');
+    }
+  });
+});
+
+describe('getProjects', () => {
+  it('resolves organization and experience references', async () => {
+    const projects = await getProjects({ lang: 'en' });
+    const opencgt = projects.find((p) => p.id === 'en/opencgt');
+    expect(opencgt).toBeDefined();
+    expect(opencgt?.organization.id).toBe('en/codegreen');
+    expect(opencgt?.experience).toBe('en/6');
+    expect(opencgt?.technologies).toContain('auth0');
+  });
+
+  it('filters by technology', async () => {
+    const projects = await getProjects({ lang: 'en', technology: 'playwright' });
+    expect(projects.every((p) => p.technologies.includes('playwright'))).toBe(true);
+    expect(projects.length).toBeGreaterThan(0);
+  });
+});
+
+describe('getSkills', () => {
+  it('returns skill entries with icon and tags', async () => {
+    const skills = await getSkills({ lang: 'en' });
+    const ts = skills.find((s) => s.id === 'en/ts');
+    expect(ts).toBeDefined();
+    expect(ts?.icon).toBe('typescript');
+    expect(ts?.tags).toContain('languages');
+  });
+});
+
+describe('getProfileSummary', () => {
+  it('aggregates counts across collections', async () => {
+    const summary = await getProfileSummary({ lang: 'en' });
+    expect(summary.experienceCount).toBeGreaterThan(0);
+    expect(summary.projectCount).toBeGreaterThan(0);
+    expect(summary.skillCount).toBeGreaterThan(0);
+    expect(summary.topTechnologies.length).toBeGreaterThan(0);
+  });
+});
+
+describe('searchByTechnology', () => {
+  it('substring-matches across experiences and projects', async () => {
+    const results = await searchByTechnology('auth', { lang: 'en' });
+    expect(results.experiences.some((e) => e.id === 'en/6')).toBe(true);
+    expect(results.projects.some((p) => p.id === 'en/opencgt')).toBe(true);
+  });
+
+  it('returns empty results for a non-matching query', async () => {
+    const results = await searchByTechnology('cobol', { lang: 'en' });
+    expect(results.experiences).toHaveLength(0);
+    expect(results.projects).toHaveLength(0);
   });
 });

--- a/apps/personal-website/src/mcp/profile-data.ts
+++ b/apps/personal-website/src/mcp/profile-data.ts
@@ -59,14 +59,16 @@ async function experienceTechnologies(entry: CollectionEntry<'experiences'>): Pr
   return Array.from(new Set([...direct, ...fromProjects]));
 }
 
+/** Experience entries of a given type (`job` or `education`) in a given language. */
+function getExperiencesByType(type: ExperienceTag, lang: string) {
+  return getCollection('experiences', (entry) => entry.data.type === type && entry.data.language === lang);
+}
+
 export async function getWorkExperience(
   options: { technology?: SkillTag; lang?: string } = {},
 ): Promise<ResolvedExperience[]> {
   const { technology, lang = 'en' } = options;
-  const entries = await getCollection(
-    'experiences',
-    (entry) => entry.data.type === 'job' && entry.data.language === lang,
-  );
+  const entries = await getExperiencesByType('job', lang);
   const withTech = await Promise.all(
     entries.map(async (entry) => ({
       entry,
@@ -83,10 +85,7 @@ export async function getEducation(
   options: { lang?: string } = {},
 ): Promise<ResolvedExperience[]> {
   const { lang = 'en' } = options;
-  const entries = await getCollection(
-    'experiences',
-    (entry) => entry.data.type === 'education' && entry.data.language === lang,
-  );
+  const entries = await getExperiencesByType('education', lang);
   return Promise.all(
     entries.map(async (entry) => resolveExperience(entry, await experienceTechnologies(entry))),
   );

--- a/apps/personal-website/src/mcp/profile-data.ts
+++ b/apps/personal-website/src/mcp/profile-data.ts
@@ -1,0 +1,80 @@
+import type { SkillTag } from '@types';
+import { type CollectionEntry,getCollection, getEntry } from 'astro:content';
+
+export interface ResolvedOrganization {
+  id: string;
+  name: string;
+  link?: string;
+}
+
+export interface ResolvedExperience {
+  id: string;
+  type: 'job' | 'education';
+  language: string;
+  position: string;
+  startAt: Date;
+  endAt?: Date;
+  technologies: SkillTag[];
+  organization: ResolvedOrganization;
+  content: string;
+}
+
+async function resolveOrganization(
+  ref: CollectionEntry<'experiences'>['data']['organization'],
+): Promise<ResolvedOrganization> {
+  const org = await getEntry(ref);
+  if (!org) throw new Error(`Organization not found: ${ref.id}`);
+  return { id: org.id, name: org.data.name, link: org.data.link };
+}
+
+/**
+ * Resolves an experience entry. `technologies` must be the already-merged set
+ * (direct + linked projects') so the returned data stays consistent with
+ * whatever technology filter was used to find this entry in the first place —
+ * see `experienceTechnologies` below.
+ */
+async function resolveExperience(
+  entry: CollectionEntry<'experiences'>,
+  technologies: SkillTag[],
+): Promise<ResolvedExperience> {
+  return {
+    id: entry.id,
+    type: entry.data.type,
+    language: entry.data.language,
+    position: entry.data.position,
+    startAt: entry.data.startAt,
+    endAt: entry.data.endAt,
+    technologies,
+    organization: await resolveOrganization(entry.data.organization),
+    content: entry.body ?? '',
+  };
+}
+
+/** Technologies declared directly on the experience, plus technologies of any linked projects. */
+async function experienceTechnologies(entry: CollectionEntry<'experiences'>): Promise<SkillTag[]> {
+  const direct = entry.data.technologies ?? [];
+  const projectRefs = entry.data.projects ?? [];
+  const projects = await Promise.all(projectRefs.map((ref) => getEntry(ref)));
+  const fromProjects = projects.flatMap((p) => p?.data.technologies ?? []);
+  return Array.from(new Set([...direct, ...fromProjects]));
+}
+
+export async function getWorkExperience(
+  options: { technology?: SkillTag; lang?: string } = {},
+): Promise<ResolvedExperience[]> {
+  const { technology, lang = 'en' } = options;
+  const entries = await getCollection(
+    'experiences',
+    (entry) => entry.data.type === 'job' && entry.data.language === lang,
+  );
+  const withTech = await Promise.all(
+    entries.map(async (entry) => ({
+      entry,
+      technologies: await experienceTechnologies(entry),
+    })),
+  );
+  const filtered = technology
+    ? withTech.filter(({ technologies }) => technologies.includes(technology))
+    : withTech;
+  return Promise.all(filtered.map(({ entry, technologies }) => resolveExperience(entry, technologies)));
+}

--- a/apps/personal-website/src/mcp/profile-data.ts
+++ b/apps/personal-website/src/mcp/profile-data.ts
@@ -1,5 +1,5 @@
-import type { SkillTag } from '@types';
-import { type CollectionEntry,getCollection, getEntry } from 'astro:content';
+import type { ExperienceTag, SkillTag } from '@types';
+import { type CollectionEntry, getCollection, getEntry } from 'astro:content';
 
 export interface ResolvedOrganization {
   id: string;
@@ -9,7 +9,7 @@ export interface ResolvedOrganization {
 
 export interface ResolvedExperience {
   id: string;
-  type: 'job' | 'education';
+  type: ExperienceTag;
   language: string;
   position: string;
   startAt: Date;

--- a/apps/personal-website/src/mcp/profile-data.ts
+++ b/apps/personal-website/src/mcp/profile-data.ts
@@ -91,6 +91,18 @@ export async function getEducation(
   );
 }
 
+/**
+ * A single experience (job or education) by id, fully resolved — same shape as
+ * `getWorkExperience`/`getEducation`'s entries. Used by the MCP resource reader so a
+ * `profile://experience/{id}` read returns the same resolved organization/technologies
+ * as the tool surface, not a raw entry with unresolved reference pointers.
+ */
+export async function getExperienceById(id: string): Promise<ResolvedExperience | undefined> {
+  const entry = await getEntry('experiences', id);
+  if (!entry) return undefined;
+  return resolveExperience(entry, await experienceTechnologies(entry));
+}
+
 export interface ResolvedProject {
   id: string;
   name: string;
@@ -124,6 +136,13 @@ export async function getProjects(
       (!technology || entry.data.technologies.includes(technology)),
   );
   return Promise.all(entries.map(resolveProject));
+}
+
+/** A single project by id, fully resolved — same rationale as `getExperienceById`. */
+export async function getProjectById(id: string): Promise<ResolvedProject | undefined> {
+  const entry = await getEntry('projects', id);
+  if (!entry) return undefined;
+  return resolveProject(entry);
 }
 
 export interface ResolvedSkill {

--- a/apps/personal-website/src/mcp/profile-data.ts
+++ b/apps/personal-website/src/mcp/profile-data.ts
@@ -78,3 +78,119 @@ export async function getWorkExperience(
     : withTech;
   return Promise.all(filtered.map(({ entry, technologies }) => resolveExperience(entry, technologies)));
 }
+
+export async function getEducation(
+  options: { lang?: string } = {},
+): Promise<ResolvedExperience[]> {
+  const { lang = 'en' } = options;
+  const entries = await getCollection(
+    'experiences',
+    (entry) => entry.data.type === 'education' && entry.data.language === lang,
+  );
+  return Promise.all(
+    entries.map(async (entry) => resolveExperience(entry, await experienceTechnologies(entry))),
+  );
+}
+
+export interface ResolvedProject {
+  id: string;
+  name: string;
+  language: string;
+  technologies: SkillTag[];
+  organization: ResolvedOrganization;
+  experience: string;
+  content: string;
+}
+
+async function resolveProject(entry: CollectionEntry<'projects'>): Promise<ResolvedProject> {
+  return {
+    id: entry.id,
+    name: entry.data.name,
+    language: entry.data.language,
+    technologies: entry.data.technologies,
+    organization: await resolveOrganization(entry.data.organization),
+    experience: entry.data.experience.id,
+    content: entry.body ?? '',
+  };
+}
+
+export async function getProjects(
+  options: { technology?: SkillTag; lang?: string } = {},
+): Promise<ResolvedProject[]> {
+  const { technology, lang = 'en' } = options;
+  const entries = await getCollection(
+    'projects',
+    (entry) =>
+      entry.data.language === lang &&
+      (!technology || entry.data.technologies.includes(technology)),
+  );
+  return Promise.all(entries.map(resolveProject));
+}
+
+export interface ResolvedSkill {
+  id: string;
+  name: string;
+  icon: SkillTag;
+  tags: string[];
+  content: string;
+}
+
+export async function getSkills(options: { lang?: string } = {}): Promise<ResolvedSkill[]> {
+  const { lang = 'en' } = options;
+  const entries = await getCollection('skills', (entry) => entry.id.startsWith(`${lang}/`));
+  return entries.map((entry) => ({
+    id: entry.id,
+    name: entry.data.name,
+    icon: entry.data.icon,
+    tags: entry.data.tags ?? [],
+    content: entry.body ?? '',
+  }));
+}
+
+export interface ProfileSummary {
+  experienceCount: number;
+  projectCount: number;
+  skillCount: number;
+  topTechnologies: SkillTag[];
+}
+
+export async function getProfileSummary(options: { lang?: string } = {}): Promise<ProfileSummary> {
+  const { lang = 'en' } = options;
+  const [experiences, projects, skills] = await Promise.all([
+    getWorkExperience({ lang }),
+    getProjects({ lang }),
+    getSkills({ lang }),
+  ]);
+  const techCounts = new Map<SkillTag, number>();
+  for (const exp of experiences) {
+    for (const tech of exp.technologies) techCounts.set(tech, (techCounts.get(tech) ?? 0) + 1);
+  }
+  for (const project of projects) {
+    for (const tech of project.technologies) techCounts.set(tech, (techCounts.get(tech) ?? 0) + 1);
+  }
+  const topTechnologies = [...techCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([tech]) => tech);
+  return {
+    experienceCount: experiences.length,
+    projectCount: projects.length,
+    skillCount: skills.length,
+    topTechnologies,
+  };
+}
+
+export async function searchByTechnology(
+  query: string,
+  options: { lang?: string } = {},
+): Promise<{ experiences: ResolvedExperience[]; projects: ResolvedProject[] }> {
+  const { lang = 'en' } = options;
+  const q = query.toLowerCase();
+  const [experiences, projects] = await Promise.all([
+    getWorkExperience({ lang }),
+    getProjects({ lang }),
+  ]);
+  return {
+    experiences: experiences.filter((e) => e.technologies.some((t) => t.toLowerCase().includes(q))),
+    projects: projects.filter((p) => p.technologies.some((t) => t.toLowerCase().includes(q))),
+  };
+}

--- a/apps/personal-website/src/mcp/smoke.test.ts
+++ b/apps/personal-website/src/mcp/smoke.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fixturesByCollection } from './profile-data.fixtures';
+
+vi.mock('astro:content', () => ({
+  getCollection: vi.fn(),
+  getEntry: vi.fn(),
+}));
+
+import { getCollection, getEntry } from 'astro:content';
+
+beforeEach(() => {
+  vi.mocked(getCollection).mockImplementation(async (name: string, filter?: (e: unknown) => boolean) => {
+    const entries = fixturesByCollection[name as keyof typeof fixturesByCollection] ?? [];
+    return filter ? entries.filter(filter) : entries;
+  });
+  vi.mocked(getEntry).mockImplementation(async (a: unknown, b?: unknown) => {
+    const [collection, id] = typeof a === 'string' ? [a, b as string] : [(a as { collection: string }).collection, (a as { id: string }).id];
+    const entries = fixturesByCollection[collection as keyof typeof fixturesByCollection] ?? [];
+    return entries.find((e) => e.id === id);
+  });
+});
+
+describe('astro:content mocking harness', () => {
+  it('returns fixture organizations through the mocked getCollection', async () => {
+    const orgs = await getCollection('organizations');
+    expect(orgs).toHaveLength(3);
+  });
+
+  it('resolves a single fixture entry through the mocked getEntry (reference-object form)', async () => {
+    const org = await getEntry({ collection: 'organizations', id: 'en/codegreen' });
+    expect(org?.data.name).toBe('CodeGreen');
+  });
+
+  it('resolves a single fixture entry through the mocked getEntry (two-arg form)', async () => {
+    const org = await getEntry('organizations', 'en/codegreen');
+    expect(org?.data.name).toBe('CodeGreen');
+  });
+});

--- a/apps/personal-website/src/mcp/smoke.test.ts
+++ b/apps/personal-website/src/mcp/smoke.test.ts
@@ -1,6 +1,10 @@
+import type { Mock } from 'vitest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { fixturesByCollection } from './profile-data.fixtures';
 
+// Vitest hoists vi.mock above all imports regardless of source position, so this runs
+// before the `astro:content` import below takes effect.
 vi.mock('astro:content', () => ({
   getCollection: vi.fn(),
   getEntry: vi.fn(),
@@ -8,13 +12,23 @@ vi.mock('astro:content', () => ({
 
 import { getCollection, getEntry } from 'astro:content';
 
+/**
+ * Resolves the (collection, id) pair from either of Astro's two `getEntry` call shapes:
+ * a single `{ collection, id }` reference object, or two separate string arguments.
+ */
+function toCollectionAndId(a: unknown, b: unknown): [string, string] {
+  if (typeof a === 'string') return [a, b as string];
+  const ref = a as { collection: string; id: string };
+  return [ref.collection, ref.id];
+}
+
 beforeEach(() => {
-  vi.mocked(getCollection).mockImplementation(async (name: string, filter?: (e: unknown) => boolean) => {
+  (getCollection as Mock).mockImplementation(async (name: string, filter?: (e: unknown) => boolean) => {
     const entries = fixturesByCollection[name as keyof typeof fixturesByCollection] ?? [];
     return filter ? entries.filter(filter) : entries;
   });
-  vi.mocked(getEntry).mockImplementation(async (a: unknown, b?: unknown) => {
-    const [collection, id] = typeof a === 'string' ? [a, b as string] : [(a as { collection: string }).collection, (a as { id: string }).id];
+  (getEntry as Mock).mockImplementation(async (a: unknown, b?: unknown) => {
+    const [collection, id] = toCollectionAndId(a, b);
     const entries = fixturesByCollection[collection as keyof typeof fixturesByCollection] ?? [];
     return entries.find((e) => e.id === id);
   });

--- a/apps/personal-website/src/pages/api/mcp.ts
+++ b/apps/personal-website/src/pages/api/mcp.ts
@@ -1,0 +1,17 @@
+import type { APIRoute } from 'astro';
+import { createMcpHandler } from 'mcp-handler';
+import { z } from 'zod';
+
+const handler = createMcpHandler(
+  (server) => {
+    server.tool('ping', 'Health check tool', { echo: z.string().optional() }, async ({ echo }) => ({
+      content: [{ type: 'text', text: `pong${echo ? `: ${echo}` : ''}` }],
+    }));
+  },
+  {},
+  { basePath: '/api' },
+);
+
+// Stateless, POST-only per the design spec: no GET/SSE stream (no server-initiated
+// push needed for a read-only server) and no DELETE (no sessions to terminate).
+export const POST: APIRoute = ({ request }) => handler(request);

--- a/apps/personal-website/src/pages/api/mcp.ts
+++ b/apps/personal-website/src/pages/api/mcp.ts
@@ -1,21 +1,125 @@
+import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { APIRoute } from 'astro';
+import { getEntry } from 'astro:content';
 import { createMcpHandler } from 'mcp-handler';
 import { z } from 'zod';
+
+import {
+  getEducation,
+  getProfileSummary,
+  getProjects,
+  getSkills,
+  getWorkExperience,
+  searchByTechnology,
+} from '../../mcp/profile-data';
+
+const langSchema = z.enum(['en', 'zh']).optional();
+const technologySchema = z.string().optional();
 
 const handler = createMcpHandler(
   (server) => {
     server.registerTool(
-      'ping',
-      { description: 'Health check tool', inputSchema: { echo: z.string().optional() } },
-      async ({ echo }) => ({
-        content: [{ type: 'text', text: `pong${echo ? `: ${echo}` : ''}` }],
+      'get_profile_summary',
+      {
+        description: 'Professional profile overview: counts and top technologies',
+        inputSchema: { lang: langSchema },
+      },
+      async ({ lang }) => ({
+        content: [{ type: 'text', text: JSON.stringify(await getProfileSummary({ lang })) }],
       }),
+    );
+
+    server.registerTool(
+      'get_work_experience',
+      {
+        description: 'Work history, optionally filtered by technology',
+        inputSchema: { technology: technologySchema, lang: langSchema },
+      },
+      async ({ technology, lang }) => ({
+        content: [
+          { type: 'text', text: JSON.stringify(await getWorkExperience({ technology: technology as any, lang })) },
+        ],
+      }),
+    );
+
+    server.registerTool(
+      'get_education',
+      { description: 'Academic background', inputSchema: { lang: langSchema } },
+      async ({ lang }) => ({
+        content: [{ type: 'text', text: JSON.stringify(await getEducation({ lang })) }],
+      }),
+    );
+
+    server.registerTool(
+      'get_projects',
+      {
+        description: 'Portfolio projects, optionally filtered by technology',
+        inputSchema: { technology: technologySchema, lang: langSchema },
+      },
+      async ({ technology, lang }) => ({
+        content: [
+          { type: 'text', text: JSON.stringify(await getProjects({ technology: technology as any, lang })) },
+        ],
+      }),
+    );
+
+    server.registerTool(
+      'get_skills',
+      { description: 'Technical skills inventory', inputSchema: { lang: langSchema } },
+      async ({ lang }) => ({
+        content: [{ type: 'text', text: JSON.stringify(await getSkills({ lang })) }],
+      }),
+    );
+
+    server.registerTool(
+      'search_by_technology',
+      {
+        description: 'Substring-match a technology name across all experiences and projects',
+        inputSchema: { query: z.string(), lang: langSchema },
+      },
+      async ({ query, lang }) => ({
+        content: [{ type: 'text', text: JSON.stringify(await searchByTechnology(query, { lang })) }],
+      }),
+    );
+
+    // `{+id}` (RFC 6570 reserved expansion) is required, not `{id}` — our ids contain
+    // slashes (e.g. `en/6`), and plain `{id}` expansion only matches a single path segment.
+    server.registerResource(
+      'experience',
+      new ResourceTemplate('profile://experience/{+id}', { list: undefined }),
+      { title: 'Work/Education Experience', mimeType: 'application/json' },
+      async (uri, { id }) => {
+        const entry = await getEntry('experiences', id as string);
+        if (!entry) throw new Error(`Experience not found: ${id}`);
+        return { contents: [{ uri: uri.href, text: JSON.stringify(entry.data) }] };
+      },
+    );
+
+    server.registerResource(
+      'project',
+      new ResourceTemplate('profile://project/{+id}', { list: undefined }),
+      { title: 'Project', mimeType: 'application/json' },
+      async (uri, { id }) => {
+        const entry = await getEntry('projects', id as string);
+        if (!entry) throw new Error(`Project not found: ${id}`);
+        return { contents: [{ uri: uri.href, text: JSON.stringify(entry.data) }] };
+      },
+    );
+
+    server.registerResource(
+      'skill',
+      new ResourceTemplate('profile://skill/{+id}', { list: undefined }),
+      { title: 'Skill', mimeType: 'application/json' },
+      async (uri, { id }) => {
+        const entry = await getEntry('skills', id as string);
+        if (!entry) throw new Error(`Skill not found: ${id}`);
+        return { contents: [{ uri: uri.href, text: JSON.stringify(entry.data) }] };
+      },
     );
   },
   {},
   { basePath: '/api' },
 );
 
-// Stateless, POST-only per the design spec: no GET/SSE stream (no server-initiated
-// push needed for a read-only server) and no DELETE (no sessions to terminate).
+// Stateless, POST-only per the design spec — same rationale as Task 4's spike.
 export const POST: APIRoute = ({ request }) => handler(request);

--- a/apps/personal-website/src/pages/api/mcp.ts
+++ b/apps/personal-website/src/pages/api/mcp.ts
@@ -1,4 +1,6 @@
 import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { SkillTag } from '@types';
+import { tags } from '@utils/constants';
 import type { APIRoute } from 'astro';
 import { getEntry } from 'astro:content';
 import { createMcpHandler } from 'mcp-handler';
@@ -6,7 +8,9 @@ import { z } from 'zod';
 
 import {
   getEducation,
+  getExperienceById,
   getProfileSummary,
+  getProjectById,
   getProjects,
   getSkills,
   getWorkExperience,
@@ -14,7 +18,11 @@ import {
 } from '../../mcp/profile-data';
 
 const langSchema = z.enum(['en', 'zh']).optional();
-const technologySchema = z.string().optional();
+// Derived from the same tags.skills vocabulary the content schemas use (content.config.ts),
+// rather than a plain z.string() — this makes the parsed value a real SkillTag, not just a
+// string, so the tool handlers below no longer need an `as any` cast to call getWorkExperience/
+// getProjects (which require SkillTag, not string).
+const technologySchema = z.enum(tags.skills as unknown as [SkillTag, ...SkillTag[]]).optional();
 
 const handler = createMcpHandler(
   (server) => {
@@ -37,7 +45,7 @@ const handler = createMcpHandler(
       },
       async ({ technology, lang }) => ({
         content: [
-          { type: 'text', text: JSON.stringify(await getWorkExperience({ technology: technology as any, lang })) },
+          { type: 'text', text: JSON.stringify(await getWorkExperience({ technology, lang })) },
         ],
       }),
     );
@@ -58,7 +66,7 @@ const handler = createMcpHandler(
       },
       async ({ technology, lang }) => ({
         content: [
-          { type: 'text', text: JSON.stringify(await getProjects({ technology: technology as any, lang })) },
+          { type: 'text', text: JSON.stringify(await getProjects({ technology, lang })) },
         ],
       }),
     );
@@ -84,14 +92,20 @@ const handler = createMcpHandler(
 
     // `{+id}` (RFC 6570 reserved expansion) is required, not `{id}` — our ids contain
     // slashes (e.g. `en/6`), and plain `{id}` expansion only matches a single path segment.
+    //
+    // experience/project resources return the same *resolved* shape as the tools above
+    // (resolved organization, merged technologies) — not a raw content-collection entry.
+    // A raw entry's `organization` field is an unresolved `{id, collection}` pointer the
+    // client has no way to dereference itself (there's no `profile://organization/{id}`
+    // resource), so returning it as-is would be a dead end, not just "a different view".
     server.registerResource(
       'experience',
       new ResourceTemplate('profile://experience/{+id}', { list: undefined }),
       { title: 'Work/Education Experience', mimeType: 'application/json' },
       async (uri, { id }) => {
-        const entry = await getEntry('experiences', id as string);
-        if (!entry) throw new Error(`Experience not found: ${id}`);
-        return { contents: [{ uri: uri.href, text: JSON.stringify(entry.data) }] };
+        const experience = await getExperienceById(id as string);
+        if (!experience) throw new Error(`Experience not found: ${id}`);
+        return { contents: [{ uri: uri.href, text: JSON.stringify(experience) }] };
       },
     );
 
@@ -100,9 +114,9 @@ const handler = createMcpHandler(
       new ResourceTemplate('profile://project/{+id}', { list: undefined }),
       { title: 'Project', mimeType: 'application/json' },
       async (uri, { id }) => {
-        const entry = await getEntry('projects', id as string);
-        if (!entry) throw new Error(`Project not found: ${id}`);
-        return { contents: [{ uri: uri.href, text: JSON.stringify(entry.data) }] };
+        const project = await getProjectById(id as string);
+        if (!project) throw new Error(`Project not found: ${id}`);
+        return { contents: [{ uri: uri.href, text: JSON.stringify(project) }] };
       },
     );
 

--- a/apps/personal-website/src/pages/api/mcp.ts
+++ b/apps/personal-website/src/pages/api/mcp.ts
@@ -4,9 +4,13 @@ import { z } from 'zod';
 
 const handler = createMcpHandler(
   (server) => {
-    server.tool('ping', 'Health check tool', { echo: z.string().optional() }, async ({ echo }) => ({
-      content: [{ type: 'text', text: `pong${echo ? `: ${echo}` : ''}` }],
-    }));
+    server.registerTool(
+      'ping',
+      { description: 'Health check tool', inputSchema: { echo: z.string().optional() } },
+      async ({ echo }) => ({
+        content: [{ type: 'text', text: `pong${echo ? `: ${echo}` : ''}` }],
+      }),
+    );
   },
   {},
   { basePath: '/api' },

--- a/apps/personal-website/vitest.config.ts
+++ b/apps/personal-website/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/docs/superpowers/specs/2026-07-04-personal-context-mcp-design.md
+++ b/docs/superpowers/specs/2026-07-04-personal-context-mcp-design.md
@@ -1,0 +1,124 @@
+# Personal Context MCP Server — Design
+
+**Date:** 2026-07-04
+**Status:** approved
+**Scope:** `apps/personal-website` — new public, read-only MCP server exposing professional profile data (`mcp.rainforest.tools`), plus a revived structured content model for experiences/organizations/projects/skills
+
+---
+
+## 1. Why Now
+
+A prior attempt exists on unmerged remote branch `origin/claude/add-mcp-website-context-011CUneBYG9kZj8pmVLGAtUP` (2025-11-04): a working MCP server (blog + full personal profile) using the low-level `@modelcontextprotocol/sdk` `Server` class over **stdio transport**. Stdio only works for local Claude Desktop configs — it cannot back a public `mcp.rainforest.tools` domain. The branch was never merged and the code no longer exists in the working tree.
+
+Since then:
+- The MCP spec's 2026-07-28 release (RC since 2026-05-21) makes the protocol **stateless at the core** — the same direction this design already needed for serverless hosting.
+- Vercel ships an official `mcp-handler` package with built-in stateless Streamable HTTP and OAuth support, removing the need to hand-roll transport/auth plumbing.
+- `career-design-2026-06.md` named `mcp.rainforest.tools` as a differentiator; a 2026-07-04 fact-check (see Obsidian vault `projects/personal-website/career-data-pull-2026-07-04/report.md` §1, F1) confirmed it had **no implementation progress** — this design is the actual follow-through.
+
+---
+
+## 2. Scope
+
+**In scope (this design):**
+- New MCP endpoint in `apps/personal-website`, public domain `mcp.rainforest.tools`
+- Structured content model for `Organization` / `Experience` / `Project` / `Skill` (revived schema, new storage mechanism)
+- Public, unauthenticated, read-only tools/resources over the profile data
+- i18n support matching the site's existing bilingual (en/zh) convention
+
+**Explicitly out of scope (follow-up work, listed but not designed here):**
+- Blog search tools/resources (the old branch bundled these; kept separate to keep this scope tight)
+- Populating the data model with current content (rss-manager, homelab MCP infra, Hermes Agent, etc. — see Obsidian vault `projects/personal-website/personal-projects-inventory-2026-07-04.md`) — tracked as a separate content checklist
+- WebMCP (`navigator.modelContext`) — Google I/O 2026, W3C Community Group Draft, Chrome-only origin trial as of 2026-07. Serves a different purpose (lets a *visitor's* in-browser agent call page tools under the visitor's session) than this server (letting *remote* agents query professional context). Revisit when the deferred GenUI assistant (Layer 2, `generative-ui-research-2026.md`) is picked up — WebMCP's imperative tool registration is conceptually closer to that work.
+- Private/authenticated tools (personal context for the owner's own AI assistants, not public visitors) — noted as a known future direction; the architecture (via `mcp-handler`'s `withMcpAuth`) supports adding this later without redesign, but nothing auth-gated ships in this round.
+- MCP registry submission
+- Content positioning rewrite (career-design Layer 1) and GenUI assistant (Layer 2) — separate sub-projects
+
+---
+
+## 3. Architecture
+
+- New route colocated in `apps/personal-website` (no separate service/infra), using Astro's hybrid rendering (`export const prerender = false` on the MCP route) so it deploys as a Vercel Function alongside the static site.
+- Public domain: `mcp.rainforest.tools`, configured as a Vercel project domain with a rewrite to the API route — same deployment, no separate project.
+- Server implementation: **rewritten using Vercel's official `mcp-handler` package**, not a port of the old branch's low-level SDK code. This is a from-scratch reimplementation of the server layer; only the data *schema* concept is carried over from the old branch.
+- Astro compatibility with `mcp-handler` is unverified (its docs/examples are Next.js `app/api/.../route.ts`). **First implementation task: a small spike** confirming `createMcpHandler`'s returned handler (a standard Fetch `Request → Response` function) wires cleanly into an Astro endpoint (`export const POST: APIRoute = ({ request }) => handler(request)`). If it doesn't wire cleanly, fall back to the raw `@modelcontextprotocol/sdk` `StreamableHTTPServerTransport` in stateless mode.
+
+---
+
+## 4. Transport
+
+Stateless, **POST-only** Streamable HTTP — no SSE/GET stream. This server has no server-initiated push scenarios (pure read-only query/response), and the MCP spec treats the SSE half of Streamable HTTP as optional. Skipping it avoids Vercel serverless long-lived-connection constraints entirely, and matches the protocol's own 2026-07-28 stateless-core direction.
+
+---
+
+## 5. Data Model
+
+Revive the old branch's schema, but store it as an **Astro Content Collection** (`src/content/profile/{experiences,organizations,projects,skills}`, Zod-validated via `src/content.config.ts`) instead of the old branch's hand-rolled directory scanner (`personal-data-reader.ts`). Rationale: the site's blog already uses content collections, giving schema validation, type safety, and a data source that a future resume-page rework could also consume — one source of truth instead of two mechanisms.
+
+Fields (unchanged from the old branch's `types.ts`):
+
+```ts
+interface Organization {
+  id: string; name: string; language: string;
+  department?: string; link?: string;
+}
+
+interface Experience {
+  id: string; type: 'job' | 'education'; language: string;
+  organization: string; // ref → Organization.id
+  position: string; startAt: Date; endAt?: Date;
+  technologies?: string[]; projects?: string[]; // ref → Project.id[]
+  content: string; // markdown description
+}
+
+interface Project {
+  id: string; name: string; language: string;
+  technologies: string[];
+  organization: string; experience: string; // refs
+  content: string;
+}
+
+interface Skill {
+  id: string; name: string; icon: string;
+  tags?: string[]; content: string;
+}
+```
+
+Each entry carries its own `language`; bilingual content is two entries (one per locale) sharing the same logical `id` prefix, matching the site's existing i18n convention (not a single entry with nested translations).
+
+---
+
+## 6. Tools / Resources Interface
+
+**Tools:**
+- `get_profile_summary(lang?)` — professional overview
+- `get_work_experience(technology?, lang?)`
+- `get_education(lang?)`
+- `get_projects(technology?, lang?)`
+- `get_skills(lang?)`
+- `search_by_technology(query, lang?)` — fuzzy/substring match on `query` against all `technologies` tags across experiences and projects (unlike the exact-tag `technology?` filter on `get_work_experience`/`get_projects`), returning matching experiences and projects together
+
+**Resources:**
+- `profile://experience/{id}`
+- `profile://project/{id}`
+- `profile://skill/{id}`
+
+---
+
+## 7. Auth
+
+Fully public, no authentication, no rate limiting — this mirrors the resume/portfolio pages' own exposure level (public professional info), and deliberately avoids repeating the homelab OAuth gateway's known gap (no allowlist) by not pretending to gate something that doesn't need gating. Standard Vercel platform-level abuse protection (Firewall) applies with no custom config.
+
+Future private/authenticated tools (noted as out of scope, §2) would use `mcp-handler`'s `withMcpAuth` + a `.well-known/oauth-protected-resource` metadata route — the same package already in use, no separate auth stack to design later.
+
+---
+
+## 8. i18n
+
+`lang` is an optional parameter on every tool, resolved in this order: explicit `lang` arg → `Accept-Language` header → default `en`. Returns the content-collection entry matching that `language`. This reuses the data model's existing per-entry `language` field — no dependency on WebMCP's (currently nonexistent) i18n story.
+
+---
+
+## 9. Testing
+
+- Local: `pnpm dev` + `curl` against the endpoint with raw JSON-RPC payloads (list tools, call each tool, read each resource type) to verify handler wiring before involving a real client.
+- Post-deploy: connect a real MCP client (Claude.ai or Claude Code remote MCP connection) to the deployed `mcp.rainforest.tools` — verifies actual client interop, not just hand-written request scripts.

--- a/docs/superpowers/specs/2026-07-04-personal-context-mcp-design.md
+++ b/docs/superpowers/specs/2026-07-04-personal-context-mcp-design.md
@@ -52,9 +52,9 @@ Stateless, **POST-only** Streamable HTTP — no SSE/GET stream. This server has 
 
 ## 5. Data Model
 
-Revive the old branch's schema, but store it as an **Astro Content Collection** (`src/content/profile/{experiences,organizations,projects,skills}`, Zod-validated via `src/content.config.ts`) instead of the old branch's hand-rolled directory scanner (`personal-data-reader.ts`). Rationale: the site's blog already uses content collections, giving schema validation, type safety, and a data source that a future resume-page rework could also consume — one source of truth instead of two mechanisms.
+**Correction found during planning:** this already exists. `organizations` / `experiences` / `projects` / `skills` are already defined as Astro Content Collections in `src/content.config.ts` (Zod-validated, `glob()`-loaded from `src/data/{organizations,experiences,projects,skills}/{en,zh}/`), with real populated content (6 organizations, 6 experiences, 4 projects, 12 skills). Nothing currently queries these collections — no page uses them yet. So there is no data model to build; the MCP server is simply the first consumer of an existing, already-correct schema.
 
-Fields (unchanged from the old branch's `types.ts`):
+Fields (matches `src/content.config.ts`, and matches what the old branch's `types.ts` independently proposed):
 
 ```ts
 interface Organization {
@@ -72,18 +72,19 @@ interface Experience {
 
 interface Project {
   id: string; name: string; language: string;
-  technologies: string[];
-  organization: string; experience: string; // refs
+  technologies: SkillTag[]; // z.enum(tags.skills) — fixed vocabulary, not free strings
+  organization: string; experience: string; // reference() to organizations/experiences
   content: string;
 }
 
 interface Skill {
-  id: string; name: string; icon: string;
+  id: string; name: string;
+  icon: SkillTag; // z.enum(tags.skills)
   tags?: string[]; content: string;
 }
 ```
 
-Each entry carries its own `language`; bilingual content is two entries (one per locale) sharing the same logical `id` prefix, matching the site's existing i18n convention (not a single entry with nested translations).
+`technologies`/`icon` are constrained to the existing `tags.skills` enum in `src/utils/constants/index.ts` (not free-form strings) — `search_by_technology` and the `technology?` filters operate over this fixed vocabulary. `organization`/`projects`/`experience` are Astro `reference()` fields, not plain strings; tools resolve these via `getEntry()` before returning data. Each entry carries its own `language`; bilingual content is two entries (one per locale) sharing the same logical `id`, matching the site's existing i18n convention (not a single entry with nested translations).
 
 ---
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -352,6 +352,9 @@ importers:
       '@mlc-ai/web-llm':
         specifier: ^0.2.80
         version: 0.2.82
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@3.25.76)
       '@nanostores/lit':
         specifier: ^0.2.3
         version: 0.2.3(lit@3.3.2)(nanostores@1.2.0)
@@ -412,6 +415,9 @@ importers:
       marked:
         specifier: ^17.0.1
         version: 17.0.6
+      mcp-handler:
+        specifier: ^1.1.0
+        version: 1.1.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))
       nanostores:
         specifier: ^1.1.0
         version: 1.2.0
@@ -433,6 +439,9 @@ importers:
       vue:
         specifier: ^3.5.32
         version: 3.5.32(typescript@5.9.3)
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@astrojs/check':
         specifier: ^0.9.9
@@ -4150,6 +4159,35 @@ packages:
       '@types/react':
         optional: true
 
+  '@redis/bloom@1.2.0':
+    resolution: {integrity: sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/client@1.6.1':
+    resolution: {integrity: sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==}
+    engines: {node: '>=14'}
+
+  '@redis/graph@1.1.1':
+    resolution: {integrity: sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/json@1.0.7':
+    resolution: {integrity: sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/search@1.2.0':
+    resolution: {integrity: sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/time-series@1.1.0':
+    resolution: {integrity: sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6953,6 +6991,10 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   cmdk@1.1.1:
     resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
     peerDependencies:
@@ -8479,6 +8521,10 @@ packages:
 
   generic-names@4.0.0:
     resolution: {integrity: sha512-ySFolZQfw9FoDb3ed9d80Cm9f0+r7qj+HJkWjeD9RBfpxEVTlVhol+gvaQB/78WbwYfbnNh8nWHHBSlg072y6A==}
+
+  generic-pool@3.9.0:
+    resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
+    engines: {node: '>= 4'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -10037,6 +10083,16 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mcp-handler@1.1.0:
+    resolution: {integrity: sha512-MVCES7g18gcoZy+R/3v5nadkUMzMAWdos8jRl6DyljOKvd2/ZKDmwlCjL6zp4vo+7FeCXOYL1uWinHWlkKAAUg==}
+    hasBin: true
+    peerDependencies:
+      '@modelcontextprotocol/sdk': 1.26.0
+      next: '>=13.0.0'
+    peerDependenciesMeta:
+      next:
+        optional: true
 
   mdast-util-definitions@6.0.0:
     resolution: {integrity: sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==}
@@ -11626,6 +11682,9 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  redis@4.7.1:
+    resolution: {integrity: sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -13035,10 +13094,6 @@ packages:
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
-    engines: {node: '>= 0.6'}
-
-  type-is@2.0.1:
-    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
   type-is@2.1.0:
@@ -17302,8 +17357,8 @@ snapshots:
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.12)
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
       cors: 2.8.6
       cross-spawn: 7.0.6
@@ -18028,7 +18083,7 @@ snapshots:
       '@nx/js': 23.0.0(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.5.0(encoding@0.1.13)(typanion@3.14.0))
       '@nx/web': 23.0.0(f751f55167c1ac96fcf2659d4b73c5d5)
       '@rspack/core': 1.6.8(@swc/helpers@0.5.18)
-      express: 4.22.1
+      express: 4.22.2
       http-proxy-middleware: 3.0.5
       picocolors: 1.1.1
       tslib: 2.8.1
@@ -18191,7 +18246,7 @@ snapshots:
       '@nx/web': 23.0.0(f751f55167c1ac96fcf2659d4b73c5d5)
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.9.3)
       '@svgr/webpack': 8.1.0(typescript@5.9.3)
-      express: 4.22.1
+      express: 4.22.2
       http-proxy-middleware: 3.0.5
       minimatch: 10.2.5
       react: 19.2.3
@@ -18375,7 +18430,7 @@ snapshots:
       '@nx/devkit': 23.0.0(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@nx/js': 23.0.0(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.5.0(encoding@0.1.13)(typanion@3.14.0))
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.9.3)
-      ajv: 8.18.0
+      ajv: 8.20.0
       autoprefixer: 10.4.21(postcss@8.5.9)
       babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.27.7)(postcss@8.5.15))
       browserslist: 4.28.2
@@ -18894,6 +18949,32 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@types/react': 19.2.9
+
+  '@redis/bloom@1.2.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/client@1.6.1':
+    dependencies:
+      cluster-key-slot: 1.1.2
+      generic-pool: 3.9.0
+      yallist: 4.0.0
+
+  '@redis/graph@1.1.1(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/json@1.0.7(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/search@1.2.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/time-series@1.1.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
 
   '@rolldown/binding-android-arm64@1.0.3':
     optional: true
@@ -21355,9 +21436,9 @@ snapshots:
     optionalDependencies:
       ajv: 8.13.0
 
-  ajv-formats@3.0.1(ajv@8.18.0):
+  ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.18.0
+      ajv: 8.20.0
 
   ajv-keywords@3.5.2(ajv@6.15.0):
     dependencies:
@@ -21392,7 +21473,7 @@ snapshots:
   ajv@8.17.1:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.0.6
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -22153,7 +22234,6 @@ snapshots:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   body-parser@2.2.2:
     dependencies:
@@ -22163,9 +22243,9 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.14.2
+      qs: 6.15.2
       raw-body: 3.0.2
-      type-is: 2.0.1
+      type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -22467,6 +22547,8 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cluster-key-slot@1.1.2: {}
+
   cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.9)(react@19.2.3)
@@ -22588,8 +22670,7 @@ snapshots:
 
   content-type@1.0.5: {}
 
-  content-type@2.0.0:
-    optional: true
+  content-type@2.0.0: {}
 
   convert-hrtime@5.0.0: {}
 
@@ -22601,15 +22682,13 @@ snapshots:
 
   cookie-signature@1.0.6: {}
 
-  cookie-signature@1.0.7:
-    optional: true
+  cookie-signature@1.0.7: {}
 
   cookie-signature@1.2.2: {}
 
   cookie@0.7.1: {}
 
-  cookie@0.7.2:
-    optional: true
+  cookie@0.7.2: {}
 
   cookie@1.1.1: {}
 
@@ -23737,7 +23816,6 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   express@5.2.1:
     dependencies:
@@ -23745,7 +23823,7 @@ snapshots:
       body-parser: 2.2.2
       content-disposition: 1.1.0
       content-type: 1.0.5
-      cookie: 0.7.1
+      cookie: 0.7.2
       cookie-signature: 1.2.2
       debug: 4.4.3
       depd: 2.0.0
@@ -23761,13 +23839,13 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.14.2
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
       serve-static: 2.2.1
       statuses: 2.0.2
-      type-is: 2.0.1
+      type-is: 2.1.0
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
@@ -23919,7 +23997,6 @@ snapshots:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   finalhandler@2.1.1:
     dependencies:
@@ -24146,6 +24223,8 @@ snapshots:
   generic-names@4.0.0:
     dependencies:
       loader-utils: 3.3.1
+
+  generic-pool@3.9.0: {}
 
   gensync@1.0.0-beta.2: {}
 
@@ -26092,6 +26171,15 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mcp-handler@1.1.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0)):
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      chalk: 5.6.2
+      commander: 11.1.0
+      redis: 4.7.1
+    optionalDependencies:
+      next: 16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0)
+
   mdast-util-definitions@6.0.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -27502,8 +27590,7 @@ snapshots:
 
   path-to-regexp@0.1.12: {}
 
-  path-to-regexp@0.1.13:
-    optional: true
+  path-to-regexp@0.1.13: {}
 
   path-to-regexp@6.1.0: {}
 
@@ -27982,7 +28069,7 @@ snapshots:
 
   qs@6.13.0:
     dependencies:
-      side-channel: 1.1.0
+      side-channel: 1.1.1
 
   qs@6.14.2:
     dependencies:
@@ -28024,7 +28111,6 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       unpipe: 1.0.0
-    optional: true
 
   raw-body@3.0.2:
     dependencies:
@@ -28178,6 +28264,15 @@ snapshots:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  redis@4.7.1:
+    dependencies:
+      '@redis/bloom': 1.2.0(@redis/client@1.6.1)
+      '@redis/client': 1.6.1
+      '@redis/graph': 1.1.1(@redis/client@1.6.1)
+      '@redis/json': 1.0.7(@redis/client@1.6.1)
+      '@redis/search': 1.2.0(@redis/client@1.6.1)
+      '@redis/time-series': 1.1.0(@redis/client@1.6.1)
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -28793,7 +28888,6 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   send@1.2.1:
     dependencies:
@@ -28847,7 +28941,6 @@ snapshots:
       send: 0.19.2
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   serve-static@2.2.1:
     dependencies:
@@ -29902,18 +29995,11 @@ snapshots:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
-  type-is@2.0.1:
-    dependencies:
-      content-type: 1.0.5
-      media-typer: 1.1.0
-      mime-types: 3.0.2
-
   type-is@2.1.0:
     dependencies:
       content-type: 2.0.0
       media-typer: 1.1.0
       mime-types: 3.0.2
-    optional: true
 
   type@2.7.3: {}
 


### PR DESCRIPTION
## Summary
- Public, read-only, stateless MCP server exposing professional profile data (experiences, projects, skills) — design spec at `docs/superpowers/specs/2026-07-04-personal-context-mcp-design.md`, implementation plan at `docs/superpowers/plans/2026-07-04-personal-context-mcp.md`.
- Data layer (`src/mcp/profile-data.ts`): 6 exported accessors (`getWorkExperience`, `getEducation`, `getProjects`, `getSkills`, `getProfileSummary`, `searchByTechnology`) + 2 by-id resolvers (`getExperienceById`, `getProjectById`), reading the site's existing (previously unused) `organizations`/`experiences`/`projects`/`skills` content collections.
- Server route (`src/pages/api/mcp.ts`): `mcp-handler` wired into an Astro API route, stateless POST-only Streamable HTTP, 6 tools + 3 resources (`profile://experience|project|skill/{id}`).
- Vitest infra added for this app (didn't exist before) — `astro:content` is mocked against fixtures rather than resolved live, since live resolution inside Vitest is a confirmed, unresolved Astro/Vitest ecosystem gap (see commit history for the investigation).

## Notable findings during implementation
- The `organizations`/`experiences`/`projects`/`skills` content collections already existed in `content.config.ts` with real data, just unused by any page — no schema work was needed, only consumption.
- `server.tool()`/`server.resource()` are deprecated in the installed SDK version; used `registerTool`/`registerResource` instead.
- Code review caught a resource/tool shape inconsistency (resources were returning unresolved `reference()` pointers) — fixed so both surfaces return the same resolved shape for the same underlying data.

## Explicitly out of scope (see design spec §2)
Blog search tools, content refresh with newer material (rss-manager/homelab/Hermes work), WebMCP, private/authenticated tools, MCP registry submission, content positioning rewrite, GenUI assistant.

## Test plan
- [x] `npx nx test personal-website` — 12/12 passing
- [x] `npx tsc --noEmit -p apps/personal-website/tsconfig.json` — no new errors (pre-existing ~20 unrelated `.astro`/`.vue` resolution errors only)
- [x] `npx nx lint personal-website` — clean
- [x] All 6 tools + 3 resources manually verified via curl against a local dev server, including a negative (not-found) test
- [ ] Domain (`mcp.rainforest.tools`) + Vercel deploy — **held back at your request, pending this review**

🤖 Generated with [Claude Code](https://claude.com/claude-code)