### PR TITLE
fix: serve RSS feed at canonical /rss.xml (404 fix)

### DIFF
--- a/apps/personal-website/src/pages/rss.xml.ts
+++ b/apps/personal-website/src/pages/rss.xml.ts
@@ -1,0 +1,25 @@
+import rss from '@astrojs/rss';
+import { useTranslation } from '@utils';
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+
+// Canonical English feed at the root `/rss.xml`, matching the Model B routing
+// (English at the root; localised feeds live at /[lang]/rss.xml). This is what
+// head.astro links to. Build-static, so prerender it as a CDN file.
+export const prerender = true;
+
+export const GET: APIRoute = async ({ site }) => {
+  const blog = await getCollection('blog');
+  const { t } = await useTranslation('en', 'blog');
+  return rss({
+    title: t('metadata-title'),
+    description: t('metadata-description'),
+    site: site!,
+    items: blog.map((post) => ({
+      title: post.data.title,
+      description: post.data.description,
+      pubDate: post.data.pubDate,
+      link: `/blog/${post.id}`,
+    })),
+  });
+};


### PR DESCRIPTION
`head.astro` links `/rss.xml`, but the `[lang]/rss.xml.ts` route only emits `/en/rss.xml` + `/zh/rss.xml`, so the canonical `/rss.xml` 404'd. This is a pre-existing Model B routing gap (English belongs at the root) surfaced during post-deploy verification of the Astro 7 merge — not caused by Astro 7.

Adds a prerendered root `rss.xml.ts` serving the English feed. Localised feeds stay at `/[lang]/rss.xml`. Build confirms `/rss.xml` now prerenders as a static file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)