### PR TITLE
Analytics, SEO & observability: Sentry, Clarity, JSON-LD, Lighthouse CI

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,37 @@
+name: Lighthouse
+
+# Audits the deployed site's Core Web Vitals / Lighthouse categories. Runs on a
+# weekly schedule against production, and on demand against any URL (paste a
+# Vercel preview deployment to check a branch before merging). Budgets live in
+# .lighthouserc.cjs as "warn" assertions, so this reports rather than blocks.
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'Base URL to audit (defaults to production)'
+        required: false
+        default: 'https://rainforest.tools'
+  schedule:
+    # Mondays 06:00 UTC. Scheduled runs only fire once this workflow is on the
+    # default branch (a GitHub constraint); workflow_dispatch works from any
+    # branch via the Actions tab.
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Audit with Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v12
+        env:
+          # A workflow_dispatch input (authorized users only), consumed only as
+          # a URL string by .lighthouserc.cjs — never interpolated into a shell
+          # command. Empty on scheduled runs → the config falls back to prod.
+          LHCI_BASE_URL: ${{ inputs.base_url }}
+        with:
+          configPath: ./.lighthouserc.cjs

--- a/.lighthouserc.cjs
+++ b/.lighthouserc.cjs
@@ -1,0 +1,50 @@
+// Lighthouse CI configuration.
+//
+// personal-website is SSR on Vercel (`output: 'server'`), so there is no static
+// `dist/` to serve locally for a faithful audit, and a dev server would score
+// unrealistically low. Instead we audit the DEPLOYED site: production by
+// default, or any URL passed via LHCI_BASE_URL (e.g. a Vercel preview
+// deployment) — set it in the workflow_dispatch input.
+//
+// Budgets are assertions at "warn": they surface Core Web Vitals / category
+// regressions in the CI log and the public report, without failing the run.
+// Tighten specific ones to "error" once the numbers are consistently green.
+const base = (process.env.LHCI_BASE_URL || 'https://rainforest.tools').replace(
+  /\/+$/,
+  '',
+);
+
+module.exports = {
+  ci: {
+    collect: {
+      url: [
+        `${base}/`,
+        `${base}/resume`,
+        // Enable once the portfolio redesign is live in production:
+        // `${base}/portfolio`,
+        // `${base}/portfolio/hashgreen-swap`,
+      ],
+      // Median of 3 runs — dampens the variance of a single remote audit.
+      numberOfRuns: 3,
+    },
+    assert: {
+      // Default Lighthouse form factor is mobile (throttled), which is the
+      // meaningful target for Core Web Vitals.
+      assertions: {
+        'categories:performance': ['warn', { minScore: 0.8 }],
+        'categories:accessibility': ['warn', { minScore: 0.9 }],
+        'categories:best-practices': ['warn', { minScore: 0.9 }],
+        'categories:seo': ['warn', { minScore: 0.9 }],
+        'first-contentful-paint': ['warn', { maxNumericValue: 2000 }],
+        'largest-contentful-paint': ['warn', { maxNumericValue: 2500 }],
+        'total-blocking-time': ['warn', { maxNumericValue: 300 }],
+        'cumulative-layout-shift': ['warn', { maxNumericValue: 0.1 }],
+      },
+    },
+    upload: {
+      // Publishes each report to Google's temporary public storage (~7 days)
+      // and prints the link in the job log — no server or secret required.
+      target: 'temporary-public-storage',
+    },
+  },
+};

--- a/apps/personal-website/astro.config.mjs
+++ b/apps/personal-website/astro.config.mjs
@@ -8,6 +8,7 @@ import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
 import vercel from '@astrojs/vercel';
 import vue from '@astrojs/vue';
+import sentry from '@sentry/astro';
 import tailwindcss from '@tailwindcss/vite';
 import pwa from '@vite-pwa/astro';
 import { defineConfig } from 'astro/config';
@@ -15,6 +16,13 @@ import rehypeKatex from 'rehype-katex';
 import remarkMath from 'remark-math';
 
 import { fallbackLng, supportedLngs } from './src/utils/i18n/settings';
+
+// Wire Sentry only when the (public) DSN is configured — i.e. production and
+// preview on Vercel. Local/dev builds have no DSN, so the integration is
+// omitted entirely and nothing Sentry-related ships. SDK init + options live in
+// sentry.{client,server}.config.js; source-map upload is disabled so no
+// SENTRY_AUTH_TOKEN (and no @sentry/cli binary) is required.
+const sentryEnabled = !!process.env.PUBLIC_SENTRY_DSN;
 
 // https://astro.build/config
 export default defineConfig({
@@ -104,6 +112,20 @@ export default defineConfig({
         directoryAndTrailingSlashHandler: true,
       },
     }),
+    ...(sentryEnabled
+      ? [
+          sentry({
+            sourceMapsUploadOptions: { enabled: false },
+            // Error monitoring only — tree-shake the tracing and replay code we
+            // never initialise (see sentry.{client,server}.config.js) out of the
+            // client bundle.
+            bundleSizeOptimizations: {
+              excludeTracing: true,
+              excludeReplay: true,
+            },
+          }),
+        ]
+      : []),
   ],
   output: 'server',
   adapter: vercel({

--- a/apps/personal-website/package.json
+++ b/apps/personal-website/package.json
@@ -29,6 +29,7 @@
     "@rainforest-dev/personal-data": "workspace:*",
     "@rainforest-dev/personal-portfolio": "workspace:*",
     "@rainforest-dev/rainforest-ui": "workspace:*",
+    "@sentry/astro": "^10.67.0",
     "@tailwindcss/vite": "catalog:",
     "@vercel/speed-insights": "^1.3.1",
     "@vueuse/core": "^14.1.0",

--- a/apps/personal-website/sentry.client.config.js
+++ b/apps/personal-website/sentry.client.config.js
@@ -1,0 +1,18 @@
+import * as Sentry from '@sentry/astro';
+
+// Browser-side error monitoring. The DSN is public by design (an ingest
+// endpoint, not a secret) and is only present in production/preview, where
+// `PUBLIC_SENTRY_DSN` is set in Vercel — so local/dev builds stay clean because
+// the guard below is falsy. Error monitoring only: performance tracing and
+// session replay are opt-in integrations we deliberately omit to keep the
+// client bundle small on a personal site.
+const dsn = import.meta.env.PUBLIC_SENTRY_DSN;
+
+if (dsn) {
+  Sentry.init({
+    dsn,
+    environment: import.meta.env.PUBLIC_VERCEL_ENV ?? import.meta.env.MODE,
+    release: import.meta.env.PUBLIC_VERCEL_GIT_COMMIT_SHA,
+    tracesSampleRate: 0,
+  });
+}

--- a/apps/personal-website/sentry.server.config.js
+++ b/apps/personal-website/sentry.server.config.js
@@ -1,0 +1,16 @@
+import * as Sentry from '@sentry/astro';
+
+// Server-side (SSR) error monitoring. `PUBLIC_SENTRY_DSN` is exposed to both the
+// client and server builds by Vite, so the same var drives both configs. Only
+// initialises when the DSN is set (production/preview on Vercel). Tracing is
+// disabled (tracesSampleRate: 0) — we want error capture, not full APM.
+const dsn = import.meta.env.PUBLIC_SENTRY_DSN;
+
+if (dsn) {
+  Sentry.init({
+    dsn,
+    environment: import.meta.env.PUBLIC_VERCEL_ENV ?? import.meta.env.MODE,
+    release: import.meta.env.PUBLIC_VERCEL_GIT_COMMIT_SHA,
+    tracesSampleRate: 0,
+  });
+}

--- a/apps/personal-website/src/components/home/hero/one-column.astro
+++ b/apps/personal-website/src/components/home/hero/one-column.astro
@@ -25,7 +25,8 @@ const translatePath = useTranslatedPath(lang);
     >
       <Picture
         src={props.profile}
-        alt="profile"
+        alt="Rainforest Cheng"
+        quality={72}
         loading="eager"
         pictureAttributes={{
           class:

--- a/apps/personal-website/src/components/home/hero/three-columns.astro
+++ b/apps/personal-website/src/components/home/hero/three-columns.astro
@@ -48,7 +48,8 @@ const translatePath = useTranslatedPath(lang);
   </div>
   <Picture
     src={props.profile}
-    alt="profile"
+    alt="Rainforest Cheng"
+    quality={72}
     loading="eager"
     pictureAttributes={{
       class: 'self-end -mb-10 h-[120%] w-full',

--- a/apps/personal-website/src/components/pages/HomePage.astro
+++ b/apps/personal-website/src/components/pages/HomePage.astro
@@ -10,7 +10,7 @@ import {
 import Experiences from '@components/home/experiences/index.astro';
 import Layout from '@layouts/index.astro';
 import { IHeroProps } from '@types';
-import { getBrandIconName } from '@utils';
+import { getBrandIconName, getGitHubUrl, getLinkedInUrl } from '@utils';
 import { hero, info } from '@utils/constants';
 import { supportedLngs, useTranslation } from '@utils/i18n';
 import type { ImageMetadata } from 'astro';
@@ -82,10 +82,38 @@ const skills = (
     Number(b.data.tags.includes('prioritized')) -
     Number(a.data.tags.includes('prioritized'))
 );
+
+// schema.org WebSite + Person for the home — the primary page humans and AI agents
+// land on. Same facts as the resume/MCP, so search + agents get a consistent identity.
+const homeSchema = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'WebSite',
+      '@id': `${info.links.website}/#website`,
+      url: info.links.website,
+      name: `${heroProps.name.first} ${heroProps.name.last}`,
+      inLanguage: lang === 'zh' ? 'zh-Hant' : 'en',
+    },
+    {
+      '@type': 'Person',
+      '@id': `${info.links.website}/#person`,
+      name: `${heroProps.name.first} ${heroProps.name.last}`,
+      jobTitle: heroProps.jobPosition,
+      url: info.links.website,
+      email: `mailto:${info.email}`,
+      sameAs: [
+        getLinkedInUrl(info.links.linkedin),
+        getGitHubUrl(info.links.github),
+      ],
+    },
+  ],
+};
 ---
 
 <Layout title={t('metadata-title')} description={t('metadata-description')}>
   <main class="contents">
+    <script type="application/ld+json" set:html={JSON.stringify(homeSchema)} />
     <Nav client:load {...navProps}>
       <Fragment slot="sider">
         <Links />

--- a/apps/personal-website/src/layouts/blog.astro
+++ b/apps/personal-website/src/layouts/blog.astro
@@ -1,5 +1,6 @@
 ---
 import { Comments } from '@components/blog';
+import { info } from '@utils/constants';
 import { Image } from 'astro:assets';
 import type { CollectionEntry } from 'astro:content';
 import clsx from 'clsx';
@@ -16,6 +17,19 @@ const {
   author: _author,
   image,
 } = Astro.props.data;
+
+const canonicalUrl = new URL(Astro.url.pathname, Astro.site).href;
+const postSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'BlogPosting',
+  headline: title,
+  description,
+  datePublished: new Date(pubDate).toISOString(),
+  author: { '@type': 'Person', name: 'Rainforest Cheng', url: info.links.website },
+  url: canonicalUrl,
+  mainEntityOfPage: canonicalUrl,
+  ...(image?.src && { image: new URL(image.src, Astro.site).href }),
+};
 ---
 
 <BaseLayout
@@ -25,6 +39,7 @@ const {
   viewTransition={{ enabled: true }}
   shell
 >
+  <script type="application/ld+json" set:html={JSON.stringify(postSchema)} />
   {
     image?.src && (
       <Image

--- a/apps/personal-website/src/layouts/head.astro
+++ b/apps/personal-website/src/layouts/head.astro
@@ -12,6 +12,10 @@ const {
 } = Astro.props;
 const url = Astro.url.toString();
 
+// Microsoft Clarity (heatmaps + session replay). Loads only when the public
+// project id is configured, so dev/preview stay clean unless you set it.
+const clarityId = import.meta.env.PUBLIC_CLARITY_PROJECT_ID;
+
 // Self-referencing canonical (each URL is its own canonical).
 const canonical = new URL(Astro.url.pathname, Astro.site).href;
 // hreflang alternates only for the localized routes: home, portfolio and resume
@@ -109,6 +113,14 @@ const xDefaultHref = isLocalized
       }
     })();
   </script>
+  {
+    clarityId && (
+      <script
+        is:inline
+        set:html={`(function(c,l,a,r,i,t,y){c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y)})(window,document,"clarity","script",${JSON.stringify(clarityId)})`}
+      />
+    )
+  }
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta name="generator" content={Astro.generator} />
   <link rel="sitemap" href="/sitemap-index.xml" />

--- a/apps/personal-website/src/layouts/head.astro
+++ b/apps/personal-website/src/layouts/head.astro
@@ -1,4 +1,6 @@
 ---
+import { fallbackLng, supportedLngs } from '@utils/i18n';
+import { getRelativeLocaleUrl } from 'astro:i18n';
 import { pwaInfo } from 'virtual:pwa-info';
 
 import type { HeadProps as Props } from './types';
@@ -9,6 +11,25 @@ const {
   imageUrl = new URL('/images/thumbnail/1.jpg', Astro.site),
 } = Astro.props;
 const url = Astro.url.toString();
+
+// Self-referencing canonical (each URL is its own canonical).
+const canonical = new URL(Astro.url.pathname, Astro.site).href;
+// hreflang alternates only for the localized routes: home, portfolio and resume
+// have per-locale variants (en at root, zh under /zh). Blog, posts and the machine
+// endpoints (llms.txt, sitemap, mcp…) are locale-agnostic, so they get no alternates.
+const localePath = Astro.url.pathname.replace(/^\/zh(?=\/|$)/, '') || '/';
+const isLocalized =
+  localePath === '/' || /^\/(portfolio|resume)(\/|$)/.test(localePath);
+const alternates = isLocalized
+  ? supportedLngs.map((l) => ({
+      // Traditional Chinese (Taiwan) is more precise than a bare `zh` for search.
+      hreflang: l === 'zh' ? 'zh-Hant' : l,
+      href: new URL(getRelativeLocaleUrl(l, localePath), Astro.site).href,
+    }))
+  : [];
+const xDefaultHref = isLocalized
+  ? new URL(getRelativeLocaleUrl(fallbackLng, localePath), Astro.site).href
+  : null;
 ---
 
 <head>
@@ -91,6 +112,10 @@ const url = Astro.url.toString();
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta name="generator" content={Astro.generator} />
   <link rel="sitemap" href="/sitemap-index.xml" />
+
+  <link rel="canonical" href={canonical} />
+  {alternates.map((a) => <link rel="alternate" hreflang={a.hreflang} href={a.href} />)}
+  {xDefaultHref && <link rel="alternate" hreflang="x-default" href={xDefaultHref} />}
 
   <!-- Open Graph and Twitter Card Metadata  -->
   <title>{title}</title>

--- a/apps/personal-website/src/pages/robots.txt.ts
+++ b/apps/personal-website/src/pages/robots.txt.ts
@@ -1,13 +1,18 @@
 import type { APIRoute } from 'astro';
 
-const getRobotsTxt = (sitemapURL: URL) => `
+// Explicitly welcome everyone, including AI crawlers (GPTBot, ClaudeBot, …), and
+// point both classic crawlers (Sitemap) and agents (llms.txt) at their entry points.
+const getRobotsTxt = (site: URL) => `
 User-agent: *
 Allow: /
 
-Sitemap: ${sitemapURL.href}
+Sitemap: ${new URL('/sitemap-index.xml', site).href}
+
+# AI-readable summaries for agents:
+# ${new URL('/llms.txt', site).href}
+# ${new URL('/llms-full.txt', site).href}
 `;
 
 export const GET: APIRoute = ({ site }) => {
-  const sitemapURL = new URL('/sitemap-index.xml', site);
-  return new Response(getRobotsTxt(sitemapURL));
+  return new Response(getRobotsTxt(site!));
 };

--- a/docs/observability-and-seo.md
+++ b/docs/observability-and-seo.md
@@ -1,0 +1,184 @@
+# Observability, Analytics & SEO
+
+How `personal-website` is instrumented for search discovery, real-user metrics,
+error monitoring, and performance regression tracking — what each piece is, where
+it lives, what turns it on, and **how to review that it's actually working**
+(see [Periodic review](#periodic-review)).
+
+> **Activation caveat.** The SEO, JSON-LD, Clarity, and Sentry work landed on the
+> `analytics-perf` branch, which is **stacked on the redesign branch** — none of it
+> is in production until that merges to `main` and deploys. The Vercel env vars
+> below sit idle until then. `PUBLIC_SENTRY_DSN` is also scoped to **Preview**, so a
+> preview deployment activates Sentry immediately (useful for validating before the
+> merge).
+
+---
+
+## What's instrumented
+
+| Layer | Tool | Turned on by | Status |
+|---|---|---|---|
+| Search / SEO | Canonical + hreflang, JSON-LD, sitemap, robots, llms.txt | always on (SSR) | ships with the branch |
+| Search consoles | Google Search Console + Bing Webmaster | dashboards (verified) | ✅ live |
+| Real-user metrics | Vercel Web Analytics + Speed Insights | `astro.config.mjs` | ✅ live (already on prod) |
+| Product analytics | Microsoft Clarity (heatmaps + replay) | `PUBLIC_CLARITY_PROJECT_ID` | env-gated, idle until deploy |
+| AI-crawler analytics | GA4 Measurement Protocol (`ai_resource_fetch`) | `GA_MEASUREMENT_ID` + `GA_API_SECRET` | ✅ live (server-side) |
+| Error monitoring | Sentry (`@sentry/astro`, error-only) | `PUBLIC_SENTRY_DSN` | env-gated, idle until deploy |
+| Performance CI | Lighthouse CI (weekly + on-demand) | `.github/workflows/lighthouse.yml` | active once on `main` |
+
+---
+
+## Components
+
+### 1. SEO — search & agent discovery
+
+- **Canonical + hreflang** — [`src/layouts/head.astro`](../apps/personal-website/src/layouts/head.astro).
+  Self-referencing canonical on every page; `hreflang` alternates (`en`, `zh-Hant`,
+  `x-default`) emitted only for the localized routes (home, `/portfolio`, `/resume`).
+- **JSON-LD structured data** —
+  [`src/components/pages/HomePage.astro`](../apps/personal-website/src/components/pages/HomePage.astro)
+  emits a `WebSite` + `Person` `@graph`;
+  [`src/layouts/blog.astro`](../apps/personal-website/src/layouts/blog.astro) emits
+  `BlogPosting` per post. Gives search + AI agents a consistent identity.
+- **Sitemap** — `@astrojs/sitemap` (in `astro.config.mjs`) generates
+  `/sitemap-index.xml` → `/sitemap-0.xml`.
+- **robots.txt** — [`src/pages/robots.txt.ts`](../apps/personal-website/src/pages/robots.txt.ts):
+  `Allow: /`, references the sitemap, and points crawlers at `/llms.txt` +
+  `/llms-full.txt`.
+- **llms.txt / llms-full.txt** — [`src/pages/llms.txt.ts`](../apps/personal-website/src/pages/llms.txt.ts),
+  [`src/pages/llms-full.txt.ts`](../apps/personal-website/src/pages/llms-full.txt.ts):
+  machine-readable site summary for LLM agents (GEO / agent-SEO).
+- **Hero image perf** —
+  [`one-column.astro`](../apps/personal-website/src/components/home/hero/one-column.astro) /
+  [`three-columns.astro`](../apps/personal-website/src/components/home/hero/three-columns.astro):
+  `<Picture quality={72}>` + descriptive `alt` (LCP + accessibility).
+
+### 2. Real-user metrics — Vercel
+
+Web Analytics (page/visitor counts) and Speed Insights (Core Web Vitals: TTFB,
+FCP, LCP, INP, CLS) are enabled via the `@astrojs/vercel` adapter in
+[`astro.config.mjs`](../apps/personal-website/astro.config.mjs). `<SpeedInsights/>`
+is rendered in `<body>` (not `<head>` — a custom element there closes the head
+early and strands stylesheets, which was the FOUC bug fixed earlier).
+Dashboards: Vercel → personal-website → Analytics / Speed Insights.
+
+### 3. Microsoft Clarity — heatmaps + session replay
+
+Env-gated inline tag in [`src/layouts/head.astro`](../apps/personal-website/src/layouts/head.astro),
+loaded only when `PUBLIC_CLARITY_PROJECT_ID` is set (so dev/preview stay clean).
+Dashboard: <https://clarity.microsoft.com>.
+
+### 4. GA4 Measurement Protocol — AI-crawler tracking
+
+[`src/utils/track-ai-resource.ts`](../apps/personal-website/src/utils/track-ai-resource.ts)
+fires a **server-side** `ai_resource_fetch` event (via `mp/collect`) when an AI
+crawler (GPTBot, ClaudeBot, PerplexityBot, Google-Extended, CCBot…) fetches a
+machine endpoint. There is **no** client-side gtag / `page_view` — human traffic
+is covered by Vercel + Clarity. Needs `GA_MEASUREMENT_ID` + `GA_API_SECRET`.
+Dashboard: GA4 → Reports / Realtime, event `ai_resource_fetch`.
+
+### 5. Sentry — error monitoring
+
+[`sentry.client.config.js`](../apps/personal-website/sentry.client.config.js) +
+[`sentry.server.config.js`](../apps/personal-website/sentry.server.config.js),
+wired in [`astro.config.mjs`](../apps/personal-website/astro.config.mjs) only when
+`PUBLIC_SENTRY_DSN` is present. **Error monitoring only** — no performance tracing,
+no session replay (tree-shaken out via the integration's `bundleSizeOptimizations`,
+keeping the client bundle lean). No source-map upload → no `SENTRY_AUTH_TOKEN`, and
+`@sentry/cli`'s build script is declined in `pnpm-workspace.yaml`'s `allowBuilds`.
+Dashboard: <https://rainforesttools.sentry.io> (project `javascript-astro`).
+
+### 6. Lighthouse CI — performance regression tracking
+
+[`.lighthouserc.cjs`](../.lighthouserc.cjs) + [`.github/workflows/lighthouse.yml`](../.github/workflows/lighthouse.yml).
+Audits the **deployed** site (SSR-on-Vercel can't be served statically, and dev
+scores are unrealistic): weekly (Mondays 06:00 UTC) against production, plus
+on-demand via `workflow_dispatch` with a `base_url` input to point at a preview.
+Budgets are **`warn`-level** (4 categories + FCP/LCP/TBT/CLS), published to
+temporary public storage — reports, doesn't block. Scheduled runs only fire once
+the workflow is on `main`.
+
+---
+
+## Environment variables
+
+Set in Vercel → personal-website → Settings → Environment Variables (Project scope).
+
+| Variable | Scope | Sensitive | Purpose | Consumed by |
+|---|---|---|---|---|
+| `PUBLIC_SENTRY_DSN` | Production + Preview | no (public DSN) | Sentry init | `sentry.{client,server}.config.js` |
+| `PUBLIC_CLARITY_PROJECT_ID` | Production | no | Clarity tag | `head.astro` |
+| `GA_MEASUREMENT_ID` | Production | no | GA4 MP endpoint | `track-ai-resource.ts` |
+| `GA_API_SECRET` | Production | **yes** | GA4 MP auth | `track-ai-resource.ts` |
+
+> The `PUBLIC_` prefix is **required** for Sentry/Clarity: Vite only inlines
+> `PUBLIC_`-prefixed vars into the client bundle. A Sentry DSN and a Clarity
+> project id are public by design (ingest endpoints, not secrets).
+
+---
+
+## External dashboards configured
+
+| Service | What was set up | Where |
+|---|---|---|
+| Google Search Console | Domain property `sc-domain:rainforest.tools` (DNS-verified); sitemap `sitemap-index.xml` submitted | <https://search.google.com/search-console> |
+| Bing Webmaster Tools | Site imported from GSC (verified, Administrator); sitemap submitted | <https://www.bing.com/webmasters> |
+| Microsoft Clarity | Project created; id in `PUBLIC_CLARITY_PROJECT_ID` | <https://clarity.microsoft.com> |
+| Sentry | Org `rainforesttools`, project `javascript-astro`; DSN in `PUBLIC_SENTRY_DSN` | <https://rainforesttools.sentry.io> |
+| GA4 | Measurement id + MP API secret | <https://analytics.google.com> |
+| Vercel | Web Analytics + Speed Insights enabled | Vercel dashboard |
+
+---
+
+## Periodic review
+
+**Cadence: weekly.** A recurring Claude Code scheduled task runs this review and
+reports back. It auto-checks the **headless-reachable** items and flags the
+**login-only** dashboards for a quick manual glance, because those sit behind auth
+an unattended job can't open. To change the cadence or stop it, ask Claude to
+update/remove the "weekly observability review" cron.
+
+### Auto-checked (no login)
+
+| Check | How | Healthy | Red flag |
+|---|---|---|---|
+| Sitemap live | GET `/sitemap-index.xml` | 200, valid XML index → `sitemap-0.xml` | non-200 / not XML |
+| robots.txt | GET `/robots.txt` | `Allow: /` + `Sitemap:` line | disallow rules, missing sitemap |
+| Lighthouse CI | `gh run list --workflow=lighthouse.yml` | recent run, no budget warnings trending down | perf/LCP/CLS warnings appearing |
+| Vercel deploy | Vercel MCP / dashboard | latest Production deploy = Ready | build failing, cold-start TTFB spikes |
+| llms.txt | GET `/llms.txt` + `/llms-full.txt` | 200, current content | 404 / stale |
+
+### Manual glance (login required)
+
+| Dashboard | Look for | Notes |
+|---|---|---|
+| Search Console | Sitemap status **Success** (not "Couldn't fetch"); Pages indexed climbing; no manual actions | "Couldn't fetch" right after submit is normal; should flip within hours |
+| Bing Webmaster | Sitemap **Processed**; URLs discovered > 0 | data populates ~48h after import |
+| Sentry | New unresolved issues; error-rate spikes after a deploy | only active once deployed to prod/preview |
+| Clarity | Sessions recording; rage-clicks / dead-clicks | only active once deployed |
+| GA4 | `ai_resource_fetch` events present | server-side AI-crawler signal |
+| Vercel Speed Insights | RES score, TTFB, LCP, INP, CLS trend | TTFB was the prior bottleneck — watch it post-routing-refactor |
+
+### First-month watch items
+
+1. GSC sitemap "Couldn't fetch" → **Success** (within hours of submission).
+2. Bing sitemap **Processing** → **Processed**, URLs discovered > 0 (~48h).
+3. After `analytics-perf` merges + deploys: confirm Clarity sessions appear and
+   Sentry receives a test error (both were idle pre-deploy).
+4. Once the Lighthouse workflow is on `main`: confirm the weekly run executes and
+   note the baseline scores.
+
+---
+
+## Change provenance
+
+Commits on `analytics-perf` (stacked on the redesign branch):
+
+| Commit | Change |
+|---|---|
+| `3c6e3d1` | SEO — canonical + hreflang + robots→llms.txt |
+| `0a010d3` | JSON-LD — WebSite/Person (home), BlogPosting (posts) |
+| `e608ad1` | perf — hero image quality 100→72 + descriptive alt |
+| `97b88a9` | Microsoft Clarity (env-gated) |
+| `3a4610a` | Sentry error monitoring (env-gated, error-only) |
+| `f0f97d7` | Lighthouse CI |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ catalogs:
     lit:
       specifier: 3.3.2
       version: 3.3.2
+    next:
+      specifier: 16.2.6
+      version: 16.2.6
     react:
       specifier: 19.2.3
       version: 19.2.3
@@ -45,6 +48,9 @@ catalogs:
     typescript:
       specifier: 5.9.3
       version: 5.9.3
+    vite:
+      specifier: 8.0.16
+      version: 8.0.16
 
 importers:
 
@@ -52,7 +58,7 @@ importers:
     dependencies:
       next:
         specifier: 'catalog:'
-        version: 16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0)
+        version: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0)
       react:
         specifier: 'catalog:'
         version: 19.2.3
@@ -77,31 +83,31 @@ importers:
         version: 23.0.0(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.5.0(encoding@0.1.13)(typanion@3.14.0))
       '@nx/next':
         specifier: 23.0.0
-        version: 23.0.0(9d0c736268777f7c0b0d919280974130)
+        version: 23.0.0(0ee324ae715689e41cf0e7e42badba4f)
       '@nx/playwright':
         specifier: 23.0.0
         version: 23.0.0(@babel/traverse@7.29.7)(@playwright/test@1.55.1)(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.36.0(jiti@2.6.1))(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.5.0(encoding@0.1.13)(typanion@3.14.0))
       '@nx/storybook':
         specifier: 23.0.0
-        version: 23.0.0(@babel/traverse@7.29.7)(@nx/web@23.0.0(10729c94848c0496401df5497596c2ba))(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.36.0(jiti@2.6.1))(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.9)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(verdaccio@6.5.0(encoding@0.1.13)(typanion@3.14.0))
+        version: 23.0.0(@babel/traverse@7.29.7)(@nx/web@23.0.0(2bc5b7ad55343b36ed9e87fc8982ad41))(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.36.0(jiti@2.6.1))(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.9)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(verdaccio@6.5.0(encoding@0.1.13)(typanion@3.14.0))
       '@nx/vite':
         specifier: 23.0.0
-        version: 23.0.0(c419635a721df6e2f7fdb0002450c433)
+        version: 23.0.0(3fc206955834a82cc16b255b4af9639f)
       '@nx/vitest':
         specifier: 23.0.0
-        version: 23.0.0(c419635a721df6e2f7fdb0002450c433)
+        version: 23.0.0(3fc206955834a82cc16b255b4af9639f)
       '@playwright/test':
         specifier: ^1.55.1
         version: 1.55.1
       '@storybook/addon-docs':
         specifier: 10.4.1
-        version: 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(esbuild@0.27.7)(rollup@4.62.2)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.9)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.27.7)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(postcss@8.5.15))
+        version: 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(esbuild@0.27.7)(rollup@4.62.2)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.9)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(postcss@8.5.15))
       '@storybook/test-runner':
         specifier: ^0.24.4
         version: 0.24.4(@swc/helpers@0.5.18)(@types/node@22.15.19)(babel-plugin-macros@3.1.0)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.9)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@22.15.19)(typescript@5.9.3))
       '@storybook/web-components-vite':
         specifier: 10.4.1
-        version: 10.4.1(esbuild@0.27.7)(lit@3.3.2)(rollup@4.62.2)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.9)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.27.7)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(postcss@8.5.15))
+        version: 10.4.1(esbuild@0.27.7)(lit@3.3.2)(rollup@4.62.2)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.9)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(postcss@8.5.15))
       '@swc-node/register':
         specifier: 1.11.1
         version: 1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3)
@@ -179,13 +185,13 @@ importers:
         version: 6.5.0(encoding@0.1.13)(typanion@3.14.0)
       vite:
         specifier: 'catalog:'
-        version: 8.0.16(@types/node@22.15.19)(esbuild@0.27.7)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
+        version: 8.0.16(@types/node@22.15.19)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
       vite-plugin-dts:
         specifier: ~4.5.4
-        version: 4.5.4(@types/node@22.15.19)(rollup@4.62.2)(typescript@5.9.3)(vite@8.0.16(@types/node@22.15.19)(esbuild@0.27.7)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.5.4(@types/node@22.15.19)(rollup@4.62.2)(typescript@5.9.3)(vite@8.0.16(@types/node@22.15.19)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       vitest:
         specifier: 4.1.4
-        version: 4.1.4(@types/node@22.15.19)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@27.0.0(postcss@8.5.9))(msw@2.13.3(@types/node@22.15.19)(typescript@5.9.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.27.7)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.15.19)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@27.0.0(postcss@8.5.9))(msw@2.13.3(@types/node@22.15.19)(typescript@5.9.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   apps/personal-calibre:
     dependencies:
@@ -209,7 +215,7 @@ importers:
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)
       epubjs:
         specifier: ^0.3.93
         version: 0.3.93
@@ -221,7 +227,7 @@ importers:
         version: 1.8.0(react@19.2.3)
       next:
         specifier: 'catalog:'
-        version: 16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0)
+        version: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -303,7 +309,7 @@ importers:
         version: 8.3.18(react@19.2.3)
       next:
         specifier: 'catalog:'
-        version: 16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0)
+        version: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0)
       react:
         specifier: 'catalog:'
         version: 19.2.3
@@ -339,7 +345,7 @@ importers:
         version: 3.7.3
       '@astrojs/vercel':
         specifier: 10.0.8
-        version: 10.0.8(astro@6.4.8(@types/node@25.6.0)(@vercel/functions@3.7.1(ws@8.21.0))(jiti@2.6.1)(less@4.1.3)(lightningcss@1.32.0)(rollup@2.79.2)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(encoding@0.1.13)(next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(react@19.2.3)(rollup@2.79.2)(svelte@5.9.0)(vue@3.5.32(typescript@5.9.3))(ws@8.21.0)
+        version: 10.0.8(astro@6.4.8(@types/node@25.6.0)(@vercel/functions@3.7.1(ws@8.21.0))(jiti@2.6.1)(less@4.1.3)(lightningcss@1.32.0)(rollup@2.79.2)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(encoding@0.1.13)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(react@19.2.3)(rollup@2.79.2)(svelte@5.9.0)(vue@3.5.32(typescript@5.9.3))(ws@8.21.0)
       '@astrojs/vue':
         specifier: 6.0.1
         version: 6.0.1(@types/node@25.6.0)(astro@6.4.8(@types/node@25.6.0)(@vercel/functions@3.7.1(ws@8.21.0))(jiti@2.6.1)(less@4.1.3)(lightningcss@1.32.0)(rollup@2.79.2)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(jiti@2.6.1)(less@4.1.3)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(vue@3.5.32(typescript@5.9.3))(yaml@2.9.0)
@@ -382,12 +388,15 @@ importers:
       '@rainforest-dev/rainforest-ui':
         specifier: workspace:*
         version: link:../../libs/rainforest-ui
+      '@sentry/astro':
+        specifier: ^10.67.0
+        version: 10.67.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(astro@6.4.8(@types/node@25.6.0)(@vercel/functions@3.7.1(ws@8.21.0))(jiti@2.6.1)(less@4.1.3)(lightningcss@1.32.0)(rollup@2.79.2)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(encoding@0.1.13)(rollup@2.79.2)(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.2.2(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       '@vercel/speed-insights':
         specifier: ^1.3.1
-        version: 1.3.1(next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(react@19.2.3)(svelte@5.9.0)(vue@3.5.32(typescript@5.9.3))
+        version: 1.3.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(react@19.2.3)(svelte@5.9.0)(vue@3.5.32(typescript@5.9.3))
       '@vueuse/core':
         specifier: ^14.1.0
         version: 14.2.1(vue@3.5.32(typescript@5.9.3))
@@ -432,7 +441,7 @@ importers:
         version: 17.0.6
       mcp-handler:
         specifier: ^1.1.0
-        version: 1.1.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))
+        version: 1.1.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))
       nanostores:
         specifier: ^1.1.0
         version: 1.2.0
@@ -658,6 +667,17 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       ajv: '>=8'
+
+  '@apm-js-collab/code-transformer-bundler-plugins@0.7.2':
+    resolution: {integrity: sha512-GvpKWDmzBFzbtVElU+tEDMDYyMY8SnMH4NNwwlUQioNHZvE6sSuHEqNkfU3iYhWL+/XO5Ej+MzhVJoqM10NYCQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@apm-js-collab/code-transformer@0.18.0':
+    resolution: {integrity: sha512-aN3Oq8r1J3gPJtCwErP664gM0+HhM1I1lujPr9TMTCcEl/joQQbpGpeMdts9B1+W2wHMsvioDMv5F4PvMWE6gw==}
+    hasBin: true
+
+  '@apm-js-collab/tracing-hooks@0.13.0':
+    resolution: {integrity: sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==}
 
   '@asamuzakjp/css-color@4.0.5':
     resolution: {integrity: sha512-lMrXidNhPGsDjytDy11Vwlb6OIGrT3CmLg3VWNFyWkLWtijKl7xjvForlh8vuj0SHGjgl4qZEQzUmYTeQA2JFQ==}
@@ -3555,6 +3575,48 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
+  '@opentelemetry/api-logs@0.220.0':
+    resolution: {integrity: sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@2.10.0':
+    resolution: {integrity: sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/instrumentation@0.220.0':
+    resolution: {integrity: sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.10.0':
+    resolution: {integrity: sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.10.0':
+    resolution: {integrity: sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace@2.10.0':
+    resolution: {integrity: sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
+
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
@@ -4681,6 +4743,145 @@ packages:
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@sentry/astro@10.67.0':
+    resolution: {integrity: sha512-0cYsElaJifNrykcMP7wkCpgA2VH2lXI5lD7vRH06Ja2B+KrOxW/JeJvKosmQpLcvV3OsuFE4h1p72v3YIN45zQ==}
+    engines: {node: '>=18.19.1'}
+    peerDependencies:
+      astro: '>=3.x || >=4.0.0-beta || >=7.0.0-beta'
+
+  '@sentry/browser-utils@10.67.0':
+    resolution: {integrity: sha512-HUzaf0xAnPAB+OHBkD7N1Py+CTbD5InHulQ/pdhX4JctWtxuwD8odMD1LzdPnW8J6gVHlDVvcVBR8mXMZYSLSw==}
+    engines: {node: '>=18'}
+
+  '@sentry/browser@10.67.0':
+    resolution: {integrity: sha512-/ZhsAvte4rYhg0A0RtSFFgAgXhyMOfQIeOAfMfptN+X6IVSYOfkA9jtrP+Ej4+6vlaUFWRir1HweF56y63dEEA==}
+    engines: {node: '>=18'}
+
+  '@sentry/bundler-plugins@10.67.0':
+    resolution: {integrity: sha512-HKLhbMZJsabZlXTog8CTa1ReeDW/mf1cwN7O8K+DKhe/kGHB3whHRseqsyjxyJwPdzC/0lM+8rgfqgxpc7jR9A==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      rollup: '>=3.2.0'
+      webpack: '>=5.0.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+      webpack:
+        optional: true
+
+  '@sentry/cli-darwin@2.58.6':
+    resolution: {integrity: sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==}
+    engines: {node: '>=10'}
+    os: [darwin]
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    resolution: {integrity: sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-arm@2.58.6':
+    resolution: {integrity: sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-i686@2.58.6':
+    resolution: {integrity: sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-x64@2.58.6':
+    resolution: {integrity: sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    resolution: {integrity: sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@sentry/cli-win32-i686@2.58.6':
+    resolution: {integrity: sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [win32]
+
+  '@sentry/cli-win32-x64@2.58.6':
+    resolution: {integrity: sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@sentry/cli@2.58.6':
+    resolution: {integrity: sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==}
+    engines: {node: '>= 10'}
+    hasBin: true
+
+  '@sentry/conventions@0.16.0':
+    resolution: {integrity: sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==}
+    engines: {node: '>=14'}
+
+  '@sentry/core@10.67.0':
+    resolution: {integrity: sha512-b6U3pJ8AUvN9aouq0vl+VZI8KT8RslBsfGMFuNwRr313zOmdmFJBZqTiUw9VGgJ2jGKxLO9alm9rlxBfX4hf+w==}
+    engines: {node: '>=18'}
+
+  '@sentry/feedback@10.67.0':
+    resolution: {integrity: sha512-I4ML2/SF3enwikb6ZSoRiqolQrx0zSzTSnUgwCmugICF/jpHW0th1pCray9R+t1Zzibw/Dpj4t/DNXaSDRa2MA==}
+    engines: {node: '>=18'}
+
+  '@sentry/node-core@10.67.0':
+    resolution: {integrity: sha512-dBHHRwZyan1pOnFJ+sNBvR8TkXbZAfZU/jpxmALS3JZ2/8AGR7cQKL+b7SleKuJ7iUDZyklN3Nqi0i5JkcA+HA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/exporter-trace-otlp-http': '>=0.57.0 <1'
+      '@opentelemetry/instrumentation': '>=0.57.1 <1'
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/core':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-http':
+        optional: true
+      '@opentelemetry/instrumentation':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+
+  '@sentry/node@10.67.0':
+    resolution: {integrity: sha512-SFKpZGqOCEFSmP93NdDP6ikZp4NS7A/JR8+2ofK3jF6Y9Vyox7pX0pxdOnPLpFcPtMybMahfWqSAWJvsFs4RmA==}
+    engines: {node: '>=18'}
+
+  '@sentry/opentelemetry@10.67.0':
+    resolution: {integrity: sha512-oLTOrAK1rOqmYRktOJZwz37B1seXPx1W2FTMVtzTVNjMFA/LZwGzePeZzhUOgzZgfLHixMd/ceWtGqoxAndcjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+
+  '@sentry/replay-canvas@10.67.0':
+    resolution: {integrity: sha512-neNA4T6MFtZzMdKYetiR+LZd9BNSd0q2szMn0wk+A15PqHE/IN7a34V6JZc9rCtmzB0wldh0eWGOBb49MSNKjA==}
+    engines: {node: '>=18'}
+
+  '@sentry/replay@10.67.0':
+    resolution: {integrity: sha512-nkEUgPCR82EcyJkCf3XCE9H0R5KisCqyCAaSGxe7NpAoQbvASHx4MUNgXVAn+D0M494gvPZh6lFH7JgzqTcSqQ==}
+    engines: {node: '>=18'}
+
+  '@sentry/server-utils@10.67.0':
+    resolution: {integrity: sha512-GQ9t+RSTx5s3b/aZrLFuL4nrwPLMah5NiZk5cjxJmgmOSgm3nMdO8gdqCedDch5B13F3YsxtaQYjSJnzLz8M5A==}
+    engines: {node: '>=18'}
+
+  '@sentry/vite-plugin@5.4.0':
+    resolution: {integrity: sha512-fFJgCxs5hDyAm9BbZJ+LbA+LK2tjX5OoD0v0ARU4StR6KQmGUduoPs69yJ9AfqZ0om3Rlp5JDliiwFcNkasORA==}
+    engines: {node: '>= 18'}
 
   '@shikijs/core@4.2.0':
     resolution: {integrity: sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ==}
@@ -7929,6 +8130,9 @@ packages:
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -9049,6 +9253,10 @@ packages:
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
+
+  import-in-the-middle@3.3.2:
+    resolution: {integrity: sha512-jTd2FfOgOWOdgjkHuk/1Ms8VKFXkPs15ymYBETw1sAOrO/dY3XeGVRWir9qBbw7pXr0T2eTFwfCZ+N02HmiNGA==}
+    engines: {node: '>=18'}
 
   import-lazy@4.0.0:
     resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
@@ -10272,6 +10480,10 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
+  meriyah@6.1.4:
+    resolution: {integrity: sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==}
+    engines: {node: '>=18.0.0'}
+
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
@@ -10517,6 +10729,9 @@ packages:
 
   mlly@1.7.4:
     resolution: {integrity: sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==}
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -11549,6 +11764,10 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -11559,6 +11778,9 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
@@ -11857,6 +12079,10 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
 
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
@@ -12213,6 +12439,9 @@ packages:
   selfsigned@2.4.1:
     resolution: {integrity: sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==}
     engines: {node: '>=10'}
+
+  semifies@1.0.0:
+    resolution: {integrity: sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==}
 
   semver-regex@4.0.5:
     resolution: {integrity: sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==}
@@ -14391,6 +14620,30 @@ snapshots:
       jsonpointer: 5.0.1
       leven: 3.1.0
 
+  '@apm-js-collab/code-transformer-bundler-plugins@0.7.2':
+    dependencies:
+      '@apm-js-collab/code-transformer': 0.18.0
+      es-module-lexer: 2.1.0
+      magic-string: 0.30.21
+      module-details-from-path: 1.0.4
+
+  '@apm-js-collab/code-transformer@0.18.0':
+    dependencies:
+      '@types/estree': 1.0.9
+      astring: 1.9.0
+      esquery: 1.7.0
+      meriyah: 6.1.4
+      semifies: 1.0.0
+      source-map: 0.6.1
+
+  '@apm-js-collab/tracing-hooks@0.13.0':
+    dependencies:
+      '@apm-js-collab/code-transformer': 0.18.0
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@asamuzakjp/css-color@4.0.5':
     dependencies:
       '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
@@ -14562,10 +14815,10 @@ snapshots:
       is-wsl: 3.1.1
       which-pm-runs: 1.1.0
 
-  '@astrojs/vercel@10.0.8(astro@6.4.8(@types/node@25.6.0)(@vercel/functions@3.7.1(ws@8.21.0))(jiti@2.6.1)(less@4.1.3)(lightningcss@1.32.0)(rollup@2.79.2)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(encoding@0.1.13)(next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(react@19.2.3)(rollup@2.79.2)(svelte@5.9.0)(vue@3.5.32(typescript@5.9.3))(ws@8.21.0)':
+  '@astrojs/vercel@10.0.8(astro@6.4.8(@types/node@25.6.0)(@vercel/functions@3.7.1(ws@8.21.0))(jiti@2.6.1)(less@4.1.3)(lightningcss@1.32.0)(rollup@2.79.2)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(encoding@0.1.13)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(react@19.2.3)(rollup@2.79.2)(svelte@5.9.0)(vue@3.5.32(typescript@5.9.3))(ws@8.21.0)':
     dependencies:
       '@astrojs/internal-helpers': 0.10.0
-      '@vercel/analytics': 1.6.1(next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(react@19.2.3)(svelte@5.9.0)(vue@3.5.32(typescript@5.9.3))
+      '@vercel/analytics': 1.6.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(react@19.2.3)(svelte@5.9.0)(vue@3.5.32(typescript@5.9.3))
       '@vercel/functions': 3.7.1(ws@8.21.0)
       '@vercel/nft': 1.10.2(encoding@0.1.13)(rollup@2.79.2)
       '@vercel/routing-utils': 5.3.3
@@ -18625,11 +18878,11 @@ snapshots:
       - nx
       - supports-color
 
-  '@nx/module-federation@23.0.0(22db16e1d3a91eccedbc66ac911c9e70)':
+  '@nx/module-federation@23.0.0(57df41c13d9efa350f1cde3366a4148b)':
     dependencies:
       '@nx/devkit': 23.0.0(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@nx/js': 23.0.0(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.5.0(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/web': 23.0.0(10729c94848c0496401df5497596c2ba)
+      '@nx/web': 23.0.0(2bc5b7ad55343b36ed9e87fc8982ad41)
       '@rspack/core': 1.6.8(@swc/helpers@0.5.18)
       express: 4.22.2
       http-proxy-middleware: 3.0.5
@@ -18668,20 +18921,20 @@ snapshots:
       - verdaccio
       - webpack-cli
 
-  '@nx/next@23.0.0(9d0c736268777f7c0b0d919280974130)':
+  '@nx/next@23.0.0(0ee324ae715689e41cf0e7e42badba4f)':
     dependencies:
       '@babel/plugin-proposal-decorators': 7.27.1(@babel/core@7.29.7)
       '@nx/devkit': 23.0.0(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@nx/eslint': 23.0.0(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.36.0(jiti@2.6.1))(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.5.0(encoding@0.1.13)(typanion@3.14.0))
       '@nx/js': 23.0.0(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.5.0(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/react': 23.0.0(658a12d01b931780af0fc3168a7d6585)
-      '@nx/web': 23.0.0(10729c94848c0496401df5497596c2ba)
+      '@nx/react': 23.0.0(a2ea1ea6564910493f41ac794e66ee63)
+      '@nx/web': 23.0.0(2bc5b7ad55343b36ed9e87fc8982ad41)
       '@nx/webpack': 23.0.0(@babel/traverse@7.29.7)(@rspack/core@1.6.8(@swc/helpers@0.5.18))(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.27.7)(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.3)(verdaccio@6.5.0(encoding@0.1.13)(typanion@3.14.0))(webpack-dev-server@5.2.1(tslib@2.8.1)(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(postcss@8.5.15)))(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(postcss@8.5.15))
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.9.3)
       '@svgr/webpack': 8.1.0(typescript@5.9.3)
       copy-webpack-plugin: 14.0.0(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(postcss@8.5.15))
       ignore: 7.0.5
-      next: 16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0)
+      next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0)
       semver: 7.7.4
       tslib: 2.8.1
       webpack-merge: 5.10.0
@@ -18784,14 +19037,14 @@ snapshots:
       - supports-color
       - verdaccio
 
-  '@nx/react@23.0.0(658a12d01b931780af0fc3168a7d6585)':
+  '@nx/react@23.0.0(a2ea1ea6564910493f41ac794e66ee63)':
     dependencies:
       '@nx/devkit': 23.0.0(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@nx/eslint': 23.0.0(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.36.0(jiti@2.6.1))(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.5.0(encoding@0.1.13)(typanion@3.14.0))
       '@nx/js': 23.0.0(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.5.0(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/module-federation': 23.0.0(22db16e1d3a91eccedbc66ac911c9e70)
+      '@nx/module-federation': 23.0.0(57df41c13d9efa350f1cde3366a4148b)
       '@nx/rollup': 23.0.0(@babel/core@7.29.7)(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/babel__core@7.20.5)(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(rollup@4.62.2)(typescript@5.9.3)(verdaccio@6.5.0(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/web': 23.0.0(10729c94848c0496401df5497596c2ba)
+      '@nx/web': 23.0.0(2bc5b7ad55343b36ed9e87fc8982ad41)
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.9.3)
       '@svgr/webpack': 8.1.0(typescript@5.9.3)
       express: 4.22.2
@@ -18802,7 +19055,7 @@ snapshots:
       semver: 7.7.4
       tslib: 2.8.1
     optionalDependencies:
-      '@nx/vite': 23.0.0(c419635a721df6e2f7fdb0002450c433)
+      '@nx/vite': 23.0.0(3fc206955834a82cc16b255b4af9639f)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/traverse'
@@ -18873,7 +19126,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/storybook@23.0.0(@babel/traverse@7.29.7)(@nx/web@23.0.0(10729c94848c0496401df5497596c2ba))(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.36.0(jiti@2.6.1))(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.9)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(verdaccio@6.5.0(encoding@0.1.13)(typanion@3.14.0))':
+  '@nx/storybook@23.0.0(@babel/traverse@7.29.7)(@nx/web@23.0.0(2bc5b7ad55343b36ed9e87fc8982ad41))(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.36.0(jiti@2.6.1))(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.9)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(verdaccio@6.5.0(encoding@0.1.13)(typanion@3.14.0))':
     dependencies:
       '@nx/cypress': 23.0.0(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.36.0(jiti@2.6.1))(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.3)(verdaccio@6.5.0(encoding@0.1.13)(typanion@3.14.0))
       '@nx/devkit': 23.0.0(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
@@ -18884,7 +19137,7 @@ snapshots:
       storybook: 10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.9)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tslib: 2.8.1
     optionalDependencies:
-      '@nx/web': 23.0.0(10729c94848c0496401df5497596c2ba)
+      '@nx/web': 23.0.0(2bc5b7ad55343b36ed9e87fc8982ad41)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@nx/jest'
@@ -18900,11 +19153,11 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/vite@23.0.0(c419635a721df6e2f7fdb0002450c433)':
+  '@nx/vite@23.0.0(3fc206955834a82cc16b255b4af9639f)':
     dependencies:
       '@nx/devkit': 23.0.0(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@nx/js': 23.0.0(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.5.0(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/vitest': 23.0.0(c419635a721df6e2f7fdb0002450c433)
+      '@nx/vitest': 23.0.0(3fc206955834a82cc16b255b4af9639f)
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.9.3)
       ajv: 8.18.0
       enquirer: 2.3.6
@@ -18912,7 +19165,7 @@ snapshots:
       semver: 7.7.4
       tsconfig-paths: 4.2.0
       tslib: 2.8.1
-      vite: 8.0.16(@types/node@22.15.19)(esbuild@0.27.7)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@22.15.19)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@nx/eslint'
@@ -18926,7 +19179,7 @@ snapshots:
       - verdaccio
       - vitest
 
-  '@nx/vitest@23.0.0(c419635a721df6e2f7fdb0002450c433)':
+  '@nx/vitest@23.0.0(3fc206955834a82cc16b255b4af9639f)':
     dependencies:
       '@nx/devkit': 23.0.0(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@nx/js': 23.0.0(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.5.0(encoding@0.1.13)(typanion@3.14.0))
@@ -18935,8 +19188,8 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@nx/eslint': 23.0.0(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.36.0(jiti@2.6.1))(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.5.0(encoding@0.1.13)(typanion@3.14.0))
-      vite: 8.0.16(@types/node@22.15.19)(esbuild@0.27.7)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
-      vitest: 4.1.4(@types/node@22.15.19)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@27.0.0(postcss@8.5.9))(msw@2.13.3(@types/node@22.15.19)(typescript@5.9.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.27.7)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      vite: 8.0.16(@types/node@22.15.19)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.15.19)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@27.0.0(postcss@8.5.9))(msw@2.13.3(@types/node@22.15.19)(typescript@5.9.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -18948,7 +19201,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/web@23.0.0(10729c94848c0496401df5497596c2ba)':
+  '@nx/web@23.0.0(2bc5b7ad55343b36ed9e87fc8982ad41)':
     dependencies:
       '@nx/devkit': 23.0.0(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@nx/js': 23.0.0(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.5.0(encoding@0.1.13)(typanion@3.14.0))
@@ -18960,7 +19213,7 @@ snapshots:
       '@nx/cypress': 23.0.0(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.36.0(jiti@2.6.1))(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.3)(verdaccio@6.5.0(encoding@0.1.13)(typanion@3.14.0))
       '@nx/eslint': 23.0.0(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.36.0(jiti@2.6.1))(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.5.0(encoding@0.1.13)(typanion@3.14.0))
       '@nx/playwright': 23.0.0(@babel/traverse@7.29.7)(@playwright/test@1.55.1)(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.36.0(jiti@2.6.1))(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.5.0(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/vite': 23.0.0(c419635a721df6e2f7fdb0002450c433)
+      '@nx/vite': 23.0.0(3fc206955834a82cc16b255b4af9639f)
       '@nx/webpack': 23.0.0(@babel/traverse@7.29.7)(@rspack/core@1.6.8(@swc/helpers@0.5.18))(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.27.7)(nx@23.0.0(@swc-node/register@1.11.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.3)(verdaccio@6.5.0(encoding@0.1.13)(typanion@3.14.0))(webpack-dev-server@5.2.1(tslib@2.8.1)(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(postcss@8.5.15)))(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(postcss@8.5.15))
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -19056,6 +19309,49 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
+
+  '@opentelemetry/api-logs@0.220.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.220.0
+      import-in-the-middle: 3.3.2
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
 
   '@oslojs/encoding@1.1.0': {}
 
@@ -19900,6 +20196,170 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
+  '@sentry/astro@10.67.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(astro@6.4.8(@types/node@25.6.0)(@vercel/functions@3.7.1(ws@8.21.0))(jiti@2.6.1)(less@4.1.3)(lightningcss@1.32.0)(rollup@2.79.2)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(encoding@0.1.13)(rollup@2.79.2)(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))':
+    dependencies:
+      '@sentry/browser': 10.67.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.67.0
+      '@sentry/node': 10.67.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))
+      '@sentry/vite-plugin': 5.4.0(encoding@0.1.13)(rollup@2.79.2)(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
+      astro: 6.4.8(@types/node@25.6.0)(@vercel/functions@3.7.1(ws@8.21.0))(jiti@2.6.1)(less@4.1.3)(lightningcss@1.32.0)(rollup@2.79.2)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - encoding
+      - rollup
+      - supports-color
+      - webpack
+
+  '@sentry/browser-utils@10.67.0':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.67.0
+
+  '@sentry/browser@10.67.0':
+    dependencies:
+      '@sentry/browser-utils': 10.67.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.67.0
+      '@sentry/feedback': 10.67.0
+      '@sentry/replay': 10.67.0
+      '@sentry/replay-canvas': 10.67.0
+
+  '@sentry/bundler-plugins@10.67.0(encoding@0.1.13)(rollup@2.79.2)(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@sentry/cli': 2.58.6(encoding@0.1.13)
+      '@sentry/core': 10.67.0
+      dotenv: 17.4.2
+      find-up: 5.0.0
+      glob: 13.0.6
+      magic-string: 0.30.21
+    optionalDependencies:
+      rollup: 2.79.2
+      webpack: 5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/cli-darwin@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli@2.58.6(encoding@0.1.13)':
+    dependencies:
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0(encoding@0.1.13)
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 2.58.6
+      '@sentry/cli-linux-arm': 2.58.6
+      '@sentry/cli-linux-arm64': 2.58.6
+      '@sentry/cli-linux-i686': 2.58.6
+      '@sentry/cli-linux-x64': 2.58.6
+      '@sentry/cli-win32-arm64': 2.58.6
+      '@sentry/cli-win32-i686': 2.58.6
+      '@sentry/cli-win32-x64': 2.58.6
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/conventions@0.16.0': {}
+
+  '@sentry/core@10.67.0':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+
+  '@sentry/feedback@10.67.0':
+    dependencies:
+      '@sentry/core': 10.67.0
+
+  '@sentry/node-core@10.67.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.67.0
+      '@sentry/opentelemetry': 10.67.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      import-in-the-middle: 3.3.2
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@sentry/node@10.67.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.67.0
+      '@sentry/node-core': 10.67.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      '@sentry/opentelemetry': 10.67.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      '@sentry/server-utils': 10.67.0
+      import-in-the-middle: 3.3.2
+    transitivePeerDependencies:
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
+
+  '@sentry/opentelemetry@10.67.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.67.0
+
+  '@sentry/replay-canvas@10.67.0':
+    dependencies:
+      '@sentry/core': 10.67.0
+      '@sentry/replay': 10.67.0
+
+  '@sentry/replay@10.67.0':
+    dependencies:
+      '@sentry/browser-utils': 10.67.0
+      '@sentry/core': 10.67.0
+
+  '@sentry/server-utils@10.67.0':
+    dependencies:
+      '@apm-js-collab/code-transformer-bundler-plugins': 0.7.2
+      '@apm-js-collab/tracing-hooks': 0.13.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.67.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sentry/vite-plugin@5.4.0(encoding@0.1.13)(rollup@2.79.2)(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))':
+    dependencies:
+      '@sentry/bundler-plugins': 10.67.0(encoding@0.1.13)(rollup@2.79.2)(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+      - webpack
+
   '@shikijs/core@4.2.0':
     dependencies:
       '@shikijs/primitive': 4.2.0
@@ -19966,10 +20426,10 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-docs@10.4.1(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(esbuild@0.27.7)(rollup@4.62.2)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.9)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.27.7)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(postcss@8.5.15))':
+  '@storybook/addon-docs@10.4.1(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(esbuild@0.27.7)(rollup@4.62.2)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.9)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(postcss@8.5.15))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.9)(react@19.2.3)
-      '@storybook/csf-plugin': 10.4.1(esbuild@0.27.7)(rollup@4.62.2)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.9)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.27.7)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(postcss@8.5.15))
+      '@storybook/csf-plugin': 10.4.1(esbuild@0.27.7)(rollup@4.62.2)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.9)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(postcss@8.5.15))
       '@storybook/icons': 2.0.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@storybook/react-dom-shim': 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.9)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       react: 19.2.3
@@ -19985,25 +20445,25 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/builder-vite@10.4.1(esbuild@0.27.7)(rollup@4.62.2)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.9)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.27.7)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(postcss@8.5.15))':
+  '@storybook/builder-vite@10.4.1(esbuild@0.27.7)(rollup@4.62.2)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.9)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(postcss@8.5.15))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.1(esbuild@0.27.7)(rollup@4.62.2)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.9)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.27.7)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(postcss@8.5.15))
+      '@storybook/csf-plugin': 10.4.1(esbuild@0.27.7)(rollup@4.62.2)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.9)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(postcss@8.5.15))
       storybook: 10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.9)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       ts-dedent: 2.3.0
-      vite: 8.0.16(@types/node@22.15.19)(esbuild@0.27.7)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@22.15.19)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.4.1(esbuild@0.27.7)(rollup@4.62.2)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.9)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.27.7)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(postcss@8.5.15))':
+  '@storybook/csf-plugin@10.4.1(esbuild@0.27.7)(rollup@4.62.2)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.9)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(postcss@8.5.15))':
     dependencies:
       storybook: 10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.9)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.7
       rollup: 4.62.2
-      vite: 8.0.16(@types/node@22.15.19)(esbuild@0.27.7)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@22.15.19)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
       webpack: 5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(postcss@8.5.15)
 
   '@storybook/global@5.0.0': {}
@@ -20056,12 +20516,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@storybook/web-components-vite@10.4.1(esbuild@0.27.7)(lit@3.3.2)(rollup@4.62.2)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.9)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.27.7)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(postcss@8.5.15))':
+  '@storybook/web-components-vite@10.4.1(esbuild@0.27.7)(lit@3.3.2)(rollup@4.62.2)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.9)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(postcss@8.5.15))':
     dependencies:
-      '@storybook/builder-vite': 10.4.1(esbuild@0.27.7)(rollup@4.62.2)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.9)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.27.7)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(postcss@8.5.15))
+      '@storybook/builder-vite': 10.4.1(esbuild@0.27.7)(rollup@4.62.2)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.9)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(postcss@8.5.15))
       '@storybook/web-components': 10.4.1(lit@3.3.2)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.9)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       storybook: 10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.9)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      vite: 8.0.16(@types/node@22.15.19)(esbuild@0.27.7)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@22.15.19)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - esbuild
       - lit
@@ -21025,9 +21485,9 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
-  '@vercel/analytics@1.6.1(next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(react@19.2.3)(svelte@5.9.0)(vue@3.5.32(typescript@5.9.3))':
+  '@vercel/analytics@1.6.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(react@19.2.3)(svelte@5.9.0)(vue@3.5.32(typescript@5.9.3))':
     optionalDependencies:
-      next: 16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0)
+      next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0)
       react: 19.2.3
       svelte: 5.9.0
       vue: 3.5.32(typescript@5.9.3)
@@ -21079,9 +21539,9 @@ snapshots:
     optionalDependencies:
       ajv: 6.15.0
 
-  '@vercel/speed-insights@1.3.1(next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(react@19.2.3)(svelte@5.9.0)(vue@3.5.32(typescript@5.9.3))':
+  '@vercel/speed-insights@1.3.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0))(react@19.2.3)(svelte@5.9.0)(vue@3.5.32(typescript@5.9.3))':
     optionalDependencies:
-      next: 16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0)
+      next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0)
       react: 19.2.3
       svelte: 5.9.0
       vue: 3.5.32(typescript@5.9.3)
@@ -21297,7 +21757,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@22.15.19)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@27.0.0(postcss@8.5.9))(msw@2.13.3(@types/node@22.15.19)(typescript@5.9.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.27.7)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.15.19)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@27.0.0(postcss@8.5.9))(msw@2.13.3(@types/node@22.15.19)(typescript@5.9.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -21333,14 +21793,14 @@ snapshots:
       msw: 2.13.3(@types/node@25.6.0)(typescript@5.9.3)
       vite: 7.3.5(@types/node@25.6.0)(jiti@2.6.1)(less@4.1.3)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
 
-  '@vitest/mocker@4.1.4(msw@2.13.3(@types/node@22.15.19)(typescript@5.9.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.27.7)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.4(msw@2.13.3(@types/node@22.15.19)(typescript@5.9.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.13.3(@types/node@22.15.19)(typescript@5.9.3)
-      vite: 8.0.16(@types/node@22.15.19)(esbuild@0.27.7)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@22.15.19)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -21397,7 +21857,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@22.15.19)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@27.0.0(postcss@8.5.9))(msw@2.13.3(@types/node@22.15.19)(typescript@5.9.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.27.7)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.15.19)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@27.0.0(postcss@8.5.9))(msw@2.13.3(@types/node@22.15.19)(typescript@5.9.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -23708,8 +24168,9 @@ snapshots:
 
   dotenv@17.4.2: {}
 
-  drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0):
+  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0):
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/better-sqlite3': 7.6.13
       better-sqlite3: 12.9.0
 
@@ -23903,6 +24364,8 @@ snapshots:
   es-module-lexer@2.0.0: {}
 
   es-module-lexer@2.1.0: {}
+
+  es-module-lexer@2.3.1: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -25491,6 +25954,12 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-in-the-middle@3.3.2:
+    dependencies:
+      cjs-module-lexer: 2.2.0
+      es-module-lexer: 2.3.1
+      module-details-from-path: 1.0.4
+
   import-lazy@4.0.0: {}
 
   import-local@3.2.0:
@@ -26795,14 +27264,14 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mcp-handler@1.1.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0)):
+  mcp-handler@1.1.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0)):
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
       chalk: 5.6.2
       commander: 11.1.0
       redis: 4.7.1
     optionalDependencies:
-      next: 16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0)
+      next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0)
 
   mdast-util-definitions@6.0.0:
     dependencies:
@@ -27043,6 +27512,8 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  meriyah@6.1.4: {}
 
   methods@1.1.2: {}
 
@@ -27444,6 +27915,8 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.1
 
+  module-details-from-path@1.0.4: {}
+
   mrmime@2.0.1: {}
 
   ms@2.0.0: {}
@@ -27549,7 +28022,7 @@ snapshots:
 
   next-tick@1.1.0: {}
 
-  next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0):
+  next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0):
     dependencies:
       '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
@@ -27568,39 +28041,13 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.6
       '@next/swc-win32-arm64-msvc': 16.2.6
       '@next/swc-win32-x64-msvc': 16.2.6
+      '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.55.1
       sass: 1.101.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
-
-  next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.101.0):
-    dependencies:
-      '@next/env': 16.2.6
-      '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.10.38
-      caniuse-lite: 1.0.30001799
-      postcss: 8.4.31
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.3)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.6
-      '@next/swc-darwin-x64': 16.2.6
-      '@next/swc-linux-arm64-gnu': 16.2.6
-      '@next/swc-linux-arm64-musl': 16.2.6
-      '@next/swc-linux-x64-gnu': 16.2.6
-      '@next/swc-linux-x64-musl': 16.2.6
-      '@next/swc-win32-arm64-msvc': 16.2.6
-      '@next/swc-win32-x64-msvc': 16.2.6
-      '@playwright/test': 1.55.1
-      sass: 1.101.0
-      sharp: 0.34.5
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-    optional: true
 
   nlcst-to-string@4.0.0:
     dependencies:
@@ -28682,6 +29129,8 @@ snapshots:
 
   process@0.11.10: {}
 
+  progress@2.0.3: {}
+
   prompts@2.4.2:
     dependencies:
       kleur: 3.0.3
@@ -28693,6 +29142,8 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  proxy-from-env@1.1.0: {}
 
   proxy-from-env@2.1.0: {}
 
@@ -29105,6 +29556,13 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
+
   require-main-filename@2.0.0: {}
 
   requires-port@1.0.0: {}
@@ -29499,6 +29957,8 @@ snapshots:
       '@types/node-forge': 1.3.14
       node-forge: 1.4.0
     optional: true
+
+  semifies@1.0.0: {}
 
   semver-regex@4.0.5: {}
 
@@ -30233,14 +30693,6 @@ snapshots:
       '@babel/core': 7.29.7
       babel-plugin-macros: 3.1.0
 
-  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.3):
-    dependencies:
-      client-only: 0.0.1
-      react: 19.2.3
-    optionalDependencies:
-      '@babel/core': 7.29.7
-    optional: true
-
   stylehacks@7.0.8(postcss@8.5.15):
     dependencies:
       browserslist: 4.28.2
@@ -30398,6 +30850,20 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.15.8(@swc/helpers@0.5.18)
       esbuild: 0.27.7
+
+  terser-webpack-plugin@5.6.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.48.0
+      webpack: 5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)
+    optionalDependencies:
+      '@swc/core': 1.15.8(@swc/helpers@0.5.18)
+      esbuild: 0.28.1
+      lightningcss: 1.32.0
+      postcss: 8.5.15
+    optional: true
 
   terser-webpack-plugin@5.6.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(postcss@8.5.15)(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(postcss@8.5.15)):
     dependencies:
@@ -31125,7 +31591,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-dts@4.5.4(@types/node@22.15.19)(rollup@4.62.2)(typescript@5.9.3)(vite@8.0.16(@types/node@22.15.19)(esbuild@0.27.7)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)):
+  vite-plugin-dts@4.5.4(@types/node@22.15.19)(rollup@4.62.2)(typescript@5.9.3)(vite@8.0.16(@types/node@22.15.19)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
       '@microsoft/api-extractor': 7.52.8(@types/node@22.15.19)
       '@rollup/pluginutils': 5.3.0(rollup@4.62.2)
@@ -31138,7 +31604,7 @@ snapshots:
       magic-string: 0.30.21
       typescript: 5.9.3
     optionalDependencies:
-      vite: 8.0.16(@types/node@22.15.19)(esbuild@0.27.7)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@22.15.19)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
@@ -31258,7 +31724,7 @@ snapshots:
       tsx: 4.23.0
       yaml: 2.9.0
 
-  vite@8.0.16(@types/node@22.15.19)(esbuild@0.27.7)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0):
+  vite@8.0.16(@types/node@22.15.19)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -31267,7 +31733,7 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 22.15.19
-      esbuild: 0.27.7
+      esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.6.1
       less: 4.1.3
@@ -31350,10 +31816,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.4(@types/node@22.15.19)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@27.0.0(postcss@8.5.9))(msw@2.13.3(@types/node@22.15.19)(typescript@5.9.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.27.7)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)):
+  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.15.19)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@27.0.0(postcss@8.5.9))(msw@2.13.3(@types/node@22.15.19)(typescript@5.9.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(msw@2.13.3(@types/node@22.15.19)(typescript@5.9.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.27.7)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.4(msw@2.13.3(@types/node@22.15.19)(typescript@5.9.3))(vite@8.0.16(@types/node@22.15.19)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
@@ -31370,9 +31836,10 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@22.15.19)(esbuild@0.27.7)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@22.15.19)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 22.15.19
       '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
       '@vitest/ui': 4.1.4(vitest@4.1.4)
@@ -31638,6 +32105,48 @@ snapshots:
       webpack: 5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(postcss@8.5.15)
 
   webpack-virtual-modules@0.6.2: {}
+
+  webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.9
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.17.0
+      acorn-import-phases: 1.0.4(acorn@8.17.0)
+      browserslist: 4.28.2
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.24.0
+      es-module-lexer: 2.1.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.2
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      terser-webpack-plugin: 5.6.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
+      watchpack: 2.5.2
+      webpack-sources: 3.5.0
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
+    optional: true
 
   webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(postcss@8.5.15):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,6 +29,9 @@ minimumReleaseAge: 1440
 
 allowBuilds:
   '@parcel/watcher': true
+  # Only used for source-map upload, which we keep disabled (personal-website's
+  # astro.config.mjs) — skip its binary-downloading postinstall.
+  '@sentry/cli': false
   '@swc/core': true
   better-sqlite3: true
   core-js: true


### PR DESCRIPTION
Layered on top of the redesign (#246): search discoverability, real-user metrics,
error monitoring, and performance-regression tracking for personal-website.

## What's included
- **SEO** — self-referencing canonical + `hreflang` (en/zh-Hant/x-default) on the localized routes; `robots.txt` now points crawlers at `/llms.txt` + `/llms-full.txt`. (`3c6e3d1`)
- **JSON-LD** — `WebSite` + `Person` `@graph` on the home page, `BlogPosting` per post. (`0a010d3`)
- **Hero image perf** — `<Picture quality={72}>` + descriptive `alt` (LCP + a11y). (`e608ad1`)
- **Microsoft Clarity** — env-gated heatmaps/replay tag, loads only when `PUBLIC_CLARITY_PROJECT_ID` is set. (`97b88a9`)
- **Sentry** — `@sentry/astro`, error-monitoring-only (no tracing/replay, tree-shaken), gated on `PUBLIC_SENTRY_DSN`, no source-map upload. (`3a4610a`)
- **Lighthouse CI** — weekly + on-demand CWV audits against the deployed site, `warn`-level budgets. (`f0f97d7`)
- **Docs** — `docs/observability-and-seo.md`: full inventory + weekly review checklist. (`bcb2bb8`)

## Env vars (already set in Vercel)
| Var | Scope | Sensitive |
|---|---|---|
| `PUBLIC_SENTRY_DSN` | Prod + Preview | no |
| `PUBLIC_CLARITY_PROJECT_ID` | Prod | no |
| `GA_MEASUREMENT_ID` | Prod | no |
| `GA_API_SECRET` | Prod | yes |

All env-gated pieces stay inert until these are present, so dev/local builds are unaffected. Verified locally: `nx affected -t lint test typecheck` green, production build succeeds with the DSN set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)