### PR TITLE
chore(personal-website): route mcp.rainforest.tools to /api/mcp

### DIFF
--- a/apps/personal-website/vercel.json
+++ b/apps/personal-website/vercel.json
@@ -1,0 +1,9 @@
+{
+  "rewrites": [
+    {
+      "source": "/",
+      "has": [{ "type": "host", "value": "mcp.rainforest.tools" }],
+      "destination": "/api/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `apps/personal-website/vercel.json` so once the `mcp.rainforest.tools` custom domain is added to this Vercel project, requests to its root rewrite to `/api/mcp` (the MCP server merged in #220) instead of serving the static site.
- Task 6 of `docs/superpowers/plans/2026-07-04-personal-context-mcp.md`.

## Note
The MCP server code is already live in production at `https://rainforest.tools/api/mcp` (verified: `tools/list` returns all 6 tools). This PR only adds the rewrite rule — it does **not** add the actual `mcp.rainforest.tools` domain to the Vercel project, since that requires either `vercel domains add mcp.rainforest.tools` (interactive OAuth) or the Vercel dashboard, neither of which I can complete from here.

## Test plan
- [x] Rewrite rule matches the plan's Task 6 spec exactly
- [ ] You add `mcp.rainforest.tools` as a domain on the `personal-website` Vercel project (dashboard → Settings → Domains, or `vercel domains add mcp.rainforest.tools` from `apps/personal-website`)
- [ ] After that, `curl -X POST https://mcp.rainforest.tools -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'` should return the same tool list as `rainforest.tools/api/mcp` does today

🤖 Generated with [Claude Code](https://claude.com/claude-code)