### PR TITLE
feat(personal-website): llms-full.txt, resume JSON-LD, and AI-resource analytics

### DIFF
--- a/apps/personal-website/package.json
+++ b/apps/personal-website/package.json
@@ -29,6 +29,7 @@
     "@rainforest-dev/personal-data": "workspace:*",
     "@rainforest-dev/rainforest-ui": "workspace:*",
     "@tailwindcss/vite": "catalog:",
+    "@vercel/analytics": "^1.6.1",
     "@vercel/speed-insights": "^1.3.1",
     "@vueuse/core": "^14.1.0",
     "astro": "6.4.8",

--- a/apps/personal-website/src/pages/[lang]/resume.astro
+++ b/apps/personal-website/src/pages/[lang]/resume.astro
@@ -2,11 +2,11 @@
 import profile from '@assets/images/profile/1.webp';
 import { ATSFriendly } from '@components/resume';
 import Layout from '@layouts/index.astro';
+import { getEducation, getSkills, getWorkExperience } from '@rainforest-dev/personal-data';
 import type { IResumeProps } from '@types';
+import { getGitHubUrl, getLinkedInUrl } from '@utils';
 import { hero, info } from '@utils/constants';
 import { supportedLngs, useTranslation } from '@utils/i18n';
-import { getEducation, getSkills, getWorkExperience } from '@rainforest-dev/personal-data';
-import { getGitHubUrl, getLinkedInUrl } from '@utils';
 
 export const prerender = true;
 export async function getStaticPaths() {

--- a/apps/personal-website/src/pages/[lang]/resume.astro
+++ b/apps/personal-website/src/pages/[lang]/resume.astro
@@ -6,6 +6,7 @@ import type { IResumeProps } from '@types';
 import { hero, info } from '@utils/constants';
 import { supportedLngs, useTranslation } from '@utils/i18n';
 import { getEducation, getSkills, getWorkExperience } from '@rainforest-dev/personal-data';
+import { getGitHubUrl, getLinkedInUrl } from '@utils';
 
 export const prerender = true;
 export async function getStaticPaths() {
@@ -65,10 +66,7 @@ const personSchema = {
   jobTitle: resumeProps.jobPosition,
   url: info.links.website,
   email: `mailto:${info.email}`,
-  sameAs: [
-    `https://www.linkedin.com/in/${info.links.linkedin}`,
-    `https://github.com/${info.links.github}`,
-  ],
+  sameAs: [getLinkedInUrl(info.links.linkedin), getGitHubUrl(info.links.github)],
   knowsAbout: skills.map((s) => s.name),
   ...(mostRecentJob && {
     worksFor: { '@type': 'Organization', name: mostRecentJob.organization.name },

--- a/apps/personal-website/src/pages/[lang]/resume.astro
+++ b/apps/personal-website/src/pages/[lang]/resume.astro
@@ -5,6 +5,7 @@ import Layout from '@layouts/index.astro';
 import type { IResumeProps } from '@types';
 import { hero, info } from '@utils/constants';
 import { supportedLngs, useTranslation } from '@utils/i18n';
+import { getEducation, getSkills, getWorkExperience } from '@rainforest-dev/personal-data';
 
 export const prerender = true;
 export async function getStaticPaths() {
@@ -14,6 +15,10 @@ export async function getStaticPaths() {
 }
 
 const { t } = await useTranslation(Astro.currentLocale, ['home', 'resume']);
+// Narrowed for @rainforest-dev/personal-data's Locale-typed params below —
+// Astro.currentLocale is `string | undefined`, but getStaticPaths only ever
+// generates 'en'/'zh' paths for this route.
+const lang = Astro.currentLocale === 'zh' ? 'zh' : 'en';
 
 const resumeProps: IResumeProps = {
   ...info,
@@ -36,9 +41,44 @@ const resumeProps: IResumeProps = {
   ],
   tags: hero.tags.map((tag) => t(tag)),
 };
+
+// schema.org Person JSON-LD, sourced from the same @rainforest-dev/personal-data functions
+// the MCP server and llms.txt(-full) read — one source of truth for "what's on record"
+// across the resume's visual rendering, AI-facing text endpoints, and this structured-data
+// block, rather than a hand-maintained fourth copy of the same facts. Placement in <body>
+// rather than threaded through Layout's <head> is intentional: Google explicitly supports
+// JSON-LD anywhere in the document, and this data is resume-page-specific (a blog post would
+// want BlogPosting, not Person), so it doesn't belong in the shared cross-page <head>.
+const [skills, workExperience, education] = await Promise.all([
+  getSkills({ lang }),
+  getWorkExperience({ lang }),
+  getEducation({ lang }),
+]);
+const mostRecentJob = workExperience.toSorted((a, b) => b.startAt.valueOf() - a.startAt.valueOf())[0];
+const personSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Person',
+  // Not resumeProps.name.fullname: the locale string behind it joins first/last with a
+  // literal "\n" for the resume's stacked visual layout, which is wrong inside structured
+  // data (recruiters' tooling would see a name with an embedded line break).
+  name: `${resumeProps.name.first} ${resumeProps.name.last}`,
+  jobTitle: resumeProps.jobPosition,
+  url: info.links.website,
+  email: `mailto:${info.email}`,
+  sameAs: [
+    `https://www.linkedin.com/in/${info.links.linkedin}`,
+    `https://github.com/${info.links.github}`,
+  ],
+  knowsAbout: skills.map((s) => s.name),
+  ...(mostRecentJob && {
+    worksFor: { '@type': 'Organization', name: mostRecentJob.organization.name },
+  }),
+  alumniOf: education.map((e) => ({ '@type': 'EducationalOrganization', name: e.organization.name })),
+};
 ---
 
 <Layout title={t('resume:metadata-title')} description={t('metadata-description')}>
+  <script type="application/ld+json" set:html={JSON.stringify(personSchema)} />
   <main
     class="w-screen h-screen flex-col-center p-10 bg-inverse-surface overflow-scroll
             print:justify-start print:items-start print:p-0 print:overflow-visible"

--- a/apps/personal-website/src/pages/api/mcp.ts
+++ b/apps/personal-website/src/pages/api/mcp.ts
@@ -1,3 +1,4 @@
+import { trackAiResourceFetch } from '@utils/track-ai-resource';
 import type { APIRoute } from 'astro';
 
 import { createProfileMcpHandler } from '../../mcp/handler';
@@ -5,4 +6,7 @@ import { createProfileMcpHandler } from '../../mcp/handler';
 const handler = createProfileMcpHandler('/api');
 
 // Stateless, POST-only per the design spec — same rationale as Task 4's spike.
-export const POST: APIRoute = ({ request }) => handler(request);
+export const POST: APIRoute = async ({ request }) => {
+  await trackAiResourceFetch('mcp', request);
+  return handler(request);
+};

--- a/apps/personal-website/src/pages/llms-full.txt.ts
+++ b/apps/personal-website/src/pages/llms-full.txt.ts
@@ -6,10 +6,12 @@ import {
   getWorkExperience,
   type ResolvedExperience,
 } from '@rainforest-dev/personal-data';
+import { trackAiResourceFetch } from '@utils/track-ai-resource';
 import type { APIRoute } from 'astro';
 import { getCollection } from 'astro:content';
 
-export const prerender = true;
+// Not prerendered — see llms.txt.ts's comment for why: a prerendered handler only runs
+// once, at build time, so it can't fire trackAiResourceFetch per real visitor.
 
 const formatMonth = (d: Date) => d.toISOString().slice(0, 7);
 
@@ -26,7 +28,8 @@ function formatExperience(e: ResolvedExperience): string {
 // sync with them. Blog posts stay a link list here (not inlined) — they're independently
 // crawlable full HTML pages already, and inlining varied-length MDX bodies would bloat
 // this file without adding anything the profile-focused sections above don't already cover.
-export const GET: APIRoute = async ({ site }) => {
+export const GET: APIRoute = async ({ site, request }) => {
+  await trackAiResourceFetch('llms-full.txt', request);
   const base = site!.origin;
   const [summary, experiences, education, projects, skills, blog] = await Promise.all([
     getProfileSummary({ lang: 'en' }),

--- a/apps/personal-website/src/pages/llms-full.txt.ts
+++ b/apps/personal-website/src/pages/llms-full.txt.ts
@@ -1,0 +1,90 @@
+import {
+  getEducation,
+  getProfileSummary,
+  getProjects,
+  getSkills,
+  getWorkExperience,
+  type ResolvedExperience,
+} from '@rainforest-dev/personal-data';
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+
+export const prerender = true;
+
+const formatMonth = (d: Date) => d.toISOString().slice(0, 7);
+
+function formatExperience(e: ResolvedExperience): string {
+  const range = `${formatMonth(e.startAt)} – ${e.endAt ? formatMonth(e.endAt) : 'present'}`;
+  const tech = e.technologies.length ? `\nTechnologies: ${e.technologies.join(', ')}` : '';
+  return `### ${e.position} — ${e.organization.name}\n${range}${tech}\n\n${e.content}`;
+}
+
+// llms-full.txt — the expanded companion to llms.txt (https://llmstxt.org): full resume
+// content inlined rather than just links, for agents that want everything in one fetch
+// instead of following each link individually. Same data sources as llms.txt and the
+// resume page (@rainforest-dev/personal-data, astro:content), so it can't drift out of
+// sync with them. Blog posts stay a link list here (not inlined) — they're independently
+// crawlable full HTML pages already, and inlining varied-length MDX bodies would bloat
+// this file without adding anything the profile-focused sections above don't already cover.
+export const GET: APIRoute = async ({ site }) => {
+  const base = site!.origin;
+  const [summary, experiences, education, projects, skills, blog] = await Promise.all([
+    getProfileSummary({ lang: 'en' }),
+    getWorkExperience({ lang: 'en' }),
+    getEducation({ lang: 'en' }),
+    getProjects({ lang: 'en' }),
+    getSkills({ lang: 'en' }),
+    getCollection('blog'),
+  ]);
+
+  const experienceText = experiences.map(formatExperience).join('\n\n');
+  const educationText = education.map(formatExperience).join('\n\n');
+
+  const projectsText = projects
+    .map(
+      (p) =>
+        `### ${p.name} — ${p.organization.name}\nTechnologies: ${p.technologies.join(', ')}\n\n${p.content}`,
+    )
+    .join('\n\n');
+
+  const skillsText = skills
+    .map(
+      (s) =>
+        `### ${s.name}${s.tags.length ? ` (${s.tags.join(', ')})` : ''}\n\n${s.content || '(no additional detail on record)'}`,
+    )
+    .join('\n\n');
+
+  const blogLinks = blog
+    .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
+    .map((post) => `- [${post.data.title}](${base}/blog/${post.id}): ${post.data.description}`)
+    .join('\n');
+
+  const body = `# Rainforest Cheng — Full Profile
+
+> ${summary.experienceCount} work experiences, ${summary.projectCount} projects, ${summary.skillCount} skills. This is the expanded companion to ${base}/llms.txt — the full resume content inlined below, rather than links out. For structured, queryable access to this same data (filter by technology, fetch a single entry, etc.) use the MCP server at ${base}/mcp instead of re-parsing this text.
+
+## Work Experience
+
+${experienceText}
+
+## Education
+
+${educationText}
+
+## Projects
+
+${projectsText}
+
+## Skills
+
+${skillsText}
+
+## Blog
+
+${blogLinks}
+`;
+
+  return new Response(body, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+};

--- a/apps/personal-website/src/pages/llms.txt.ts
+++ b/apps/personal-website/src/pages/llms.txt.ts
@@ -1,16 +1,22 @@
 import { getProfileSummary, getSkills } from '@rainforest-dev/personal-data';
+import { trackAiResourceFetch } from '@utils/track-ai-resource';
 import type { APIRoute } from 'astro';
 import { getCollection } from 'astro:content';
 
 import { MCP_RESOURCES, MCP_TOOLS } from '../mcp/handler';
 
-export const prerender = true;
+// Not prerendered, deliberately: a prerendered route's handler only ever runs once, at
+// build time, to produce a static file — Vercel then serves that file directly and never
+// invokes this code again per visitor. Since trackAiResourceFetch below needs to fire on
+// every real request, this has to run on-demand (the same mechanism /mcp already uses),
+// even though the content itself is static enough that prerendering would otherwise fit.
 
 // llms.txt (https://llmstxt.org) — a machine-readable index for LLM agents/crawlers,
 // analogous to robots.txt/sitemap.xml but describing *what's here* rather than what's
 // crawlable. Generated from the same content sources as the resume/blog pages (astro:content,
 // @rainforest-dev/personal-data) so it can't drift out of sync with them.
-export const GET: APIRoute = async ({ site }) => {
+export const GET: APIRoute = async ({ site, request }) => {
+  await trackAiResourceFetch('llms.txt', request);
   const base = site!.origin;
   const [summary, skills, blog] = await Promise.all([
     getProfileSummary({ lang: 'en' }),

--- a/apps/personal-website/src/pages/mcp.ts
+++ b/apps/personal-website/src/pages/mcp.ts
@@ -1,3 +1,4 @@
+import { trackAiResourceFetch } from '@utils/track-ai-resource';
 import type { APIRoute } from 'astro';
 
 import { createProfileMcpHandler } from '../mcp/handler';
@@ -8,4 +9,7 @@ import { createProfileMcpHandler } from '../mcp/handler';
 // ahead of Astro's own generated routing; see the routing-fix PR for the investigation).
 const handler = createProfileMcpHandler();
 
-export const POST: APIRoute = ({ request }) => handler(request);
+export const POST: APIRoute = async ({ request }) => {
+  await trackAiResourceFetch('mcp', request);
+  return handler(request);
+};

--- a/apps/personal-website/src/utils/track-ai-resource.ts
+++ b/apps/personal-website/src/utils/track-ai-resource.ts
@@ -1,0 +1,40 @@
+import { track } from '@vercel/analytics/server';
+
+// Coarse bot classification, not an exhaustive list — good enough to answer "are AI
+// crawlers actually hitting these endpoints", which is the question this exists to answer.
+// Extend as new agents show up in real traffic rather than trying to enumerate every one
+// up front.
+const AI_BOT_PATTERNS: [name: string, pattern: RegExp][] = [
+  ['GPTBot', /GPTBot/i],
+  ['ClaudeBot', /ClaudeBot|Claude-User|anthropic-ai/i],
+  ['PerplexityBot', /PerplexityBot|Perplexity-User/i],
+  ['Google-Extended', /Google-Extended/i],
+  ['CCBot', /CCBot/i],
+  ['Bytespider', /Bytespider/i],
+];
+
+function classifyUserAgent(userAgent: string | null): string {
+  if (!userAgent) return 'unknown';
+  const match = AI_BOT_PATTERNS.find(([, pattern]) => pattern.test(userAgent));
+  return match ? match[0] : 'other';
+}
+
+/**
+ * Fires a Vercel Analytics custom event for a hit on one of the AI-facing resources
+ * (llms.txt, llms-full.txt, the MCP server) — these are the endpoints this whole feature
+ * set exists to measure the effect of, so "did anything real request them, and was it an
+ * AI crawler" is the question worth tracking, not raw pageviews. Swallows its own errors:
+ * a failed analytics call must never turn into a broken response for the actual resource.
+ * Server-only (imports @vercel/analytics/server) — import this by its exact path from API
+ * routes, not via the shared @utils barrel, which client-hydrated components also pull from.
+ */
+export async function trackAiResourceFetch(resource: string, request: Request): Promise<void> {
+  try {
+    await track('ai_resource_fetch', {
+      resource,
+      bot: classifyUserAgent(request.headers.get('user-agent')),
+    });
+  } catch {
+    // Best-effort only.
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -376,6 +376,9 @@ importers:
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.2.2(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@vercel/analytics':
+        specifier: ^1.6.1
+        version: 1.6.1(next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(react@19.2.3)(svelte@5.9.0)(vue@3.5.32(typescript@5.9.3))
       '@vercel/speed-insights':
         specifier: ^1.3.1
         version: 1.3.1(next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(react@19.2.3)(svelte@5.9.0)(vue@3.5.32(typescript@5.9.3))


### PR DESCRIPTION
## Summary
- **`llms-full.txt`**: expanded companion to `llms.txt` (https://llmstxt.org) with full work experience/education/projects/skills content inlined, for agents that want everything in one fetch. Same `@rainforest-dev/personal-data` sources as `llms.txt`/the MCP server, so it can't drift out of sync. Blog stays a link list (posts are already independently crawlable full pages).
- **schema.org `Person` JSON-LD** on the resume page (both locales), sourced from the same personal-data functions. Caught and fixed a real bug while wiring it up: the visual resume's `name.fullname` embeds a literal `\n` between first/last name for its stacked layout — using it directly would have shipped a name with an embedded line break into structured data, so the schema's `name` is built from first/last separately instead. Also reused the existing `getLinkedInUrl`/`getGitHubUrl` helpers for `sameAs` instead of re-deriving the URLs.
- **AI-resource hit tracking** via `@vercel/analytics/server`'s `track()` on `llms.txt`, `llms-full.txt`, `/mcp`, and `/api/mcp` — chosen over GA4 Measurement Protocol since it needs zero new accounts/secrets (plugs into this same Vercel project's existing Web Analytics). Each event carries a coarse bot classification (GPTBot/ClaudeBot/PerplexityBot/Google-Extended/CCBot/Bytespider/other/unknown) so the actual question — "are AI crawlers hitting these" — is answerable, not just raw counts.
- Switched `llms.txt`/`llms-full.txt` from prerendered (static, build-once) to on-demand: a prerendered handler only ever runs at build time, so it would fire the tracking call exactly once, never per real visitor. Uses the same on-demand mechanism `/mcp` already relies on.

## Test plan
- [x] `astro build` succeeds; confirmed via `.vercel/output/config.json` that `llms.txt`/`llms-full.txt` now route to `_render` (on-demand), not a static file
- [x] Inspected built `llms-full.txt` output — correct full experience/education/project/skill content
- [x] Extracted and validated the JSON-LD from both `en/resume` and `zh/resume` built HTML — correct, no embedded newlines, correct `sameAs`/`knowsAbout`/`worksFor`/`alumniOf`
- [x] Live `astro dev`: hit all four endpoints with different `User-Agent` headers (GPTBot, ClaudeBot, plain browser) — `@vercel/analytics/server` logs the classified event to console in dev mode, confirmed correct classification for each
- [x] Lint clean (autofixed import ordering; only the pre-existing `site!` non-null-assertion warning pattern remains, matching `rss.xml.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)