### PR TITLE
chore(personal-website): bump version to force a real Nx-affected rebuild

### DIFF
--- a/apps/personal-website/package.json
+++ b/apps/personal-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "personal-website",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "module",
   "scripts": {
     "astro": "astro",


### PR DESCRIPTION
Root cause of both #232/#233 failing to fix the outage: they were empty commits, and Vercel's monorepo 'skipping unaffected projects' optimization (https://vercel.com/docs/monorepos#skipping-unaffected-projects) correctly-but-unhelpfully canceled them since Nx's affected-detection saw zero file changes. This bumps the version (matching this repo's own established precedent for forcing a real redeploy) so Nx recognizes personal-website as affected and actually rebuilds.