### PR TITLE
ci: run affected tasks locally when Nx Cloud is disabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,18 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - uses: nrwl/nx-set-shas@v5
 
-      - run: pnpm exec nx affected -t lint test typecheck
+      # Run affected tasks. Nx Cloud is opt-in via the NX_CLOUD_ENABLED repo
+      # variable (same flag that gates the agents above). When it's off —
+      # including if the Nx Cloud plan lapses — set NX_NO_CLOUD so `nx affected`
+      # runs locally instead of hard-failing on "Workspace unable to be
+      # authorized". Full Cloud execution returns by flipping the variable back
+      # on (nxCloudId stays configured in nx.json).
+      - name: Run affected tasks (Nx Cloud)
+        if: vars.NX_CLOUD_ENABLED == 'true'
+        run: pnpm exec nx affected -t lint test typecheck
+
+      - name: Run affected tasks (local)
+        if: vars.NX_CLOUD_ENABLED != 'true'
+        run: pnpm exec nx affected -t lint test typecheck
+        env:
+          NX_NO_CLOUD: 'true'


### PR DESCRIPTION
## Problem
Since the Nx Cloud org was disabled (FREE plan exceeded), **every** CI run fails:

```
NX  Nx Cloud: Workspace is unable to be authorized. Exiting run.
    This Nx Cloud organization has been disabled due to exceeding the FREE plan.
##[error]Process completed with exit code 1.
```

`nx affected` hard-exits **before running any lint/test/typecheck**, because `nx.json` carries an `nxCloudId` so nx always tries to authorize with Cloud. This has been red on `main`, #237, and #238.

## Fix
Gate the Cloud *connection* on the same `NX_CLOUD_ENABLED` repo variable that already gates the distributed-agents step:

- `NX_CLOUD_ENABLED == 'true'` → run through Nx Cloud (unchanged).
- otherwise → run `nx affected` with `NX_NO_CLOUD=true`, so tasks execute **locally on the runner** instead of dying on Cloud auth.

`nxCloudId` stays in `nx.json` — flip `NX_CLOUD_ENABLED` back to `true` (after re-enabling the plan) to restore full distributed Cloud execution. No behavioral change when Cloud is healthy.

Two explicit steps are used instead of a computed `NX_NO_CLOUD` env, because GitHub's `A && B || C` ternary collapses on an empty-string branch and Nx misreads `NX_NO_CLOUD='false'` as "disable cloud."

## Verification
Locally, `NX_NO_CLOUD=true nx run …` never contacts Nx Cloud (no auth attempt, no warning), while a plain run still hits the disabled org. **This PR's own CI run exercises the fixed workflow** — it should be the first green run since the outage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)