### PR TITLE
feat: cookieless recruiter-conversion tracking (exposure)

### DIFF
--- a/apps/personal-website/src/layouts/index.astro
+++ b/apps/personal-website/src/layouts/index.astro
@@ -41,5 +41,10 @@ const dir = _dir(lang);
       )
     }
     <SpeedInsights />
+    <script>
+      // Cookieless recruiter-conversion tracking (outbound clicks, contact, resume,
+      // case-study views) → /api/event → GA4. No cookies, no consent banner.
+      import '../scripts/conversion-tracking';
+    </script>
   </body>
 </html>

--- a/apps/personal-website/src/pages/api/event.ts
+++ b/apps/personal-website/src/pages/api/event.ts
@@ -1,0 +1,49 @@
+import { sendGa4Event } from '@utils/ga4';
+import type { APIRoute } from 'astro';
+
+// On-demand: this is the cookieless conversion-event sink. The browser (see
+// src/scripts/conversion-tracking.ts) POSTs recruiter-relevant interactions here
+// and we forward them to GA4 server-side, so GA_API_SECRET stays private and no
+// GA cookie is ever set on the visitor.
+export const prerender = false;
+
+// Allowlist of accepted events → their permitted param keys. Anything else is
+// rejected, so this public endpoint can't be abused to inject arbitrary GA4 data.
+const ALLOWED: Record<string, readonly string[]> = {
+  outbound_click: ['target'], // github | linkedin | email
+  contact_submit: [],
+  resume_view: [],
+  case_study_view: ['slug'],
+};
+
+export const POST: APIRoute = async ({ request }) => {
+  // Same-origin guard: reduces casual spam without being a hard security boundary.
+  const origin = request.headers.get('origin');
+  const host = request.headers.get('host');
+  if (origin && host && new URL(origin).host !== host) {
+    return new Response(null, { status: 403 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(null, { status: 400 });
+  }
+
+  const { event, params } = (body ?? {}) as {
+    event?: string;
+    params?: Record<string, unknown>;
+  };
+  if (!event || !(event in ALLOWED)) return new Response(null, { status: 400 });
+
+  // Keep only allowlisted string params, length-capped.
+  const clean: Record<string, string> = {};
+  for (const key of ALLOWED[event]) {
+    const value = params?.[key];
+    if (typeof value === 'string' && value) clean[key] = value.slice(0, 100);
+  }
+
+  await sendGa4Event(event, clean);
+  return new Response(null, { status: 204 });
+};

--- a/apps/personal-website/src/scripts/conversion-tracking.ts
+++ b/apps/personal-website/src/scripts/conversion-tracking.ts
@@ -1,0 +1,63 @@
+// Cookieless, recruiter-focused conversion tracking. Posts interactions to
+// /api/event, which forwards them to GA4 server-side. No cookies and no storage,
+// so it needs no consent banner. Events:
+//   outbound_click { target: github | linkedin | email }
+//   contact_submit            (the contact form "submits" via a mailto: link)
+//   resume_view               (visiting /resume)
+//   case_study_view { slug }  (visiting a /portfolio/<slug> page)
+
+type Params = Record<string, string>;
+
+function send(event: string, params: Params = {}): void {
+  try {
+    const body = JSON.stringify({ event, params });
+    const blob = new Blob([body], { type: 'application/json' });
+    // sendBeacon survives the navigation an outbound-link click triggers.
+    if (!navigator.sendBeacon?.('/api/event', blob)) {
+      void fetch('/api/event', {
+        method: 'POST',
+        body,
+        keepalive: true,
+        headers: { 'content-type': 'application/json' },
+      }).catch(() => undefined);
+    }
+  } catch {
+    // best-effort
+  }
+}
+
+// One delegated click listener for the whole document, bound once per page.
+const w = window as unknown as { __convClickBound?: boolean };
+if (!w.__convClickBound) {
+  w.__convClickBound = true;
+  document.addEventListener(
+    'click',
+    (e) => {
+      const target = e.target as Element | null;
+      const anchor = target?.closest?.('a[href]') as HTMLAnchorElement | null;
+      if (!anchor) return;
+      const href = anchor.getAttribute('href') ?? '';
+      // The contact form's submit button is a mailto: link — the real conversion.
+      if (href.startsWith('mailto:') && anchor.closest('contact-form')) {
+        send('contact_submit');
+        return;
+      }
+      if (/linkedin\.com/i.test(href)) send('outbound_click', { target: 'linkedin' });
+      else if (/github\.com/i.test(href)) send('outbound_click', { target: 'github' });
+      else if (href.startsWith('mailto:')) send('outbound_click', { target: 'email' });
+    },
+    { capture: true },
+  );
+}
+
+// Page-view conversions. Runs on initial load (module executes on every full page
+// load) and after each view-transition swap (for client-side navigations).
+function trackPageView(): void {
+  const path = location.pathname.replace(/^\/zh(?=\/|$)/, '') || '/';
+  if (path === '/resume') send('resume_view');
+  const caseStudy = path.match(/^\/portfolio\/([^/]+)\/?$/);
+  if (caseStudy) send('case_study_view', { slug: caseStudy[1] });
+}
+
+trackPageView();
+document.addEventListener('astro:after-swap', trackPageView);

--- a/apps/personal-website/src/utils/ga4.ts
+++ b/apps/personal-website/src/utils/ga4.ts
@@ -1,0 +1,34 @@
+/**
+ * Fires a single GA4 event via the Measurement Protocol, server-side.
+ *
+ * Cookieless by design: GA4 requires a `client_id`, but we mint a fresh random
+ * one per event (we count events, not stitch users), so nothing is stored on the
+ * visitor and no consent banner is required. Keeping `GA_API_SECRET` server-side
+ * also means the browser never sees it.
+ *
+ * Requires `GA_MEASUREMENT_ID` + `GA_API_SECRET` (Vercel → Environment Variables).
+ * No-ops when unset, and swallows its own errors — analytics must never turn into
+ * a broken response for the caller.
+ */
+export async function sendGa4Event(
+  name: string,
+  params: Record<string, string | number> = {},
+  clientId: string = crypto.randomUUID(),
+): Promise<void> {
+  const measurementId = process.env.GA_MEASUREMENT_ID;
+  const apiSecret = process.env.GA_API_SECRET;
+  if (!measurementId || !apiSecret) return;
+
+  try {
+    await fetch(
+      `https://www.google-analytics.com/mp/collect?measurement_id=${measurementId}&api_secret=${apiSecret}`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ client_id: clientId, events: [{ name, params }] }),
+      },
+    );
+  } catch {
+    // Best-effort only.
+  }
+}

--- a/apps/personal-website/src/utils/track-ai-resource.ts
+++ b/apps/personal-website/src/utils/track-ai-resource.ts
@@ -1,3 +1,5 @@
+import { sendGa4Event } from './ga4';
+
 // Coarse bot classification, not an exhaustive list — good enough to answer "are AI
 // crawlers actually hitting these endpoints", which is the question this exists to answer.
 // Extend as new agents show up in real traffic rather than trying to enumerate every one
@@ -28,40 +30,11 @@ function classifyUserAgent(userAgent: string | null): string {
  * separately confirmed (via bisection) to break this project's Vercel Function generation
  * entirely — its /_render Function silently disappeared from the build output. GA4's
  * Measurement Protocol has no such constraints: plain HTTP, no SDK/dependency, works on
- * any plan.
- *
- * Requires GA_MEASUREMENT_ID and GA_API_SECRET env vars (Vercel dashboard → Settings →
- * Environment Variables — see GA4 Admin → Data Streams → your stream → Measurement
- * Protocol API secrets → Create). Silently no-ops if either is unset, so this is safe to
- * deploy before they're configured. Swallows its own errors: a failed analytics call must
- * never turn into a broken response for the actual resource being served.
+ * any plan. Human conversion events go through the same sender — see src/pages/api/event.ts.
  */
 export async function trackAiResourceFetch(resource: string, request: Request): Promise<void> {
-  const measurementId = process.env.GA_MEASUREMENT_ID;
-  const apiSecret = process.env.GA_API_SECRET;
-  if (!measurementId || !apiSecret) return;
-
-  try {
-    await fetch(
-      `https://www.google-analytics.com/mp/collect?measurement_id=${measurementId}&api_secret=${apiSecret}`,
-      {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({
-          // GA4 requires a client_id; there's no real client/session for server-to-server
-          // bot traffic, so a fresh one per event is fine — nothing here needs cross-request
-          // identity, just per-hit counts and properties.
-          client_id: crypto.randomUUID(),
-          events: [
-            {
-              name: 'ai_resource_fetch',
-              params: { resource, bot: classifyUserAgent(request.headers.get('user-agent')) },
-            },
-          ],
-        }),
-      },
-    );
-  } catch {
-    // Best-effort only.
-  }
+  await sendGa4Event('ai_resource_fetch', {
+    resource,
+    bot: classifyUserAgent(request.headers.get('user-agent')),
+  });
 }


### PR DESCRIPTION
Closes the biggest measurement gap for the **recruiter/exposure** goal: today GA4 only tracks AI bots and Vercel only counts pageviews, so there's no visibility into whether visitors *convert*.

Adds a **cookieless** GA4 conversion pipeline — **no consent banner** (no cookies, no client `gtag`, random per-event `client_id`):
- `src/utils/ga4.ts` — shared GA4 Measurement Protocol sender (server-side; `GA_API_SECRET` stays private). `track-ai-resource.ts` refactored to reuse it.
- `src/pages/api/event.ts` — allowlisted, sanitised, same-origin-guarded POST endpoint → GA4.
- `src/scripts/conversion-tracking.ts` — site-wide client tracker: `outbound_click {github|linkedin|email}`, `contact_submit`, `resume_view`, `case_study_view {slug}`.

**Why this vs client GA4 + Consent Mode:** near-zero maintenance (add an event = 1 allowlist entry + 1 call), no CMP/banner/consent-flow to maintain. Trade-off: GA4 user/session counts are meaningless (random ids), but **event counts are exact** — which is all the recruiter signal needs. Clarity stays as-is (self-degrades to cookieless for EU → no banner).

Verified: build + lint green; endpoint (`event.mjs`) + sender (`ga4.mjs`) compiled server-side; tracker inlined on every page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)