### PR TITLE
fix(personal-liff): correct Nx cache outputs for Next.js build target

### DIFF
--- a/apps/personal-liff/package.json
+++ b/apps/personal-liff/package.json
@@ -24,6 +24,12 @@
             "--experimental-https"
           ]
         }
+      },
+      "build": {
+        "outputs": [
+          "{projectRoot}/.next/!(cache)/**/*",
+          "{projectRoot}/.next/!(cache)"
+        ]
       }
     }
   }


### PR DESCRIPTION
## Summary
- Fixes Vercel deployment failures for `apps/personal-liff` on Nx Cloud remote cache hits (`Error: The file "/vercel/path0/apps/personal-liff/.next/routes-manifest.json" couldn't be found`), where Nx reports the `build` task as successful (`[remote cache]`) but the deploy fails right after because `.next` was never actually restored.
- **Root cause**: the root `nx.json` `targetDefaults` for `"build"` declares `outputs: ["{projectRoot}/dist"]` (correct for `@nx/js`/`@nx/vite` library builds), and this explicit target-default **overrides** `@nx/next`'s own inferred `outputs` (which would normally point at `.next`, excluding `.next/cache`). Confirmed via `nx show project personal-liff --json`: resolved `outputs` was `{projectRoot}/dist`, not `.next`.
- Since `next build` never produces a `dist/` folder, Nx's cache for this target captures nothing meaningful. On a cache-hit against a fresh checkout (like a Vercel build), Nx marks the task successful without ever restoring `.next`, so the Next.js output directory Vercel looks for simply doesn't exist.

## Fix
Added a project-level override in `apps/personal-liff/package.json`'s `nx.targets.build.outputs`, matching what `@nx/next`'s own plugin inference produces:
```json
"build": {
  "outputs": [
    "{projectRoot}/.next/!(cache)/**/*",
    "{projectRoot}/.next/!(cache)"
  ]
}
```
This is scoped to `personal-liff` only — the shared `nx.json` `targetDefaults` is untouched, so other projects relying on the `dist`-based default (e.g. `personal-calibre`, which has the same latent misconfiguration but deploys via Docker rather than an Nx-cache-dependent Vercel build, so it isn't affected in practice) are unaffected.

## Root cause verification & local repro
1. `rm -rf apps/personal-liff/.next .nx/cache && nx build personal-liff` → cache miss, `next build` runs, `.next/routes-manifest.json` created correctly.
2. `rm -rf apps/personal-liff/.next` (simulating a fresh checkout, with the populated Nx cache left intact) `&& nx build personal-liff` → **cache hit**, task reported successful, but `.next` was never restored — `routes-manifest.json` missing. This reproduces the exact Vercel failure locally.
3. After adding the `outputs` override above, repeated step 2: cache hit, and this time `.next/routes-manifest.json` **is** correctly restored from cache.

## Test plan
- [x] Verified `nx show project personal-liff --json` resolves `build.outputs` to `.next` paths (not `dist`) after the fix
- [x] Reproduced the bug locally (cache hit + missing `.next`) before the fix
- [x] Verified the fix resolves it (cache hit + `.next/routes-manifest.json` present) after the fix
- [x] Confirmed `personal-calibre`'s resolved `build.outputs` is unchanged (still `{projectRoot}/dist`), so no other project's caching behavior is affected
- [ ] Recommend also invalidating/clearing the existing bad Nx Cloud remote cache entries for `personal-liff:build` (the old cache hash's cached artifacts are still the broken `dist`-only ones) so the next deploy doesn't hit a stale bad entry before a fresh build repopulates the cache under the new outputs config

🤖 Generated with [Claude Code](https://claude.com/claude-code)