### PR TITLE
fix(personal-website): restore Vercel Function generation, switch AI-resource tracking to GA4

### DIFF
--- a/apps/personal-website/package.json
+++ b/apps/personal-website/package.json
@@ -29,7 +29,6 @@
     "@rainforest-dev/personal-data": "workspace:*",
     "@rainforest-dev/rainforest-ui": "workspace:*",
     "@tailwindcss/vite": "catalog:",
-    "@vercel/analytics": "^1.6.1",
     "@vercel/speed-insights": "^1.3.1",
     "@vueuse/core": "^14.1.0",
     "astro": "6.4.8",

--- a/apps/personal-website/src/utils/track-ai-resource.ts
+++ b/apps/personal-website/src/utils/track-ai-resource.ts
@@ -1,5 +1,3 @@
-import { track } from '@vercel/analytics/server';
-
 // Coarse bot classification, not an exhaustive list — good enough to answer "are AI
 // crawlers actually hitting these endpoints", which is the question this exists to answer.
 // Extend as new agents show up in real traffic rather than trying to enumerate every one
@@ -20,20 +18,49 @@ function classifyUserAgent(userAgent: string | null): string {
 }
 
 /**
- * Fires a Vercel Analytics custom event for a hit on one of the AI-facing resources
+ * Fires a GA4 Measurement Protocol event for a hit on one of the AI-facing resources
  * (llms.txt, llms-full.txt, the MCP server) — these are the endpoints this whole feature
  * set exists to measure the effect of, so "did anything real request them, and was it an
- * AI crawler" is the question worth tracking, not raw pageviews. Swallows its own errors:
- * a failed analytics call must never turn into a broken response for the actual resource.
- * Server-only (imports @vercel/analytics/server) — import this by its exact path from API
- * routes, not via the shared @utils barrel, which client-hydrated components also pull from.
+ * AI crawler" is the question worth tracking, not raw pageviews.
+ *
+ * GA4 over Vercel Web Analytics custom events: Vercel Custom Events require a paid plan
+ * (not available on Hobby at all), and @vercel/analytics as a direct dependency was
+ * separately confirmed (via bisection) to break this project's Vercel Function generation
+ * entirely — its /_render Function silently disappeared from the build output. GA4's
+ * Measurement Protocol has no such constraints: plain HTTP, no SDK/dependency, works on
+ * any plan.
+ *
+ * Requires GA_MEASUREMENT_ID and GA_API_SECRET env vars (Vercel dashboard → Settings →
+ * Environment Variables — see GA4 Admin → Data Streams → your stream → Measurement
+ * Protocol API secrets → Create). Silently no-ops if either is unset, so this is safe to
+ * deploy before they're configured. Swallows its own errors: a failed analytics call must
+ * never turn into a broken response for the actual resource being served.
  */
 export async function trackAiResourceFetch(resource: string, request: Request): Promise<void> {
+  const measurementId = process.env.GA_MEASUREMENT_ID;
+  const apiSecret = process.env.GA_API_SECRET;
+  if (!measurementId || !apiSecret) return;
+
   try {
-    await track('ai_resource_fetch', {
-      resource,
-      bot: classifyUserAgent(request.headers.get('user-agent')),
-    });
+    await fetch(
+      `https://www.google-analytics.com/mp/collect?measurement_id=${measurementId}&api_secret=${apiSecret}`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          // GA4 requires a client_id; there's no real client/session for server-to-server
+          // bot traffic, so a fresh one per event is fine — nothing here needs cross-request
+          // identity, just per-hit counts and properties.
+          client_id: crypto.randomUUID(),
+          events: [
+            {
+              name: 'ai_resource_fetch',
+              params: { resource, bot: classifyUserAgent(request.headers.get('user-agent')) },
+            },
+          ],
+        }),
+      },
+    );
   } catch {
     // Best-effort only.
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -376,9 +376,6 @@ importers:
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.2.2(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
-      '@vercel/analytics':
-        specifier: ^1.6.1
-        version: 1.6.1(next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(react@19.2.3)(svelte@5.9.0)(vue@3.5.32(typescript@5.9.3))
       '@vercel/speed-insights':
         specifier: ^1.3.1
         version: 1.3.1(next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(react@19.2.3)(svelte@5.9.0)(vue@3.5.32(typescript@5.9.3))


### PR DESCRIPTION
## Summary

Production (`rainforest.tools`) has been down since #231 merged — Vercel silently stopped generating a serverless Function for this project (confirmed via the deployment's **Resources** tab: 0 Functions instead of 1). The root cause was isolated via bisection (throwaway preview branches, each inspected in the dashboard) down to `@vercel/analytics` being a **direct dependency** of `apps/personal-website` — removing just the import/dependency restored the Function, no other change required.

No matching upstream issue was found in `withastro/astro`, `vercel/analytics`, or `withastro/adapters` for this exact interaction, and `@astrojs/vercel`'s `webAnalytics: { enabled: true }` option doesn't use `@vercel/analytics`'s runtime at all (it's a plain client-side `<script>` tag injector), so there's no dependency worth fighting to keep.

This PR:
- Removes `@vercel/analytics` as a direct dependency (still present transitively via `@astrojs/vercel`, which is fine — only the *direct* dependency broke Function generation)
- Replaces the AI-resource-hit tracking (`llms.txt`, `llms-full.txt`, `/mcp`) with a plain GA4 Measurement Protocol POST — no SDK, no Vercel runtime dependency
- Chosen over Vercel Custom Events because those require a paid plan (Hobby doesn't support them; regular pageviews still track for free via the untouched `webAnalytics` script injection)
- Silently no-ops if `GA_MEASUREMENT_ID`/`GA_API_SECRET` aren't set, so this is safe to deploy before those env vars are configured in Vercel

None of the features added in #231 (llms-full.txt, resume JSON-LD, AI-resource tracking) are being reverted — this fixes the mechanism, not the feature set.

## Test plan
- [x] Local `astro build` succeeds, `.vercel/output/functions/_render.func` present
- [x] Local `astro dev`: `/llms.txt`, `/llms-full.txt` return 200 with `GA_MEASUREMENT_ID`/`GA_API_SECRET` unset (no-op path) and with fake values set (fetch path, doesn't throw)
- [x] Local `astro dev`: `POST /mcp` with a real `initialize` JSON-RPC request returns 200 with a valid MCP response
- [ ] CI green
- [ ] Preview deployment's Resources tab shows the `/_render` Function again (the definitive test — this is what was missing since #231)
- [ ] After merge: `rainforest.tools`, `/en/resume`, `/mcp`, `/llms.txt`, `/llms-full.txt` all return 200 in production
- [ ] Add `GA_MEASUREMENT_ID`/`GA_API_SECRET` in Vercel env vars to activate tracking (safe to do anytime after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)