### PR TITLE
feat(personal-website): add llms.txt for AI agent/crawler discovery

### DIFF
--- a/apps/personal-website/src/mcp/handler.ts
+++ b/apps/personal-website/src/mcp/handler.ts
@@ -22,6 +22,42 @@ const langSchema = z.enum(['en', 'zh']).optional();
 // getProjects (which require SkillTag, not string).
 const technologySchema = z.enum(tags.skills as unknown as [SkillTag, ...SkillTag[]]).optional();
 
+// Single source of truth for each tool's name/description — server.registerTool below reads
+// from these instead of repeating the strings, and llms.txt.ts imports MCP_TOOLS to describe
+// this server's capabilities without maintaining a second, hand-written copy of the same list
+// that could silently drift out of sync if a tool were renamed/added/removed here.
+export const MCP_TOOLS = [
+  {
+    name: 'get_profile_summary',
+    description: 'Professional profile overview: counts and top technologies',
+  },
+  { name: 'get_work_experience', description: 'Work history, optionally filtered by technology' },
+  { name: 'get_education', description: 'Academic background' },
+  {
+    name: 'get_projects',
+    description: 'Portfolio projects, optionally filtered by technology',
+  },
+  { name: 'get_skills', description: 'Technical skills inventory' },
+  {
+    name: 'search_by_technology',
+    description: 'Substring-match a technology name across all experiences and projects',
+  },
+] as const;
+
+// Same rationale as MCP_TOOLS, for the resource URI templates registered below. `{+id}`
+// (RFC 6570 reserved expansion), not `{id}` — our ids contain slashes (e.g. `en/6`), and
+// plain `{id}` expansion only matches a single path segment, so this is the real template
+// clients need, not a simplified display form.
+export const MCP_RESOURCES = [
+  { uriTemplate: 'profile://experience/{+id}', title: 'Work/Education Experience' },
+  { uriTemplate: 'profile://project/{+id}', title: 'Project' },
+  { uriTemplate: 'profile://skill/{+id}', title: 'Skill' },
+] as const;
+
+const [profileSummaryTool, workExperienceTool, educationTool, projectsTool, skillsTool, searchTool] =
+  MCP_TOOLS;
+const [experienceResource, projectResource, skillResource] = MCP_RESOURCES;
+
 /**
  * Builds an MCP request handler mounted at `${basePath}/mcp` — mcp-handler validates the
  * incoming request's pathname against exactly that computed endpoint (see its
@@ -36,20 +72,17 @@ export function createProfileMcpHandler(basePath?: string) {
   return createMcpHandler(
     (server) => {
       server.registerTool(
-        'get_profile_summary',
-        {
-          description: 'Professional profile overview: counts and top technologies',
-          inputSchema: { lang: langSchema },
-        },
+        profileSummaryTool.name,
+        { description: profileSummaryTool.description, inputSchema: { lang: langSchema } },
         async ({ lang }) => ({
           content: [{ type: 'text', text: JSON.stringify(await getProfileSummary({ lang })) }],
         }),
       );
 
       server.registerTool(
-        'get_work_experience',
+        workExperienceTool.name,
         {
-          description: 'Work history, optionally filtered by technology',
+          description: workExperienceTool.description,
           inputSchema: { technology: technologySchema, lang: langSchema },
         },
         async ({ technology, lang }) => ({
@@ -60,17 +93,17 @@ export function createProfileMcpHandler(basePath?: string) {
       );
 
       server.registerTool(
-        'get_education',
-        { description: 'Academic background', inputSchema: { lang: langSchema } },
+        educationTool.name,
+        { description: educationTool.description, inputSchema: { lang: langSchema } },
         async ({ lang }) => ({
           content: [{ type: 'text', text: JSON.stringify(await getEducation({ lang })) }],
         }),
       );
 
       server.registerTool(
-        'get_projects',
+        projectsTool.name,
         {
-          description: 'Portfolio projects, optionally filtered by technology',
+          description: projectsTool.description,
           inputSchema: { technology: technologySchema, lang: langSchema },
         },
         async ({ technology, lang }) => ({
@@ -81,27 +114,21 @@ export function createProfileMcpHandler(basePath?: string) {
       );
 
       server.registerTool(
-        'get_skills',
-        { description: 'Technical skills inventory', inputSchema: { lang: langSchema } },
+        skillsTool.name,
+        { description: skillsTool.description, inputSchema: { lang: langSchema } },
         async ({ lang }) => ({
           content: [{ type: 'text', text: JSON.stringify(await getSkills({ lang })) }],
         }),
       );
 
       server.registerTool(
-        'search_by_technology',
-        {
-          description: 'Substring-match a technology name across all experiences and projects',
-          inputSchema: { query: z.string(), lang: langSchema },
-        },
+        searchTool.name,
+        { description: searchTool.description, inputSchema: { query: z.string(), lang: langSchema } },
         async ({ query, lang }) => ({
           content: [{ type: 'text', text: JSON.stringify(await searchByTechnology(query, { lang })) }],
         }),
       );
 
-      // `{+id}` (RFC 6570 reserved expansion) is required, not `{id}` — our ids contain
-      // slashes (e.g. `en/6`), and plain `{id}` expansion only matches a single path segment.
-      //
       // experience/project resources return the same *resolved* shape as the tools above
       // (resolved organization, merged technologies) — not a raw content-collection entry.
       // A raw entry's `organization` field is an unresolved `{id, collection}` pointer the
@@ -109,8 +136,8 @@ export function createProfileMcpHandler(basePath?: string) {
       // resource), so returning it as-is would be a dead end, not just "a different view".
       server.registerResource(
         'experience',
-        new ResourceTemplate('profile://experience/{+id}', { list: undefined }),
-        { title: 'Work/Education Experience', mimeType: 'application/json' },
+        new ResourceTemplate(experienceResource.uriTemplate, { list: undefined }),
+        { title: experienceResource.title, mimeType: 'application/json' },
         async (uri, { id }) => {
           const experience = await getExperienceById(id as string);
           if (!experience) throw new Error(`Experience not found: ${id}`);
@@ -120,8 +147,8 @@ export function createProfileMcpHandler(basePath?: string) {
 
       server.registerResource(
         'project',
-        new ResourceTemplate('profile://project/{+id}', { list: undefined }),
-        { title: 'Project', mimeType: 'application/json' },
+        new ResourceTemplate(projectResource.uriTemplate, { list: undefined }),
+        { title: projectResource.title, mimeType: 'application/json' },
         async (uri, { id }) => {
           const project = await getProjectById(id as string);
           if (!project) throw new Error(`Project not found: ${id}`);
@@ -131,8 +158,8 @@ export function createProfileMcpHandler(basePath?: string) {
 
       server.registerResource(
         'skill',
-        new ResourceTemplate('profile://skill/{+id}', { list: undefined }),
-        { title: 'Skill', mimeType: 'application/json' },
+        new ResourceTemplate(skillResource.uriTemplate, { list: undefined }),
+        { title: skillResource.title, mimeType: 'application/json' },
         async (uri, { id }) => {
           const entry = await getEntry('skills', id as string);
           if (!entry) throw new Error(`Skill not found: ${id}`);

--- a/apps/personal-website/src/pages/llms.txt.ts
+++ b/apps/personal-website/src/pages/llms.txt.ts
@@ -1,0 +1,52 @@
+import { getProfileSummary, getSkills } from '@rainforest-dev/personal-data';
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+
+import { MCP_RESOURCES, MCP_TOOLS } from '../mcp/handler';
+
+export const prerender = true;
+
+// llms.txt (https://llmstxt.org) — a machine-readable index for LLM agents/crawlers,
+// analogous to robots.txt/sitemap.xml but describing *what's here* rather than what's
+// crawlable. Generated from the same content sources as the resume/blog pages (astro:content,
+// @rainforest-dev/personal-data) so it can't drift out of sync with them.
+export const GET: APIRoute = async ({ site }) => {
+  const base = site!.origin;
+  const [summary, skills, blog] = await Promise.all([
+    getProfileSummary({ lang: 'en' }),
+    getSkills({ lang: 'en' }),
+    getCollection('blog'),
+  ]);
+
+  const blogLinks = blog
+    .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
+    .map((post) => `- [${post.data.title}](${base}/blog/${post.id}): ${post.data.description}`)
+    .join('\n');
+
+  const skillNames = skills.map((s) => s.name).join(', ');
+  const toolNames = MCP_TOOLS.map((t) => t.name).join(', ');
+  const resourceTemplates = MCP_RESOURCES.map((r) => r.uriTemplate).join(', ');
+
+  const body = `# Rainforest Cheng
+
+> Personal site and technical blog for Rainforest Cheng, a frontend/full-stack engineer. ${summary.experienceCount} work experiences, ${summary.projectCount} projects, and ${summary.skillCount} skills on record — top technologies: ${summary.topTechnologies.slice(0, 8).join(', ')}.
+
+## Profile
+
+- [Resume](${base}/en/resume): Full work history, education, and skills, in English
+- [履歷 (Chinese resume)](${base}/zh/resume): Same content in Traditional Chinese
+- [MCP server](${base}/mcp): Query this profile programmatically over MCP (JSON-RPC 2.0 via HTTP POST; also reachable at ${base}/api/mcp). Tools: ${toolNames}. Resources: ${resourceTemplates}. This is the preferred way to get structured, up-to-date data about this profile — prefer it over parsing the resume page's HTML.
+
+## Blog
+
+${blogLinks}
+
+## Skills
+
+${skillNames}
+`;
+
+  return new Response(body, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+};


### PR DESCRIPTION
## Summary
- Adds `/llms.txt` (https://llmstxt.org) — a plain-text index for LLM agents/crawlers, analogous to `robots.txt`/`sitemap.xml`, listing what's on the site and where, cheaper for an agent to parse than crawling full HTML pages.
- Points agents at the MCP server (`/mcp`, `/api/mcp`) as the preferred way to get structured profile data, rather than parsing the resume page's HTML.
- Generated dynamically at build time (prerendered, same as `resume.astro`) from the site's existing content sources — `astro:content` for blog posts, `@rainforest-dev/personal-data` for the profile summary/skills — so it can't go stale relative to the real content.
- Refactored `src/mcp/handler.ts` to export `MCP_TOOLS`/`MCP_RESOURCES`: each tool/resource's name, description, and URI template now lives in one place that both the actual `server.registerTool`/`registerResource` calls and `llms.txt`'s generated text read from, instead of `llms.txt` carrying a hand-written copy of the same list that could drift if a tool were ever renamed/added/removed.

## Test plan
- [x] `astro build` succeeds; inspected the generated static `llms.txt` output — correct profile summary, blog list, skills list
- [x] Live `astro dev`: `/llms.txt`'s tool/resource text matches `tools/list`/`resources/templates/list` responses from `/mcp` exactly (same source now)
- [x] `/mcp` and `/api/mcp` still work correctly after the handler.ts refactor (get_skills, etc.)
- [x] Lint clean (one pre-existing-pattern warning on `site!`, matching `rss.xml.ts`'s existing style)

🤖 Generated with [Claude Code](https://claude.com/claude-code)