### PR TITLE
E0: on-device AI capability primitive

### DIFF
--- a/apps/personal-website/src/utils/ai/AiCapability.vue
+++ b/apps/personal-website/src/utils/ai/AiCapability.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+
+import { useLanguageModel } from './use-language-model';
+
+// Slot per state. This component supplies no copy and no assets: the blog demos provide the
+// recorded fallback, and because ⌘K degrades to deterministic search, the `unsupported` slot's
+// default is the plain search UI rather than an apology.
+const { state, error, refresh, enable } = useLanguageModel();
+
+onMounted(refresh);
+</script>
+
+<template>
+  <slot v-if="state.kind === 'ready'" name="ready" />
+  <slot
+    v-else-if="state.kind === 'downloading'"
+    name="downloading"
+    :progress="state.progress"
+  />
+  <slot
+    v-else-if="state.kind === 'downloadable'"
+    name="downloadable"
+    :enable="enable"
+  />
+  <slot v-else-if="state.kind === 'unavailable'" name="unavailable" />
+  <slot v-else name="unsupported" :error="error" />
+</template>

--- a/apps/personal-website/src/utils/ai/index.ts
+++ b/apps/personal-website/src/utils/ai/index.ts
@@ -1,0 +1,11 @@
+export { default as AiCapability } from './AiCapability.vue';
+export {
+  destroy,
+  detectCapability,
+  enableModel,
+  selectTool,
+} from './language-model';
+export type { AiState, ToolDescriptor } from './types';
+export { useLanguageModel } from './use-language-model';
+export type { AgentToolRegistration } from './webmcp';
+export { registerAgentTools } from './webmcp';

--- a/apps/personal-website/src/utils/ai/language-model.test.ts
+++ b/apps/personal-website/src/utils/ai/language-model.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { detectCapability, __resetForTests } from './language-model';
+import { detectCapability, enableModel, __resetForTests } from './language-model';
 
 type Availability = 'unavailable' | 'downloadable' | 'downloading' | 'available';
 
@@ -41,5 +41,52 @@ describe('detectCapability', () => {
 
     stubLanguageModel('available');
     expect(await detectCapability()).toEqual({ kind: 'ready' });
+  });
+});
+
+describe('enableModel', () => {
+  it('throws a clear error when the API is absent', async () => {
+    stubLanguageModel(null);
+    await expect(enableModel()).rejects.toThrow(/not available/i);
+  });
+
+  it('creates a session and reports download progress', async () => {
+    const events: number[] = [];
+    Object.defineProperty(globalThis, 'LanguageModel', {
+      configurable: true,
+      writable: true,
+      value: {
+        availability: vi.fn(async () => 'downloadable'),
+        create: vi.fn(async (opts: { monitor?: (m: EventTarget) => void }) => {
+          const monitor = new EventTarget();
+          opts.monitor?.(monitor);
+          const event = new Event('downloadprogress') as Event & { loaded: number; total: number };
+          event.loaded = 5;
+          event.total = 10;
+          monitor.dispatchEvent(event);
+          return { prompt: vi.fn(), destroy: vi.fn() };
+        }),
+      },
+    });
+
+    await enableModel((p) => events.push(p));
+    expect(events).toEqual([0.5]);
+  });
+
+  it('surfaces NotAllowedError rather than hanging when called outside a user gesture', async () => {
+    // The platform throws this when create() runs outside a click handler. It must reject, not
+    // hang — a hung enable leaves the UI stuck on "downloading" forever.
+    Object.defineProperty(globalThis, 'LanguageModel', {
+      configurable: true,
+      writable: true,
+      value: {
+        availability: vi.fn(async () => 'downloadable'),
+        create: vi.fn(async () => {
+          throw new DOMException('requires a user gesture', 'NotAllowedError');
+        }),
+      },
+    });
+
+    await expect(enableModel()).rejects.toMatchObject({ name: 'NotAllowedError' });
   });
 });

--- a/apps/personal-website/src/utils/ai/language-model.test.ts
+++ b/apps/personal-website/src/utils/ai/language-model.test.ts
@@ -5,6 +5,7 @@ import {
   destroy,
   detectCapability,
   enableModel,
+  RUN_TIMEOUT_MS,
   selectTool,
 } from './language-model';
 
@@ -157,6 +158,18 @@ describe('selectTool', () => {
     expect(sessionStorage.getItem('rf:ai:constraint-probe:v1')).toBe('failed');
   });
 
+  it('degrades on the first call when the response is not parseable JSON', async () => {
+    // responseConstraint is supposed to guarantee schema-valid JSON. If it resolves with
+    // something else on the first call, that is the constraint silently not constraining —
+    // exactly the capability failure the probe exists to catch.
+    stubSession(async () => 'not json');
+    await enableModel();
+
+    await expect(selectTool('q', SCHEMA)).rejects.toThrow();
+
+    expect(sessionStorage.getItem('rf:ai:constraint-probe:v1')).toBe('failed');
+  });
+
   it('does not blame the browser for a later failure after one success', async () => {
     let calls = 0;
     stubSession(async () => {
@@ -175,6 +188,58 @@ describe('selectTool', () => {
   it('throws when called before enableModel', async () => {
     stubLanguageModel('available');
     await expect(selectTool('q', SCHEMA)).rejects.toThrow(/enableModel/);
+  });
+
+  it('does not degrade when the caller aborts mid-flight', async () => {
+    // A hung `session.prompt()` that only settles once its `signal` fires — this is how the
+    // platform is expected to behave when asked to abort.
+    stubSession(
+      (_query, opts) =>
+        new Promise<string>((_resolve, reject) => {
+          (
+            opts as { signal?: AbortSignal } | undefined
+          )?.signal?.addEventListener('abort', () =>
+            reject(new DOMException('aborted', 'AbortError')),
+          );
+        }),
+    );
+    await enableModel();
+
+    const controller = new AbortController();
+    const pending = selectTool('q', SCHEMA, { signal: controller.signal });
+    controller.abort();
+
+    await expect(pending).rejects.toThrow();
+
+    // An abort is never a capability verdict.
+    expect(sessionStorage.getItem('rf:ai:constraint-probe:v1')).toBeNull();
+  });
+
+  it('does not degrade when the run times out', async () => {
+    vi.useFakeTimers();
+    try {
+      stubSession(
+        (_query, opts) =>
+          new Promise<string>((_resolve, reject) => {
+            (
+              opts as { signal?: AbortSignal } | undefined
+            )?.signal?.addEventListener('abort', () =>
+              reject(new DOMException('timed out', 'AbortError')),
+            );
+          }),
+      );
+      await enableModel();
+
+      const pending = selectTool('q', SCHEMA);
+      const assertion = expect(pending).rejects.toThrow();
+      await vi.advanceTimersByTimeAsync(RUN_TIMEOUT_MS);
+      await assertion;
+
+      // A timeout says nothing about support either.
+      expect(sessionStorage.getItem('rf:ai:constraint-probe:v1')).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/apps/personal-website/src/utils/ai/language-model.test.ts
+++ b/apps/personal-website/src/utils/ai/language-model.test.ts
@@ -112,7 +112,7 @@ describe('selectTool', () => {
   });
 
   it('passes the schema as responseConstraint', async () => {
-    const prompt = vi.fn(async () => '{"tool":"x"}');
+    const prompt = vi.fn<(q: string, o?: unknown) => Promise<string>>(async () => '{"tool":"x"}');
     stubSession(prompt);
     await enableModel();
     await selectTool('q', SCHEMA);

--- a/apps/personal-website/src/utils/ai/language-model.test.ts
+++ b/apps/personal-website/src/utils/ai/language-model.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { detectCapability, enableModel, __resetForTests } from './language-model';
+import { detectCapability, enableModel, selectTool, __resetForTests } from './language-model';
 
 type Availability = 'unavailable' | 'downloadable' | 'downloading' | 'available';
 
@@ -88,5 +88,68 @@ describe('enableModel', () => {
     });
 
     await expect(enableModel()).rejects.toMatchObject({ name: 'NotAllowedError' });
+  });
+});
+
+function stubSession(prompt: (q: string, o?: unknown) => Promise<string>) {
+  Object.defineProperty(globalThis, 'LanguageModel', {
+    configurable: true,
+    writable: true,
+    value: {
+      availability: vi.fn(async () => 'available'),
+      create: vi.fn(async () => ({ prompt, destroy: vi.fn() })),
+    },
+  });
+}
+
+const SCHEMA = { type: 'object', properties: { tool: { type: 'string' } } };
+
+describe('selectTool', () => {
+  it('returns parsed schema-valid JSON', async () => {
+    stubSession(async () => '{"tool":"get_skills"}');
+    await enableModel();
+    expect(await selectTool('what can he do', SCHEMA)).toEqual({ tool: 'get_skills' });
+  });
+
+  it('passes the schema as responseConstraint', async () => {
+    const prompt = vi.fn(async () => '{"tool":"x"}');
+    stubSession(prompt);
+    await enableModel();
+    await selectTool('q', SCHEMA);
+    expect(prompt.mock.calls[0][1]).toMatchObject({ responseConstraint: SCHEMA });
+  });
+
+  it('degrades ready -> unsupported when the first constrained call fails', async () => {
+    stubSession(async () => {
+      throw new DOMException('nope', 'NotSupportedError');
+    });
+    await enableModel();
+    expect(await detectCapability()).toEqual({ kind: 'ready' });
+
+    await expect(selectTool('q', SCHEMA)).rejects.toThrow();
+
+    // The transition the spec warns about: it reported ready, then the probe failed.
+    expect(await detectCapability()).toEqual({ kind: 'unsupported' });
+    expect(sessionStorage.getItem('rf:ai:constraint-probe:v1')).toBe('failed');
+  });
+
+  it('does not blame the browser for a later failure after one success', async () => {
+    let calls = 0;
+    stubSession(async () => {
+      calls += 1;
+      if (calls === 1) return '{"tool":"ok"}';
+      throw new Error('transient');
+    });
+    await enableModel();
+    await selectTool('q', SCHEMA);
+    await expect(selectTool('q', SCHEMA)).rejects.toThrow('transient');
+
+    // One success proves the browser can do this — a later error is not a capability verdict.
+    expect(sessionStorage.getItem('rf:ai:constraint-probe:v1')).toBeNull();
+  });
+
+  it('throws when called before enableModel', async () => {
+    stubLanguageModel('available');
+    await expect(selectTool('q', SCHEMA)).rejects.toThrow(/enableModel/);
   });
 });

--- a/apps/personal-website/src/utils/ai/language-model.test.ts
+++ b/apps/personal-website/src/utils/ai/language-model.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   __resetForTests,
+  acquire,
   destroy,
   detectCapability,
   enableModel,
@@ -242,6 +243,51 @@ describe('selectTool', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe('acquire', () => {
+  function stubWithDestroy(destroySpy: () => void) {
+    Object.defineProperty(globalThis, 'LanguageModel', {
+      configurable: true,
+      writable: true,
+      value: {
+        availability: vi.fn(async () => 'available'),
+        create: vi.fn(async () => ({ prompt: vi.fn(), destroy: destroySpy })),
+      },
+    });
+  }
+
+  it('keeps the session alive until the last consumer releases', async () => {
+    const destroySpy = vi.fn();
+    stubWithDestroy(destroySpy);
+
+    const releaseFirst = acquire();
+    const releaseSecond = acquire();
+    await enableModel();
+
+    releaseFirst();
+    // The palette must survive an embedded demo unmounting.
+    expect(destroySpy).not.toHaveBeenCalled();
+
+    releaseSecond();
+    expect(destroySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a repeated release so the count cannot go negative', async () => {
+    const destroySpy = vi.fn();
+    stubWithDestroy(destroySpy);
+
+    const releaseFirst = acquire();
+    const releaseSecond = acquire();
+    await enableModel();
+
+    releaseFirst();
+    releaseFirst(); // double unmount must not free a session others still hold
+    expect(destroySpy).not.toHaveBeenCalled();
+
+    releaseSecond();
+    expect(destroySpy).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/personal-website/src/utils/ai/language-model.test.ts
+++ b/apps/personal-website/src/utils/ai/language-model.test.ts
@@ -1,8 +1,18 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { detectCapability, enableModel, selectTool, destroy, __resetForTests } from './language-model';
+import {
+  __resetForTests,
+  destroy,
+  detectCapability,
+  enableModel,
+  selectTool,
+} from './language-model';
 
-type Availability = 'unavailable' | 'downloadable' | 'downloading' | 'available';
+type Availability =
+  | 'unavailable'
+  | 'downloadable'
+  | 'downloading'
+  | 'available';
 
 /** Install a stub `LanguageModel` global. Pass `null` to remove it entirely. */
 function stubLanguageModel(availability: Availability | null) {
@@ -37,7 +47,10 @@ describe('detectCapability', () => {
     expect(await detectCapability()).toEqual({ kind: 'downloadable' });
 
     stubLanguageModel('downloading');
-    expect(await detectCapability()).toEqual({ kind: 'downloading', progress: 0 });
+    expect(await detectCapability()).toEqual({
+      kind: 'downloading',
+      progress: 0,
+    });
 
     stubLanguageModel('available');
     expect(await detectCapability()).toEqual({ kind: 'ready' });
@@ -60,7 +73,10 @@ describe('enableModel', () => {
         create: vi.fn(async (opts: { monitor?: (m: EventTarget) => void }) => {
           const monitor = new EventTarget();
           opts.monitor?.(monitor);
-          const event = new Event('downloadprogress') as Event & { loaded: number; total: number };
+          const event = new Event('downloadprogress') as Event & {
+            loaded: number;
+            total: number;
+          };
           event.loaded = 5;
           event.total = 10;
           monitor.dispatchEvent(event);
@@ -87,7 +103,9 @@ describe('enableModel', () => {
       },
     });
 
-    await expect(enableModel()).rejects.toMatchObject({ name: 'NotAllowedError' });
+    await expect(enableModel()).rejects.toMatchObject({
+      name: 'NotAllowedError',
+    });
   });
 });
 
@@ -108,15 +126,21 @@ describe('selectTool', () => {
   it('returns parsed schema-valid JSON', async () => {
     stubSession(async () => '{"tool":"get_skills"}');
     await enableModel();
-    expect(await selectTool('what can he do', SCHEMA)).toEqual({ tool: 'get_skills' });
+    expect(await selectTool('what can he do', SCHEMA)).toEqual({
+      tool: 'get_skills',
+    });
   });
 
   it('passes the schema as responseConstraint', async () => {
-    const prompt = vi.fn<(q: string, o?: unknown) => Promise<string>>(async () => '{"tool":"x"}');
+    const prompt = vi.fn<(q: string, o?: unknown) => Promise<string>>(
+      async () => '{"tool":"x"}',
+    );
     stubSession(prompt);
     await enableModel();
     await selectTool('q', SCHEMA);
-    expect(prompt.mock.calls[0][1]).toMatchObject({ responseConstraint: SCHEMA });
+    expect(prompt.mock.calls[0][1]).toMatchObject({
+      responseConstraint: SCHEMA,
+    });
   });
 
   it('degrades ready -> unsupported when the first constrained call fails', async () => {

--- a/apps/personal-website/src/utils/ai/language-model.test.ts
+++ b/apps/personal-website/src/utils/ai/language-model.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { detectCapability, __resetForTests } from './language-model';
+
+type Availability = 'unavailable' | 'downloadable' | 'downloading' | 'available';
+
+/** Install a stub `LanguageModel` global. Pass `null` to remove it entirely. */
+function stubLanguageModel(availability: Availability | null) {
+  if (availability === null) {
+    Reflect.deleteProperty(globalThis, 'LanguageModel');
+    return;
+  }
+  Object.defineProperty(globalThis, 'LanguageModel', {
+    configurable: true,
+    writable: true,
+    value: { availability: vi.fn(async () => availability), create: vi.fn() },
+  });
+}
+
+afterEach(() => {
+  stubLanguageModel(null);
+  sessionStorage.clear();
+  __resetForTests();
+});
+
+describe('detectCapability', () => {
+  it('reports unsupported when the global is absent', async () => {
+    stubLanguageModel(null);
+    expect(await detectCapability()).toEqual({ kind: 'unsupported' });
+  });
+
+  it('maps availability() onto the state machine', async () => {
+    stubLanguageModel('unavailable');
+    expect(await detectCapability()).toEqual({ kind: 'unavailable' });
+
+    stubLanguageModel('downloadable');
+    expect(await detectCapability()).toEqual({ kind: 'downloadable' });
+
+    stubLanguageModel('downloading');
+    expect(await detectCapability()).toEqual({ kind: 'downloading', progress: 0 });
+
+    stubLanguageModel('available');
+    expect(await detectCapability()).toEqual({ kind: 'ready' });
+  });
+});

--- a/apps/personal-website/src/utils/ai/language-model.test.ts
+++ b/apps/personal-website/src/utils/ai/language-model.test.ts
@@ -133,6 +133,8 @@ describe('selectTool', () => {
   });
 
   it('passes the schema as responseConstraint', async () => {
+    // Explicit generic: an argumentless vi.fn(async () => ...) infers a zero-arg mock type, so
+    // mock.calls[0][1] is out of bounds under astro check's strict pass even though it runs fine.
     const prompt = vi.fn<(q: string, o?: unknown) => Promise<string>>(
       async () => '{"tool":"x"}',
     );
@@ -240,6 +242,62 @@ describe('selectTool', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe('enableModel re-entrancy', () => {
+  it('releases the previous session instead of leaking it', async () => {
+    const firstDestroy = vi.fn();
+    const sessions = [
+      { prompt: vi.fn(), destroy: firstDestroy },
+      { prompt: vi.fn(), destroy: vi.fn() },
+    ];
+    let created = 0;
+    Object.defineProperty(globalThis, 'LanguageModel', {
+      configurable: true,
+      writable: true,
+      value: {
+        availability: vi.fn(async () => 'available'),
+        create: vi.fn(async () => sessions[created++]),
+      },
+    });
+
+    await enableModel();
+    await enableModel();
+
+    // Without the release, the first session would be overwritten and never freed.
+    expect(firstDestroy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('selectTool with an already-aborted signal', () => {
+  it('aborts immediately rather than waiting out the timeout', async () => {
+    let promptStarted = false;
+    stubSession((_q, o) => {
+      promptStarted = true;
+      const { signal } = o as { signal: AbortSignal };
+      return new Promise((_resolve, reject) => {
+        if (signal.aborted) {
+          reject(new DOMException('aborted', 'AbortError'));
+          return;
+        }
+        signal.addEventListener('abort', () =>
+          reject(new DOMException('aborted', 'AbortError')),
+        );
+      });
+    });
+    await enableModel();
+
+    const controller = new AbortController();
+    controller.abort(); // already aborted BEFORE the call
+
+    await expect(
+      selectTool('q', SCHEMA, { signal: controller.signal }),
+    ).rejects.toThrow();
+
+    // Subscribing alone would miss this: the abort event already fired.
+    expect(promptStarted).toBe(true);
+    expect(sessionStorage.getItem('rf:ai:constraint-probe:v1')).toBeNull();
   });
 });
 

--- a/apps/personal-website/src/utils/ai/language-model.test.ts
+++ b/apps/personal-website/src/utils/ai/language-model.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { detectCapability, enableModel, selectTool, __resetForTests } from './language-model';
+import { detectCapability, enableModel, selectTool, destroy, __resetForTests } from './language-model';
 
 type Availability = 'unavailable' | 'downloadable' | 'downloading' | 'available';
 
@@ -151,5 +151,25 @@ describe('selectTool', () => {
   it('throws when called before enableModel', async () => {
     stubLanguageModel('available');
     await expect(selectTool('q', SCHEMA)).rejects.toThrow(/enableModel/);
+  });
+});
+
+describe('destroy', () => {
+  it('releases the session and is safe to call twice', async () => {
+    const destroySpy = vi.fn();
+    Object.defineProperty(globalThis, 'LanguageModel', {
+      configurable: true,
+      writable: true,
+      value: {
+        availability: vi.fn(async () => 'available'),
+        create: vi.fn(async () => ({ prompt: vi.fn(), destroy: destroySpy })),
+      },
+    });
+
+    await enableModel();
+    destroy();
+    destroy();
+
+    expect(destroySpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/personal-website/src/utils/ai/language-model.ts
+++ b/apps/personal-website/src/utils/ai/language-model.ts
@@ -11,6 +11,8 @@ let probeFailed = false;
 /** Test-only: clear module state between cases. */
 export function __resetForTests(): void {
   probeFailed = false;
+  hasSucceededOnce = false;
+  session = null;
 }
 
 function hasProbeFailure(): boolean {
@@ -70,4 +72,54 @@ export async function enableModel(onProgress?: (progress: number) => void): Prom
       });
     },
   } as never)) as unknown as Session;
+}
+
+/** Wall clock, not step count. On-device inference blocks the main thread, so a hung run has to
+ *  be cut off by an abort signal the platform honours rather than a timer we can't fire. */
+const RUN_TIMEOUT_MS = 20_000;
+
+let hasSucceededOnce = false;
+
+function markProbeFailed(): void {
+  probeFailed = true;
+  try {
+    sessionStorage.setItem(PROBE_CACHE_KEY, 'failed');
+  } catch {
+    // Storage blocked; the in-memory flag still holds for this page.
+  }
+}
+
+/**
+ * One constrained call per turn. `responseConstraint` guarantees schema-valid JSON by
+ * construction, so there is no free-form parse step to fail.
+ *
+ * If the FIRST call fails, we treat it as rung 3 of the capability ladder failing and degrade to
+ * `unsupported`. After one success we never blame the browser again — a later error is transient,
+ * not a capability verdict. Aborts are excluded either way: a timeout says nothing about support.
+ */
+export async function selectTool<T>(
+  query: string,
+  schema: Record<string, unknown>,
+  opts: { signal?: AbortSignal } = {},
+): Promise<T> {
+  if (!session) throw new Error('enableModel() must be called before selectTool()');
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), RUN_TIMEOUT_MS);
+  opts.signal?.addEventListener('abort', () => controller.abort(), { once: true });
+
+  try {
+    const raw = await session.prompt(query, {
+      responseConstraint: schema,
+      signal: controller.signal,
+    });
+    hasSucceededOnce = true;
+    return JSON.parse(raw) as T;
+  } catch (error) {
+    const aborted = error instanceof DOMException && error.name === 'AbortError';
+    if (!hasSucceededOnce && !aborted) markProbeFailed();
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
 }

--- a/apps/personal-website/src/utils/ai/language-model.ts
+++ b/apps/personal-website/src/utils/ai/language-model.ts
@@ -98,12 +98,14 @@ function markProbeFailed(): void {
 }
 
 /**
- * One constrained call per turn. `responseConstraint` guarantees schema-valid JSON by
- * construction, so there is no free-form parse step to fail.
+ * One constrained call per turn. `responseConstraint` is *supposed* to guarantee schema-valid
+ * JSON by construction — but we parse defensively rather than trust it, because a browser that
+ * accepts the option and then ignores it is exactly the failure this function must detect.
  *
- * If the FIRST call fails, we treat it as rung 3 of the capability ladder failing and degrade to
- * `unsupported`. After one success we never blame the browser again — a later error is transient,
- * not a capability verdict. Aborts are excluded either way: a timeout says nothing about support.
+ * If the FIRST call fails — including failing to parse — we treat it as rung 3 of the capability
+ * ladder failing and degrade to `unsupported`. After one success we never blame the browser again:
+ * a later error is transient, not a capability verdict. Aborts are excluded either way, since a
+ * timeout says nothing about whether constraints are supported.
  */
 export async function selectTool<T>(
   query: string,

--- a/apps/personal-website/src/utils/ai/language-model.ts
+++ b/apps/personal-website/src/utils/ai/language-model.ts
@@ -13,6 +13,7 @@ export function __resetForTests(): void {
   probeFailed = false;
   hasSucceededOnce = false;
   session = null;
+  consumers = 0;
 }
 
 function hasProbeFailure(): boolean {
@@ -155,8 +156,39 @@ export async function selectTool<T>(
   }
 }
 
-/** Sessions hold the model in memory; the platform guidance requires explicit release. */
+/**
+ * Tears the session down immediately, regardless of how many consumers are live.
+ *
+ * Prefer `acquire()` unless you genuinely own the whole page — see below for why.
+ */
 export function destroy(): void {
   session?.destroy();
   session = null;
+}
+
+let consumers = 0;
+
+/**
+ * Registers a consumer and returns its release function. The session is destroyed only when the
+ * LAST consumer releases.
+ *
+ * There is one session per page, so a consumer that tears down on its own unmount takes the
+ * session out from under everyone else. That is not hypothetical: the command palette and an
+ * embedded demo can share a page, and the demo unmounting on a route change would leave the
+ * palette's next call throwing "enableModel() must be called before selectTool()" — recoverable
+ * only by another real user gesture, which the palette has no way to stage.
+ *
+ * Release is idempotent per consumer, so a double-unmount can't drive the count negative and
+ * free a session other consumers are still using.
+ */
+export function acquire(): () => void {
+  consumers += 1;
+  let released = false;
+
+  return () => {
+    if (released) return;
+    released = true;
+    consumers = Math.max(0, consumers - 1);
+    if (consumers === 0) destroy();
+  };
 }

--- a/apps/personal-website/src/utils/ai/language-model.ts
+++ b/apps/personal-website/src/utils/ai/language-model.ts
@@ -1,0 +1,45 @@
+import type { AiState } from './types';
+
+/**
+ * Bumped when the probe's meaning changes, so a browser update re-probes rather than inheriting
+ * a stale "this browser can't" verdict.
+ */
+const PROBE_CACHE_KEY = 'rf:ai:constraint-probe:v1';
+
+let probeFailed = false;
+
+/** Test-only: clear module state between cases. */
+export function __resetForTests(): void {
+  probeFailed = false;
+}
+
+function hasProbeFailure(): boolean {
+  if (probeFailed) return true;
+  try {
+    return sessionStorage.getItem(PROBE_CACHE_KEY) === 'failed';
+  } catch {
+    // Private mode or blocked storage — treat as "not yet probed" rather than failing shut.
+    return false;
+  }
+}
+
+/**
+ * Rungs 1 and 2 of the capability ladder. Rung 3 (does `responseConstraint` actually work) needs
+ * a session, which needs a download, which needs a user gesture — so it runs in `selectTool()`.
+ */
+export async function detectCapability(): Promise<AiState> {
+  if (typeof LanguageModel === 'undefined') return { kind: 'unsupported' };
+  if (hasProbeFailure()) return { kind: 'unsupported' };
+
+  const availability = await LanguageModel.availability();
+  switch (availability) {
+    case 'unavailable':
+      return { kind: 'unavailable' };
+    case 'downloadable':
+      return { kind: 'downloadable' };
+    case 'downloading':
+      return { kind: 'downloading', progress: 0 };
+    default:
+      return { kind: 'ready' };
+  }
+}

--- a/apps/personal-website/src/utils/ai/language-model.ts
+++ b/apps/personal-website/src/utils/ai/language-model.ts
@@ -43,3 +43,31 @@ export async function detectCapability(): Promise<AiState> {
       return { kind: 'ready' };
   }
 }
+
+type Session = { prompt: (input: string, opts?: unknown) => Promise<string>; destroy: () => void };
+
+let session: Session | null = null;
+
+/**
+ * Starts the model download and opens a session.
+ *
+ * MUST be called synchronously from a click handler. The first `create()` triggers a
+ * multi-hundred-megabyte download and throws `NotAllowedError` outside a user gesture, so this
+ * cannot be called on ⌘K-open or on keystroke — consumers wire it to an explicit control.
+ */
+export async function enableModel(onProgress?: (progress: number) => void): Promise<void> {
+  if (typeof LanguageModel === 'undefined') {
+    throw new Error('Prompt API is not available in this browser');
+  }
+
+  session = (await LanguageModel.create({
+    // Output is pinned to English: non-English replies are unreliable on current on-device models.
+    expectedOutputs: [{ type: 'text', languages: ['en'] }],
+    monitor(m: EventTarget) {
+      m.addEventListener('downloadprogress', (event) => {
+        const { loaded, total } = event as Event & { loaded: number; total: number };
+        onProgress?.(total > 0 ? loaded / total : 0);
+      });
+    },
+  } as never)) as unknown as Session;
+}

--- a/apps/personal-website/src/utils/ai/language-model.ts
+++ b/apps/personal-website/src/utils/ai/language-model.ts
@@ -46,7 +46,10 @@ export async function detectCapability(): Promise<AiState> {
   }
 }
 
-type Session = { prompt: (input: string, opts?: unknown) => Promise<string>; destroy: () => void };
+type Session = {
+  prompt: (input: string, opts?: unknown) => Promise<string>;
+  destroy: () => void;
+};
 
 let session: Session | null = null;
 
@@ -57,7 +60,9 @@ let session: Session | null = null;
  * multi-hundred-megabyte download and throws `NotAllowedError` outside a user gesture, so this
  * cannot be called on ⌘K-open or on keystroke — consumers wire it to an explicit control.
  */
-export async function enableModel(onProgress?: (progress: number) => void): Promise<void> {
+export async function enableModel(
+  onProgress?: (progress: number) => void,
+): Promise<void> {
   if (typeof LanguageModel === 'undefined') {
     throw new Error('Prompt API is not available in this browser');
   }
@@ -67,16 +72,19 @@ export async function enableModel(onProgress?: (progress: number) => void): Prom
     expectedOutputs: [{ type: 'text', languages: ['en'] }],
     monitor(m: EventTarget) {
       m.addEventListener('downloadprogress', (event) => {
-        const { loaded, total } = event as Event & { loaded: number; total: number };
+        const { loaded, total } = event as Event & {
+          loaded: number;
+          total: number;
+        };
         onProgress?.(total > 0 ? loaded / total : 0);
       });
     },
   } as never)) as unknown as Session;
 }
 
-/** Wall clock, not step count. On-device inference blocks the main thread, so a hung run has to
- *  be cut off by an abort signal the platform honours rather than a timer we can't fire. */
-const RUN_TIMEOUT_MS = 20_000;
+/** Wall-clock bound on a single run. The abort is what the platform honours — we ask it to
+ *  stop rather than assuming we can interrupt inference ourselves. */
+export const RUN_TIMEOUT_MS = 20_000;
 
 let hasSucceededOnce = false;
 
@@ -102,25 +110,30 @@ export async function selectTool<T>(
   schema: Record<string, unknown>,
   opts: { signal?: AbortSignal } = {},
 ): Promise<T> {
-  if (!session) throw new Error('enableModel() must be called before selectTool()');
+  if (!session)
+    throw new Error('enableModel() must be called before selectTool()');
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), RUN_TIMEOUT_MS);
-  opts.signal?.addEventListener('abort', () => controller.abort(), { once: true });
+  const onCallerAbort = () => controller.abort();
+  opts.signal?.addEventListener('abort', onCallerAbort, { once: true });
 
   try {
     const raw = await session.prompt(query, {
       responseConstraint: schema,
       signal: controller.signal,
     });
+    const parsed = JSON.parse(raw) as T;
     hasSucceededOnce = true;
-    return JSON.parse(raw) as T;
+    return parsed;
   } catch (error) {
-    const aborted = error instanceof DOMException && error.name === 'AbortError';
+    const aborted =
+      error instanceof DOMException && error.name === 'AbortError';
     if (!hasSucceededOnce && !aborted) markProbeFailed();
     throw error;
   } finally {
     clearTimeout(timer);
+    opts.signal?.removeEventListener('abort', onCallerAbort);
   }
 }
 

--- a/apps/personal-website/src/utils/ai/language-model.ts
+++ b/apps/personal-website/src/utils/ai/language-model.ts
@@ -59,6 +59,10 @@ let session: Session | null = null;
  * MUST be called synchronously from a click handler. The first `create()` triggers a
  * multi-hundred-megabyte download and throws `NotAllowedError` outside a user gesture, so this
  * cannot be called on ⌘K-open or on keystroke — consumers wire it to an explicit control.
+ *
+ * There is ONE session per page. Calling this again replaces the previous one, releasing it first
+ * so a double-click or a re-mounting component can't strand a session holding the model in memory.
+ * Consumers sharing a page must coordinate `enableModel`/`destroy` between themselves.
  */
 export async function enableModel(
   onProgress?: (progress: number) => void,
@@ -66,6 +70,10 @@ export async function enableModel(
   if (typeof LanguageModel === 'undefined') {
     throw new Error('Prompt API is not available in this browser');
   }
+
+  // Release any existing session before overwriting the reference — otherwise the old one leaks,
+  // which is the exact thing destroy()'s "platform requires explicit release" note warns about.
+  session?.destroy();
 
   session = (await LanguageModel.create({
     // Output is pinned to English: non-English replies are unreliable on current on-device models.
@@ -79,7 +87,7 @@ export async function enableModel(
         onProgress?.(total > 0 ? loaded / total : 0);
       });
     },
-  } as never)) as unknown as Session;
+  })) as unknown as Session;
 }
 
 /** Wall-clock bound on a single run. The abort is what the platform honours — we ask it to
@@ -118,7 +126,15 @@ export async function selectTool<T>(
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), RUN_TIMEOUT_MS);
   const onCallerAbort = () => controller.abort();
-  opts.signal?.addEventListener('abort', onCallerAbort, { once: true });
+
+  // An `abort` listener never fires on a signal that is ALREADY aborted — the event fires once,
+  // when abort() is called. Subscribing alone would let a pre-aborted caller signal run the full
+  // RUN_TIMEOUT_MS as if nothing were wrong, so check the current state first.
+  if (opts.signal?.aborted) {
+    controller.abort();
+  } else {
+    opts.signal?.addEventListener('abort', onCallerAbort, { once: true });
+  }
 
   try {
     const raw = await session.prompt(query, {

--- a/apps/personal-website/src/utils/ai/language-model.ts
+++ b/apps/personal-website/src/utils/ai/language-model.ts
@@ -123,3 +123,9 @@ export async function selectTool<T>(
     clearTimeout(timer);
   }
 }
+
+/** Sessions hold the model in memory; the platform guidance requires explicit release. */
+export function destroy(): void {
+  session?.destroy();
+  session = null;
+}

--- a/apps/personal-website/src/utils/ai/types.ts
+++ b/apps/personal-website/src/utils/ai/types.ts
@@ -1,0 +1,28 @@
+/**
+ * The single union every consumer switches on.
+ *
+ * `unsupported` and `unavailable` are distinct on purpose: they are different sentences to a
+ * user ("this browser can't" vs "this machine can't"), and only the first is worth re-probing
+ * in a different browser.
+ */
+export type AiState =
+  | { kind: 'unsupported' }
+  | { kind: 'unavailable' }
+  | { kind: 'downloadable' }
+  | { kind: 'downloading'; progress: number }
+  | { kind: 'ready' };
+
+/**
+ * One tool, described once. `inputSchema` is JSON Schema — the same shape `selectTool()` passes
+ * as `responseConstraint` and the same shape WebMCP's `registerTool()` expects. That shared
+ * shape is why both live in this module: one descriptor feeds local constrained decoding and
+ * remote agent registration, so the two cannot drift.
+ *
+ * The descriptors themselves belong to E, not here.
+ */
+export interface ToolDescriptor {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  execute: (input: Record<string, unknown>) => unknown | Promise<unknown>;
+}

--- a/apps/personal-website/src/utils/ai/use-language-model.ts
+++ b/apps/personal-website/src/utils/ai/use-language-model.ts
@@ -1,0 +1,67 @@
+import { onUnmounted, readonly, ref } from 'vue';
+
+import {
+  destroy,
+  detectCapability,
+  enableModel as enableModelCore,
+  selectTool as selectToolCore,
+} from './language-model';
+import type { AiState } from './types';
+
+/**
+ * Vue adapter over the framework-agnostic core. Holds no logic of its own beyond reactivity and
+ * cleanup — everything fragile lives in language-model.ts so a React consumer could reuse it.
+ *
+ * ONE SESSION PER PAGE. The core keeps a single module-level session, so two components each
+ * calling `enable()`/unmounting will fight over it: whichever unmounts first destroys the session
+ * the other is still using. Until ownership is designed properly, use this from ONE component per
+ * page.
+ */
+export function useLanguageModel() {
+  const state = ref<AiState>({ kind: 'unsupported' });
+  const error = ref<Error | null>(null);
+
+  async function refresh(): Promise<void> {
+    state.value = await detectCapability();
+  }
+
+  /** Bind directly to a click handler — see enableModel() in the core. */
+  async function enable(): Promise<void> {
+    error.value = null;
+    try {
+      state.value = { kind: 'downloading', progress: 0 };
+      await enableModelCore((progress) => {
+        state.value = { kind: 'downloading', progress };
+      });
+      state.value = { kind: 'ready' };
+    } catch (cause) {
+      error.value = cause as Error;
+      await refresh();
+    }
+  }
+
+  async function selectTool<T>(
+    query: string,
+    schema: Record<string, unknown>,
+  ): Promise<T | null> {
+    try {
+      return await selectToolCore<T>(query, schema);
+    } catch (cause) {
+      error.value = cause as Error;
+      // The core may have degraded ready -> unsupported on a first-call failure; re-read rather
+      // than assuming the previous state still holds.
+      await refresh();
+      return null;
+    }
+  }
+
+  onUnmounted(destroy);
+
+  return {
+    state: readonly(state),
+    error: readonly(error),
+    refresh,
+    enable,
+    selectTool,
+  };
+}

--- a/apps/personal-website/src/utils/ai/use-language-model.ts
+++ b/apps/personal-website/src/utils/ai/use-language-model.ts
@@ -1,7 +1,7 @@
 import { onUnmounted, readonly, ref } from 'vue';
 
 import {
-  destroy,
+  acquire,
   detectCapability,
   enableModel as enableModelCore,
   selectTool as selectToolCore,
@@ -12,10 +12,9 @@ import type { AiState } from './types';
  * Vue adapter over the framework-agnostic core. Holds no logic of its own beyond reactivity and
  * cleanup — everything fragile lives in language-model.ts so a React consumer could reuse it.
  *
- * ONE SESSION PER PAGE. The core keeps a single module-level session, so two components each
- * calling `enable()`/unmounting will fight over it: whichever unmounts first destroys the session
- * the other is still using. Until ownership is designed properly, use this from ONE component per
- * page.
+ * ONE SESSION PER PAGE, shared by every consumer. Teardown is reference-counted via the core's
+ * `acquire()`, so the session survives until the last component using it unmounts — a demo
+ * unmounting on a route change no longer destroys the palette's session.
  */
 export function useLanguageModel() {
   const state = ref<AiState>({ kind: 'unsupported' });
@@ -55,7 +54,10 @@ export function useLanguageModel() {
     }
   }
 
-  onUnmounted(destroy);
+  // acquire() runs now, registering this consumer; the returned release runs on unmount and
+  // only tears the session down when it is the last one out.
+  const release = acquire();
+  onUnmounted(release);
 
   return {
     state: readonly(state),

--- a/apps/personal-website/src/utils/ai/webmcp.test.ts
+++ b/apps/personal-website/src/utils/ai/webmcp.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { ToolDescriptor } from './types';
+import { registerAgentTools } from './webmcp';
+
+const TOOLS: ToolDescriptor[] = [
+  {
+    name: 'get_skills',
+    description: 'List technical skills',
+    inputSchema: { type: 'object', properties: {} },
+    execute: () => ['typescript'],
+  },
+];
+
+afterEach(() => {
+  Reflect.deleteProperty(document, 'modelContext');
+});
+
+describe('registerAgentTools', () => {
+  it('no-ops and reports false when WebMCP is absent', () => {
+    // This is every browser today — the default path, not an edge case.
+    expect(registerAgentTools(TOOLS, new AbortController().signal)).toBe(false);
+  });
+
+  it('registers each tool with the abort signal when WebMCP exists', () => {
+    const registerTool = vi.fn();
+    Object.defineProperty(document, 'modelContext', {
+      configurable: true,
+      value: { registerTool },
+    });
+    const controller = new AbortController();
+
+    expect(registerAgentTools(TOOLS, controller.signal)).toBe(true);
+    expect(registerTool).toHaveBeenCalledTimes(1);
+
+    const [descriptor, options] = registerTool.mock.calls[0];
+    expect(descriptor.name).toBe('get_skills');
+    expect(descriptor.inputSchema).toEqual(TOOLS[0].inputSchema);
+    expect(descriptor.annotations).toEqual({ readOnlyHint: true });
+    expect(options).toEqual({ signal: controller.signal });
+  });
+});

--- a/apps/personal-website/src/utils/ai/webmcp.test.ts
+++ b/apps/personal-website/src/utils/ai/webmcp.test.ts
@@ -17,26 +17,81 @@ afterEach(() => {
 });
 
 describe('registerAgentTools', () => {
-  it('no-ops and reports false when WebMCP is absent', () => {
+  it('registers nothing when WebMCP is absent', () => {
     // This is every browser today — the default path, not an edge case.
-    expect(registerAgentTools(TOOLS, new AbortController().signal)).toBe(false);
+    expect(registerAgentTools(TOOLS).registered).toBe(false);
   });
 
-  it('registers each tool with the abort signal when WebMCP exists', () => {
+  it('returns a dispose that is safe to call when nothing was registered', () => {
+    // Callers wire dispose into teardown unconditionally; it must not care whether the
+    // registration actually happened.
+    expect(() => registerAgentTools(TOOLS).dispose()).not.toThrow();
+  });
+
+  it('registers each tool when WebMCP exists', () => {
     const registerTool = vi.fn();
     Object.defineProperty(document, 'modelContext', {
       configurable: true,
       value: { registerTool },
     });
-    const controller = new AbortController();
 
-    expect(registerAgentTools(TOOLS, controller.signal)).toBe(true);
+    expect(registerAgentTools(TOOLS).registered).toBe(true);
     expect(registerTool).toHaveBeenCalledTimes(1);
 
     const [descriptor, options] = registerTool.mock.calls[0];
     expect(descriptor.name).toBe('get_skills');
     expect(descriptor.inputSchema).toEqual(TOOLS[0].inputSchema);
     expect(descriptor.annotations).toEqual({ readOnlyHint: true });
-    expect(options).toEqual({ signal: controller.signal });
+    expect(options.signal).toBeInstanceOf(AbortSignal);
+    expect(options.signal.aborted).toBe(false);
+  });
+
+  it('dispose aborts the signal the tools were registered with', () => {
+    // The whole point of owning the controller: unregistering is not the caller's to forget.
+    const registerTool = vi.fn();
+    Object.defineProperty(document, 'modelContext', {
+      configurable: true,
+      value: { registerTool },
+    });
+
+    const { dispose } = registerAgentTools(TOOLS);
+    const { signal } = registerTool.mock.calls[0][1];
+
+    expect(signal.aborted).toBe(false);
+    dispose();
+    expect(signal.aborted).toBe(true);
+  });
+
+  it('dispose is idempotent', () => {
+    const registerTool = vi.fn();
+    Object.defineProperty(document, 'modelContext', {
+      configurable: true,
+      value: { registerTool },
+    });
+
+    const { dispose } = registerAgentTools(TOOLS);
+    dispose();
+    expect(() => dispose()).not.toThrow();
+    expect(registerTool.mock.calls[0][1].signal.aborted).toBe(true);
+  });
+
+  it('gives each registration its own signal, so disposing one leaves the other live', () => {
+    // Two consumers can share a page. One unmounting must not silently unregister the other's
+    // tools — a shared controller would do exactly that.
+    const registerTool = vi.fn();
+    Object.defineProperty(document, 'modelContext', {
+      configurable: true,
+      value: { registerTool },
+    });
+
+    const first = registerAgentTools(TOOLS);
+    registerAgentTools(TOOLS); // second consumer; we only need its signal below
+    const firstSignal = registerTool.mock.calls[0][1].signal;
+    const secondSignal = registerTool.mock.calls[1][1].signal;
+
+    first.dispose();
+
+    expect(firstSignal.aborted).toBe(true);
+    expect(secondSignal.aborted).toBe(false);
   });
 });

--- a/apps/personal-website/src/utils/ai/webmcp.ts
+++ b/apps/personal-website/src/utils/ai/webmcp.ts
@@ -7,34 +7,49 @@ type ModelContext = {
   ) => void;
 };
 
+/** What the caller gets back: whether anything was registered, and the one way to undo it. */
+export interface AgentToolRegistration {
+  /** False when WebMCP is unavailable — which is every browser today. */
+  registered: boolean;
+  /** Unregisters everything this call registered. Idempotent, and a no-op when nothing was. */
+  dispose: () => void;
+}
+
 /**
  * Expose tools to external agents via WebMCP.
  *
  * `document.modelContext` exists in no shipping browser as of 2026-07-28 (verified: Chrome 150,
- * Edge 150, Chromium 148), so this returns false and does nothing today. It is built now because
- * WebMCP's `inputSchema` is JSON Schema — the same shape `selectTool()` passes as
- * `responseConstraint` — so one descriptor serves both and they cannot drift.
+ * Edge 150, Chromium 148), so this registers nothing and reports `registered: false` today. It is
+ * built now because WebMCP's `inputSchema` is JSON Schema — the same shape `selectTool()` passes
+ * as `responseConstraint` — so one descriptor serves both and they cannot drift.
  *
  * Deliberately NOT part of `AiState`: WebMCP availability is orthogonal to whether the local
  * model can run, and conflating them would let one break the other.
  *
- * Unregistration is via `signal` only — WebMCP has no `unregisterTool()`. This function owns that
- * contract so consumers cannot leak registrations across route changes.
+ * WebMCP has no `unregisterTool()` — aborting the signal you registered with is the only way to
+ * remove a tool. So this owns the `AbortController` and hands back a `dispose`, rather than
+ * taking a signal: a caller cannot forget to abort a controller it never created. Requiring a
+ * signal instead would only look safe — `registerAgentTools(tools, new AbortController().signal)`
+ * type-checks and leaks exactly as much as passing nothing at all.
  */
 export function registerAgentTools(
   tools: ToolDescriptor[],
-  signal: AbortSignal,
-): boolean {
+): AgentToolRegistration {
   const context = (document as Document & { modelContext?: ModelContext })
     .modelContext;
-  if (!context?.registerTool) return false;
+  if (!context?.registerTool) {
+    return { registered: false, dispose: () => undefined };
+  }
 
+  const controller = new AbortController();
   for (const tool of tools) {
     // Every tool here reads profile data and mutates nothing.
     context.registerTool(
       { ...tool, annotations: { readOnlyHint: true } },
-      { signal },
+      { signal: controller.signal },
     );
   }
-  return true;
+
+  // `abort()` is itself idempotent, so repeat disposal needs no extra bookkeeping.
+  return { registered: true, dispose: () => controller.abort() };
 }

--- a/apps/personal-website/src/utils/ai/webmcp.ts
+++ b/apps/personal-website/src/utils/ai/webmcp.ts
@@ -1,0 +1,40 @@
+import type { ToolDescriptor } from './types';
+
+type ModelContext = {
+  registerTool: (
+    descriptor: ToolDescriptor & { annotations: { readOnlyHint: boolean } },
+    options: { signal: AbortSignal },
+  ) => void;
+};
+
+/**
+ * Expose tools to external agents via WebMCP.
+ *
+ * `document.modelContext` exists in no shipping browser as of 2026-07-28 (verified: Chrome 150,
+ * Edge 150, Chromium 148), so this returns false and does nothing today. It is built now because
+ * WebMCP's `inputSchema` is JSON Schema — the same shape `selectTool()` passes as
+ * `responseConstraint` — so one descriptor serves both and they cannot drift.
+ *
+ * Deliberately NOT part of `AiState`: WebMCP availability is orthogonal to whether the local
+ * model can run, and conflating them would let one break the other.
+ *
+ * Unregistration is via `signal` only — WebMCP has no `unregisterTool()`. This function owns that
+ * contract so consumers cannot leak registrations across route changes.
+ */
+export function registerAgentTools(
+  tools: ToolDescriptor[],
+  signal: AbortSignal,
+): boolean {
+  const context = (document as Document & { modelContext?: ModelContext })
+    .modelContext;
+  if (!context?.registerTool) return false;
+
+  for (const tool of tools) {
+    // Every tool here reads profile data and mutates nothing.
+    context.registerTool(
+      { ...tool, annotations: { readOnlyHint: true } },
+      { signal },
+    );
+  }
+  return true;
+}

--- a/apps/personal-website/vitest.config.ts
+++ b/apps/personal-website/vitest.config.ts
@@ -2,7 +2,9 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    environment: 'node',
+    // jsdom rather than node: the on-device AI capability core (src/utils/ai/) caches a
+    // failed capability probe in sessionStorage, which node's environment doesn't provide.
+    environment: 'jsdom',
     include: ['src/**/*.test.ts'],
     // Task 8 (2026-07-07 personal-data-library plan) deleted this app's only local test
     // files (mcp/smoke.test.ts, mcp/profile-data.test.ts) — their replacements now live

--- a/docs/superpowers/plans/2026-07-28-ai-capability-primitive.md
+++ b/docs/superpowers/plans/2026-07-28-ai-capability-primitive.md
@@ -882,6 +882,29 @@ assurance.
 It is a real rule and it still applies — it just belongs to the **consumer**, so it moves to E's
 spec as a requirement on how tool results are displayed. No task here implements it, deliberately.
 
+## Lint is a gate, not an afterthought
+
+This repo enforces `simple-import-sort` via ESLint (see the root `CLAUDE.md`). Tasks 3–6 each
+append a new named import to the same line in `language-model.test.ts`, so the import list grows
+unsorted and trips the rule — but only if something checks. No task in the original plan ran lint,
+so it went unnoticed until the end of the group.
+
+**Run `pnpm nx lint personal-website --fix` after each task that adds an import**, and commit the
+result with the task rather than as a separate cleanup.
+
+## A known limit of these tests
+
+Every stub installs the global via `Object.defineProperty(globalThis, 'LanguageModel', { value: … })`.
+`PropertyDescriptor.value` is typed `any`, so **none of these stubs is checked against the real
+ambient `LanguageModel` type** from `@types/dom-chromium-ai`. The stubs implement only
+`availability` and `create`; the fake session only `prompt` and `destroy`.
+
+This is fine — it is the ordinary way to stub a global, and typing it faithfully would mean
+maintaining a fake that tracks an abstract class we do not control. Record it so the blast radius
+is known: if that types package is bumped and `availability()` gains a required argument, or
+`create()`'s return shape changes, **this suite will keep passing while the real code breaks**.
+Re-verify against a real browser (workstream D) after any such bump.
+
 ## Verification order matters
 
 `astro check` (run as part of `pnpm nx build personal-website`) type-checks **test files too**, so

--- a/docs/superpowers/plans/2026-07-28-ai-capability-primitive.md
+++ b/docs/superpowers/plans/2026-07-28-ai-capability-primitive.md
@@ -14,17 +14,17 @@
 
 ## File Structure
 
-| File | Responsibility |
-|---|---|
-| `apps/personal-website/vitest.config.ts` | **Already exists** (PR #224) and already yields an inferred `test` target. Modified only to switch `environment` to `jsdom`. See Task 1's correction note. |
-| `apps/personal-website/src/utils/ai/types.ts` | `AiState`, `ToolDescriptor`. No logic. |
-| `apps/personal-website/src/utils/ai/language-model.ts` | The core. Detection, session lifecycle, constrained call, bounds, probe-failure cache. |
-| `apps/personal-website/src/utils/ai/language-model.test.ts` | Unit tests against a stubbed `LanguageModel` global. |
-| `apps/personal-website/src/utils/ai/webmcp.ts` | `registerAgentTools()`. Inert when `document.modelContext` is absent. |
-| `apps/personal-website/src/utils/ai/webmcp.test.ts` | Unit tests, including the no-op path (which is every browser today). |
-| `apps/personal-website/src/utils/ai/use-language-model.ts` | Vue composable. Refs + lifecycle cleanup. |
-| `apps/personal-website/src/utils/ai/AiCapability.vue` | Slot-per-state wrapper. |
-| `apps/personal-website/src/utils/ai/index.ts` | Barrel export. |
+| File                                                        | Responsibility                                                                                                                                             |
+| ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `apps/personal-website/vitest.config.ts`                    | **Already exists** (PR #224) and already yields an inferred `test` target. Modified only to switch `environment` to `jsdom`. See Task 1's correction note. |
+| `apps/personal-website/src/utils/ai/types.ts`               | `AiState`, `ToolDescriptor`. No logic.                                                                                                                     |
+| `apps/personal-website/src/utils/ai/language-model.ts`      | The core. Detection, session lifecycle, constrained call, bounds, probe-failure cache.                                                                     |
+| `apps/personal-website/src/utils/ai/language-model.test.ts` | Unit tests against a stubbed `LanguageModel` global.                                                                                                       |
+| `apps/personal-website/src/utils/ai/webmcp.ts`              | `registerAgentTools()`. Inert when `document.modelContext` is absent.                                                                                      |
+| `apps/personal-website/src/utils/ai/webmcp.test.ts`         | Unit tests, including the no-op path (which is every browser today).                                                                                       |
+| `apps/personal-website/src/utils/ai/use-language-model.ts`  | Vue composable. Refs + lifecycle cleanup.                                                                                                                  |
+| `apps/personal-website/src/utils/ai/AiCapability.vue`       | Slot-per-state wrapper.                                                                                                                                    |
+| `apps/personal-website/src/utils/ai/index.ts`               | Barrel export.                                                                                                                                             |
 
 Vue layer (`use-language-model.ts`, `AiCapability.vue`) is verified in the browser during D, per spec §10. Only the framework-agnostic core is unit-tested here.
 
@@ -32,11 +32,11 @@ Vue layer (`use-language-model.ts`, `AiCapability.vue`) is verified in the brows
 
 ### Task 1: Test infrastructure
 
-> **Corrected 2026-07-28 during execution.** This task originally said *Create*
+> **Corrected 2026-07-28 during execution.** This task originally said _Create_
 > `apps/personal-website/vitest.config.ts` on the premise that the app had no test target. That
 > premise was wrong — the file has existed since commit `6212b2e` (PR #224), and Nx already
 > infers a `test` target from it. The original check missed it because in zsh
-> `ls vite.config.* vitest.config.*` aborts the whole command when the *first* glob has no match,
+> `ls vite.config.* vitest.config.*` aborts the whole command when the _first_ glob has no match,
 > reporting "none" while the file was present.
 >
 > Landing the original content would also have **broken CI**: it dropped `passWithNoTests: true`,
@@ -44,6 +44,7 @@ Vue layer (`use-language-model.ts`, `AiCapability.vue`) is verified in the brows
 > window before Task 3 adds the first test file.
 
 **Files:**
+
 - Modify: `apps/personal-website/vitest.config.ts`
 
 - [ ] **Step 1: Make the minimal change**
@@ -83,6 +84,7 @@ git commit -m "test(personal-website): run app tests in jsdom for the AI capabil
 ### Task 2: Types
 
 **Files:**
+
 - Create: `apps/personal-website/src/utils/ai/types.ts`
 
 - [ ] **Step 1: Write the types**
@@ -135,6 +137,7 @@ git commit -m "feat(ai): add AiState and ToolDescriptor types"
 ### Task 3: `detectCapability()` — rungs 1 and 2
 
 **Files:**
+
 - Create: `apps/personal-website/src/utils/ai/language-model.test.ts`
 - Create: `apps/personal-website/src/utils/ai/language-model.ts`
 
@@ -145,7 +148,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { detectCapability, __resetForTests } from './language-model';
 
-type Availability = 'unavailable' | 'downloadable' | 'downloading' | 'available';
+type Availability =
+  | 'unavailable'
+  | 'downloadable'
+  | 'downloading'
+  | 'available';
 
 /** Install a stub `LanguageModel` global. Pass `null` to remove it entirely. */
 function stubLanguageModel(availability: Availability | null) {
@@ -180,7 +187,10 @@ describe('detectCapability', () => {
     expect(await detectCapability()).toEqual({ kind: 'downloadable' });
 
     stubLanguageModel('downloading');
-    expect(await detectCapability()).toEqual({ kind: 'downloading', progress: 0 });
+    expect(await detectCapability()).toEqual({
+      kind: 'downloading',
+      progress: 0,
+    });
 
     stubLanguageModel('available');
     expect(await detectCapability()).toEqual({ kind: 'ready' });
@@ -260,6 +270,7 @@ git commit -m "feat(ai): detect Prompt API capability (presence + availability)"
 ### Task 4: `enableModel()` — gesture-triggered download
 
 **Files:**
+
 - Modify: `apps/personal-website/src/utils/ai/language-model.ts`
 - Modify: `apps/personal-website/src/utils/ai/language-model.test.ts`
 
@@ -284,7 +295,10 @@ describe('enableModel', () => {
         create: vi.fn(async (opts: { monitor?: (m: EventTarget) => void }) => {
           const monitor = new EventTarget();
           opts.monitor?.(monitor);
-          const event = new Event('downloadprogress') as Event & { loaded: number; total: number };
+          const event = new Event('downloadprogress') as Event & {
+            loaded: number;
+            total: number;
+          };
           event.loaded = 5;
           event.total = 10;
           monitor.dispatchEvent(event);
@@ -311,7 +325,9 @@ describe('enableModel', () => {
       },
     });
 
-    await expect(enableModel()).rejects.toMatchObject({ name: 'NotAllowedError' });
+    await expect(enableModel()).rejects.toMatchObject({
+      name: 'NotAllowedError',
+    });
   });
 });
 ```
@@ -328,7 +344,10 @@ Expected: FAIL — `enableModel` is not exported.
 Add to `language-model.ts`:
 
 ```typescript
-type Session = { prompt: (input: string, opts?: unknown) => Promise<string>; destroy: () => void };
+type Session = {
+  prompt: (input: string, opts?: unknown) => Promise<string>;
+  destroy: () => void;
+};
 
 let session: Session | null = null;
 
@@ -339,7 +358,9 @@ let session: Session | null = null;
  * multi-hundred-megabyte download and throws `NotAllowedError` outside a user gesture, so this
  * cannot be called on ⌘K-open or on keystroke — consumers wire it to an explicit control.
  */
-export async function enableModel(onProgress?: (progress: number) => void): Promise<void> {
+export async function enableModel(
+  onProgress?: (progress: number) => void,
+): Promise<void> {
   if (typeof LanguageModel === 'undefined') {
     throw new Error('Prompt API is not available in this browser');
   }
@@ -349,7 +370,10 @@ export async function enableModel(onProgress?: (progress: number) => void): Prom
     expectedOutputs: [{ type: 'text', languages: ['en'] }],
     monitor(m: EventTarget) {
       m.addEventListener('downloadprogress', (event) => {
-        const { loaded, total } = event as Event & { loaded: number; total: number };
+        const { loaded, total } = event as Event & {
+          loaded: number;
+          total: number;
+        };
         onProgress?.(total > 0 ? loaded / total : 0);
       });
     },
@@ -376,6 +400,7 @@ git commit -m "feat(ai): gesture-triggered model download with progress"
 This is the task the spec calls the single most important thing to get right.
 
 **Files:**
+
 - Modify: `apps/personal-website/src/utils/ai/language-model.ts`
 - Modify: `apps/personal-website/src/utils/ai/language-model.test.ts`
 
@@ -401,18 +426,24 @@ describe('selectTool', () => {
   it('returns parsed schema-valid JSON', async () => {
     stubSession(async () => '{"tool":"get_skills"}');
     await enableModel();
-    expect(await selectTool('what can he do', SCHEMA)).toEqual({ tool: 'get_skills' });
+    expect(await selectTool('what can he do', SCHEMA)).toEqual({
+      tool: 'get_skills',
+    });
   });
 
   it('passes the schema as responseConstraint', async () => {
     // Explicit generic: an argumentless `vi.fn(async () => ...)` infers Mock<() => Promise<string>>,
     // so `mock.calls` is typed `[][]` and `calls[0][1]` is out of bounds. Runtime is fine, but
     // `astro check` type-checks test files and rejects it.
-    const prompt = vi.fn<(q: string, o?: unknown) => Promise<string>>(async () => '{"tool":"x"}');
+    const prompt = vi.fn<(q: string, o?: unknown) => Promise<string>>(
+      async () => '{"tool":"x"}',
+    );
     stubSession(prompt);
     await enableModel();
     await selectTool('q', SCHEMA);
-    expect(prompt.mock.calls[0][1]).toMatchObject({ responseConstraint: SCHEMA });
+    expect(prompt.mock.calls[0][1]).toMatchObject({
+      responseConstraint: SCHEMA,
+    });
   });
 
   it('degrades ready -> unsupported when the first constrained call fails', async () => {
@@ -491,11 +522,14 @@ export async function selectTool<T>(
   schema: Record<string, unknown>,
   opts: { signal?: AbortSignal } = {},
 ): Promise<T> {
-  if (!session) throw new Error('enableModel() must be called before selectTool()');
+  if (!session)
+    throw new Error('enableModel() must be called before selectTool()');
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), RUN_TIMEOUT_MS);
-  opts.signal?.addEventListener('abort', () => controller.abort(), { once: true });
+  opts.signal?.addEventListener('abort', () => controller.abort(), {
+    once: true,
+  });
 
   try {
     const raw = await session.prompt(query, {
@@ -505,7 +539,8 @@ export async function selectTool<T>(
     hasSucceededOnce = true;
     return JSON.parse(raw) as T;
   } catch (error) {
-    const aborted = error instanceof DOMException && error.name === 'AbortError';
+    const aborted =
+      error instanceof DOMException && error.name === 'AbortError';
     if (!hasSucceededOnce && !aborted) markProbeFailed();
     throw error;
   } finally {
@@ -541,6 +576,7 @@ git commit -m "feat(ai): constrained tool selection with first-use capability pr
 ### Task 6: `destroy()`
 
 **Files:**
+
 - Modify: `apps/personal-website/src/utils/ai/language-model.ts`
 - Modify: `apps/personal-website/src/utils/ai/language-model.test.ts`
 
@@ -607,11 +643,12 @@ git commit -m "feat(ai): release the model session explicitly"
 
 > **Revised 2026-07-28 during execution.** The signature below took a required `AbortSignal`;
 > it now owns its own `AbortController` and returns `{ registered, dispose }`. See the spec's §8
-> revision note for why — in short, a required signal makes callers *look* responsible without
-> making them *be* responsible. The code blocks in this task are superseded by the shipped
+> revision note for why — in short, a required signal makes callers _look_ responsible without
+> making them _be_ responsible. The code blocks in this task are superseded by the shipped
 > implementation in `apps/personal-website/src/utils/ai/webmcp.ts`.
 
 **Files:**
+
 - Create: `apps/personal-website/src/utils/ai/webmcp.ts`
 - Create: `apps/personal-website/src/utils/ai/webmcp.test.ts`
 
@@ -693,13 +730,20 @@ type ModelContext = {
  * Unregistration is via `signal` only — WebMCP has no `unregisterTool()`. This function owns that
  * contract so consumers cannot leak registrations across route changes.
  */
-export function registerAgentTools(tools: ToolDescriptor[], signal: AbortSignal): boolean {
-  const context = (document as Document & { modelContext?: ModelContext }).modelContext;
+export function registerAgentTools(
+  tools: ToolDescriptor[],
+  signal: AbortSignal,
+): boolean {
+  const context = (document as Document & { modelContext?: ModelContext })
+    .modelContext;
   if (!context?.registerTool) return false;
 
   for (const tool of tools) {
     // Every tool here reads profile data and mutates nothing.
-    context.registerTool({ ...tool, annotations: { readOnlyHint: true } }, { signal });
+    context.registerTool(
+      { ...tool, annotations: { readOnlyHint: true } },
+      { signal },
+    );
   }
   return true;
 }
@@ -722,6 +766,7 @@ git commit -m "feat(ai): WebMCP tool registration, inert until browsers ship it"
 ### Task 8: Vue composable
 
 **Files:**
+
 - Create: `apps/personal-website/src/utils/ai/use-language-model.ts`
 
 - [ ] **Step 1: Write the composable**
@@ -764,7 +809,10 @@ export function useLanguageModel() {
     }
   }
 
-  async function selectTool<T>(query: string, schema: Record<string, unknown>): Promise<T | null> {
+  async function selectTool<T>(
+    query: string,
+    schema: Record<string, unknown>,
+  ): Promise<T | null> {
     try {
       return await selectToolCore<T>(query, schema);
     } catch (cause) {
@@ -778,7 +826,13 @@ export function useLanguageModel() {
 
   onUnmounted(destroy);
 
-  return { state: readonly(state), error: readonly(error), refresh, enable, selectTool };
+  return {
+    state: readonly(state),
+    error: readonly(error),
+    refresh,
+    enable,
+    selectTool,
+  };
 }
 ```
 
@@ -799,6 +853,7 @@ git commit -m "feat(ai): Vue composable over the capability core"
 ### Task 9: `AiCapability.vue`
 
 **Files:**
+
 - Create: `apps/personal-website/src/utils/ai/AiCapability.vue`
 
 - [ ] **Step 1: Write the component**
@@ -824,7 +879,11 @@ onMounted(refresh);
     name="downloading"
     :progress="state.progress"
   />
-  <slot v-else-if="state.kind === 'downloadable'" name="downloadable" :enable="enable" />
+  <slot
+    v-else-if="state.kind === 'downloadable'"
+    name="downloadable"
+    :enable="enable"
+  />
   <slot v-else-if="state.kind === 'unavailable'" name="unavailable" />
   <slot v-else name="unsupported" :error="error" />
 </template>
@@ -847,13 +906,19 @@ git commit -m "feat(ai): slot-per-state capability wrapper"
 ### Task 10: Barrel export and final verification
 
 **Files:**
+
 - Create: `apps/personal-website/src/utils/ai/index.ts`
 
 - [ ] **Step 1: Write the barrel**
 
 ```typescript
 export { default as AiCapability } from './AiCapability.vue';
-export { destroy, detectCapability, enableModel, selectTool } from './language-model';
+export {
+  destroy,
+  detectCapability,
+  enableModel,
+  selectTool,
+} from './language-model';
 export type { AiState, ToolDescriptor } from './types';
 export { useLanguageModel } from './use-language-model';
 export { registerAgentTools } from './webmcp';
@@ -880,7 +945,7 @@ git commit -m "feat(ai): barrel export for the capability primitive"
 
 ## Correction to spec §6
 
-The spec lists *"model output is untrusted — `textContent`, never `innerHTML`"* among the rules
+The spec lists _"model output is untrusted — `textContent`, never `innerHTML`"_ among the rules
 **E0 enforces**. E0 cannot enforce it: E0 never renders, and after this plan every rendering
 decision belongs to the slot content that E and D supply. Listing it as enforced would give false
 assurance.

--- a/docs/superpowers/plans/2026-07-28-ai-capability-primitive.md
+++ b/docs/superpowers/plans/2026-07-28-ai-capability-primitive.md
@@ -1,0 +1,887 @@
+# On-Device AI Capability Primitive (E0) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the module that owns Chrome Prompt API capability detection, session lifecycle, constrained tool selection, and graceful degradation — so the ⌘K palette (E) and the blog demos (D) cannot diverge on unsupported-browser behaviour.
+
+**Architecture:** A framework-agnostic TypeScript core (`language-model.ts`) with no Vue import, a thin Vue composable over it, and a slot-per-state wrapper component. Capability detection is a three-rung ladder where the third rung — does `responseConstraint` actually work — can only be tested by prompting, so it runs on first real use and may move state from `ready` to `unsupported` mid-flight. WebMCP registration ships as an inert, feature-detected mechanism.
+
+**Tech Stack:** TypeScript 6, Vue 3.5, Vitest 4.1.4 (jsdom), Astro 7. `@types/dom-chromium-ai` is already in `apps/personal-website/tsconfig.json`'s `types` array, so `LanguageModel` is an ambient global — no import, no `declare global`.
+
+**Spec:** [2026-07-28-ai-capability-primitive-design.md](../specs/2026-07-28-ai-capability-primitive-design.md)
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `apps/personal-website/vitest.config.ts` | Test target for the app. Named `vitest.config.ts`, **not** `vite.config.ts`, so `@nx/vite/plugin` does not infer `build`/`serve`/`preview` targets that collide with Astro's. |
+| `apps/personal-website/src/utils/ai/types.ts` | `AiState`, `ToolDescriptor`. No logic. |
+| `apps/personal-website/src/utils/ai/language-model.ts` | The core. Detection, session lifecycle, constrained call, bounds, probe-failure cache. |
+| `apps/personal-website/src/utils/ai/language-model.test.ts` | Unit tests against a stubbed `LanguageModel` global. |
+| `apps/personal-website/src/utils/ai/webmcp.ts` | `registerAgentTools()`. Inert when `document.modelContext` is absent. |
+| `apps/personal-website/src/utils/ai/webmcp.test.ts` | Unit tests, including the no-op path (which is every browser today). |
+| `apps/personal-website/src/utils/ai/use-language-model.ts` | Vue composable. Refs + lifecycle cleanup. |
+| `apps/personal-website/src/utils/ai/AiCapability.vue` | Slot-per-state wrapper. |
+| `apps/personal-website/src/utils/ai/index.ts` | Barrel export. |
+
+Vue layer (`use-language-model.ts`, `AiCapability.vue`) is verified in the browser during D, per spec §10. Only the framework-agnostic core is unit-tested here.
+
+---
+
+### Task 1: Test infrastructure
+
+**Files:**
+- Create: `apps/personal-website/vitest.config.ts`
+
+- [ ] **Step 1: Create the vitest config**
+
+```typescript
+import { defineConfig } from 'vitest/config';
+
+// Deliberately `vitest.config.ts` and not `vite.config.ts`: @nx/vite/plugin infers
+// build/serve/preview targets from `vite.config.*`, which would collide with the Astro-based
+// `build` and `dev` targets declared in package.json. @nx/vitest infers only `test` from this
+// filename. Astro's own Vite config stays in astro.config.mjs and is untouched.
+export default defineConfig({
+  root: __dirname,
+  cacheDir: '../../node_modules/.vite/apps/personal-website',
+  test: {
+    watch: false,
+    globals: true,
+    // jsdom, not node: the capability core caches a probe failure in sessionStorage.
+    environment: 'jsdom',
+    include: ['src/**/*.test.ts'],
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: '../../coverage/apps/personal-website',
+      provider: 'v8',
+    },
+  },
+});
+```
+
+- [ ] **Step 2: Verify Nx infers the test target**
+
+Run: `pnpm nx show project personal-website --json | python3 -c "import json,sys; print(sorted(json.load(sys.stdin)['targets']))"`
+
+Expected: output includes `test` alongside `build` and `dev`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/personal-website/vitest.config.ts
+git commit -m "test(personal-website): add vitest config so the app can unit-test"
+```
+
+---
+
+### Task 2: Types
+
+**Files:**
+- Create: `apps/personal-website/src/utils/ai/types.ts`
+
+- [ ] **Step 1: Write the types**
+
+```typescript
+/**
+ * The single union every consumer switches on.
+ *
+ * `unsupported` and `unavailable` are distinct on purpose: they are different sentences to a
+ * user ("this browser can't" vs "this machine can't"), and only the first is worth re-probing
+ * in a different browser.
+ */
+export type AiState =
+  | { kind: 'unsupported' }
+  | { kind: 'unavailable' }
+  | { kind: 'downloadable' }
+  | { kind: 'downloading'; progress: number }
+  | { kind: 'ready' };
+
+/**
+ * One tool, described once. `inputSchema` is JSON Schema — the same shape `selectTool()` passes
+ * as `responseConstraint` and the same shape WebMCP's `registerTool()` expects. That shared
+ * shape is why both live in this module: one descriptor feeds local constrained decoding and
+ * remote agent registration, so the two cannot drift.
+ *
+ * The descriptors themselves belong to E, not here.
+ */
+export interface ToolDescriptor {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  execute: (input: Record<string, unknown>) => unknown | Promise<unknown>;
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `pnpm nx build personal-website`
+Expected: `Complete!` with no TypeScript errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/personal-website/src/utils/ai/types.ts
+git commit -m "feat(ai): add AiState and ToolDescriptor types"
+```
+
+---
+
+### Task 3: `detectCapability()` — rungs 1 and 2
+
+**Files:**
+- Create: `apps/personal-website/src/utils/ai/language-model.test.ts`
+- Create: `apps/personal-website/src/utils/ai/language-model.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { detectCapability, __resetForTests } from './language-model';
+
+type Availability = 'unavailable' | 'downloadable' | 'downloading' | 'available';
+
+/** Install a stub `LanguageModel` global. Pass `null` to remove it entirely. */
+function stubLanguageModel(availability: Availability | null) {
+  if (availability === null) {
+    Reflect.deleteProperty(globalThis, 'LanguageModel');
+    return;
+  }
+  Object.defineProperty(globalThis, 'LanguageModel', {
+    configurable: true,
+    writable: true,
+    value: { availability: vi.fn(async () => availability), create: vi.fn() },
+  });
+}
+
+afterEach(() => {
+  stubLanguageModel(null);
+  sessionStorage.clear();
+  __resetForTests();
+});
+
+describe('detectCapability', () => {
+  it('reports unsupported when the global is absent', async () => {
+    stubLanguageModel(null);
+    expect(await detectCapability()).toEqual({ kind: 'unsupported' });
+  });
+
+  it('maps availability() onto the state machine', async () => {
+    stubLanguageModel('unavailable');
+    expect(await detectCapability()).toEqual({ kind: 'unavailable' });
+
+    stubLanguageModel('downloadable');
+    expect(await detectCapability()).toEqual({ kind: 'downloadable' });
+
+    stubLanguageModel('downloading');
+    expect(await detectCapability()).toEqual({ kind: 'downloading', progress: 0 });
+
+    stubLanguageModel('available');
+    expect(await detectCapability()).toEqual({ kind: 'ready' });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm nx test personal-website`
+Expected: FAIL — cannot resolve `./language-model`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+```typescript
+import type { AiState } from './types';
+
+/**
+ * Bumped when the probe's meaning changes, so a browser update re-probes rather than inheriting
+ * a stale "this browser can't" verdict.
+ */
+const PROBE_CACHE_KEY = 'rf:ai:constraint-probe:v1';
+
+let probeFailed = false;
+
+/** Test-only: clear module state between cases. */
+export function __resetForTests(): void {
+  probeFailed = false;
+}
+
+function hasProbeFailure(): boolean {
+  if (probeFailed) return true;
+  try {
+    return sessionStorage.getItem(PROBE_CACHE_KEY) === 'failed';
+  } catch {
+    // Private mode or blocked storage — treat as "not yet probed" rather than failing shut.
+    return false;
+  }
+}
+
+/**
+ * Rungs 1 and 2 of the capability ladder. Rung 3 (does `responseConstraint` actually work) needs
+ * a session, which needs a download, which needs a user gesture — so it runs in `selectTool()`.
+ */
+export async function detectCapability(): Promise<AiState> {
+  if (typeof LanguageModel === 'undefined') return { kind: 'unsupported' };
+  if (hasProbeFailure()) return { kind: 'unsupported' };
+
+  const availability = await LanguageModel.availability();
+  switch (availability) {
+    case 'unavailable':
+      return { kind: 'unavailable' };
+    case 'downloadable':
+      return { kind: 'downloadable' };
+    case 'downloading':
+      return { kind: 'downloading', progress: 0 };
+    default:
+      return { kind: 'ready' };
+  }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm nx test personal-website`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/personal-website/src/utils/ai/language-model.ts apps/personal-website/src/utils/ai/language-model.test.ts
+git commit -m "feat(ai): detect Prompt API capability (presence + availability)"
+```
+
+---
+
+### Task 4: `enableModel()` — gesture-triggered download
+
+**Files:**
+- Modify: `apps/personal-website/src/utils/ai/language-model.ts`
+- Modify: `apps/personal-website/src/utils/ai/language-model.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `language-model.test.ts`:
+
+```typescript
+describe('enableModel', () => {
+  it('throws a clear error when the API is absent', async () => {
+    stubLanguageModel(null);
+    await expect(enableModel()).rejects.toThrow(/not available/i);
+  });
+
+  it('creates a session and reports download progress', async () => {
+    const events: number[] = [];
+    Object.defineProperty(globalThis, 'LanguageModel', {
+      configurable: true,
+      writable: true,
+      value: {
+        availability: vi.fn(async () => 'downloadable'),
+        create: vi.fn(async (opts: { monitor?: (m: EventTarget) => void }) => {
+          const monitor = new EventTarget();
+          opts.monitor?.(monitor);
+          const event = new Event('downloadprogress') as Event & { loaded: number; total: number };
+          event.loaded = 5;
+          event.total = 10;
+          monitor.dispatchEvent(event);
+          return { prompt: vi.fn(), destroy: vi.fn() };
+        }),
+      },
+    });
+
+    await enableModel((p) => events.push(p));
+    expect(events).toEqual([0.5]);
+  });
+
+  it('surfaces NotAllowedError rather than hanging when called outside a user gesture', async () => {
+    // The platform throws this when create() runs outside a click handler. It must reject, not
+    // hang — a hung enable leaves the UI stuck on "downloading" forever.
+    Object.defineProperty(globalThis, 'LanguageModel', {
+      configurable: true,
+      writable: true,
+      value: {
+        availability: vi.fn(async () => 'downloadable'),
+        create: vi.fn(async () => {
+          throw new DOMException('requires a user gesture', 'NotAllowedError');
+        }),
+      },
+    });
+
+    await expect(enableModel()).rejects.toMatchObject({ name: 'NotAllowedError' });
+  });
+});
+```
+
+Add `enableModel` to the import at the top of the file.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm nx test personal-website`
+Expected: FAIL — `enableModel` is not exported.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `language-model.ts`:
+
+```typescript
+type Session = { prompt: (input: string, opts?: unknown) => Promise<string>; destroy: () => void };
+
+let session: Session | null = null;
+
+/**
+ * Starts the model download and opens a session.
+ *
+ * MUST be called synchronously from a click handler. The first `create()` triggers a
+ * multi-hundred-megabyte download and throws `NotAllowedError` outside a user gesture, so this
+ * cannot be called on ⌘K-open or on keystroke — consumers wire it to an explicit control.
+ */
+export async function enableModel(onProgress?: (progress: number) => void): Promise<void> {
+  if (typeof LanguageModel === 'undefined') {
+    throw new Error('Prompt API is not available in this browser');
+  }
+
+  session = (await LanguageModel.create({
+    // Output is pinned to English: non-English replies are unreliable on current on-device models.
+    expectedOutputs: [{ type: 'text', languages: ['en'] }],
+    monitor(m: EventTarget) {
+      m.addEventListener('downloadprogress', (event) => {
+        const { loaded, total } = event as Event & { loaded: number; total: number };
+        onProgress?.(total > 0 ? loaded / total : 0);
+      });
+    },
+  } as never)) as unknown as Session;
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm nx test personal-website`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/personal-website/src/utils/ai/language-model.ts apps/personal-website/src/utils/ai/language-model.test.ts
+git commit -m "feat(ai): gesture-triggered model download with progress"
+```
+
+---
+
+### Task 5: `selectTool()` and the ready→unsupported transition
+
+This is the task the spec calls the single most important thing to get right.
+
+**Files:**
+- Modify: `apps/personal-website/src/utils/ai/language-model.ts`
+- Modify: `apps/personal-website/src/utils/ai/language-model.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `language-model.test.ts`:
+
+```typescript
+function stubSession(prompt: (q: string, o?: unknown) => Promise<string>) {
+  Object.defineProperty(globalThis, 'LanguageModel', {
+    configurable: true,
+    writable: true,
+    value: {
+      availability: vi.fn(async () => 'available'),
+      create: vi.fn(async () => ({ prompt, destroy: vi.fn() })),
+    },
+  });
+}
+
+const SCHEMA = { type: 'object', properties: { tool: { type: 'string' } } };
+
+describe('selectTool', () => {
+  it('returns parsed schema-valid JSON', async () => {
+    stubSession(async () => '{"tool":"get_skills"}');
+    await enableModel();
+    expect(await selectTool('what can he do', SCHEMA)).toEqual({ tool: 'get_skills' });
+  });
+
+  it('passes the schema as responseConstraint', async () => {
+    const prompt = vi.fn(async () => '{"tool":"x"}');
+    stubSession(prompt);
+    await enableModel();
+    await selectTool('q', SCHEMA);
+    expect(prompt.mock.calls[0][1]).toMatchObject({ responseConstraint: SCHEMA });
+  });
+
+  it('degrades ready -> unsupported when the first constrained call fails', async () => {
+    stubSession(async () => {
+      throw new DOMException('nope', 'NotSupportedError');
+    });
+    await enableModel();
+    expect(await detectCapability()).toEqual({ kind: 'ready' });
+
+    await expect(selectTool('q', SCHEMA)).rejects.toThrow();
+
+    // The transition the spec warns about: it reported ready, then the probe failed.
+    expect(await detectCapability()).toEqual({ kind: 'unsupported' });
+    expect(sessionStorage.getItem('rf:ai:constraint-probe:v1')).toBe('failed');
+  });
+
+  it('does not blame the browser for a later failure after one success', async () => {
+    let calls = 0;
+    stubSession(async () => {
+      calls += 1;
+      if (calls === 1) return '{"tool":"ok"}';
+      throw new Error('transient');
+    });
+    await enableModel();
+    await selectTool('q', SCHEMA);
+    await expect(selectTool('q', SCHEMA)).rejects.toThrow('transient');
+
+    // One success proves the browser can do this — a later error is not a capability verdict.
+    expect(sessionStorage.getItem('rf:ai:constraint-probe:v1')).toBeNull();
+  });
+
+  it('throws when called before enableModel', async () => {
+    stubLanguageModel('available');
+    await expect(selectTool('q', SCHEMA)).rejects.toThrow(/enableModel/);
+  });
+});
+```
+
+Add `selectTool` to the import at the top of the file.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm nx test personal-website`
+Expected: FAIL — `selectTool` is not exported.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `language-model.ts`:
+
+```typescript
+/** Wall clock, not step count. On-device inference blocks the main thread, so a hung run has to
+ *  be cut off by an abort signal the platform honours rather than a timer we can't fire. */
+const RUN_TIMEOUT_MS = 20_000;
+
+let hasSucceededOnce = false;
+
+function markProbeFailed(): void {
+  probeFailed = true;
+  try {
+    sessionStorage.setItem(PROBE_CACHE_KEY, 'failed');
+  } catch {
+    // Storage blocked; the in-memory flag still holds for this page.
+  }
+}
+
+/**
+ * One constrained call per turn. `responseConstraint` guarantees schema-valid JSON by
+ * construction, so there is no free-form parse step to fail.
+ *
+ * If the FIRST call fails, we treat it as rung 3 of the capability ladder failing and degrade to
+ * `unsupported`. After one success we never blame the browser again — a later error is transient,
+ * not a capability verdict. Aborts are excluded either way: a timeout says nothing about support.
+ */
+export async function selectTool<T>(
+  query: string,
+  schema: Record<string, unknown>,
+  opts: { signal?: AbortSignal } = {},
+): Promise<T> {
+  if (!session) throw new Error('enableModel() must be called before selectTool()');
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), RUN_TIMEOUT_MS);
+  opts.signal?.addEventListener('abort', () => controller.abort(), { once: true });
+
+  try {
+    const raw = await session.prompt(query, {
+      responseConstraint: schema,
+      signal: controller.signal,
+    });
+    hasSucceededOnce = true;
+    return JSON.parse(raw) as T;
+  } catch (error) {
+    const aborted = error instanceof DOMException && error.name === 'AbortError';
+    if (!hasSucceededOnce && !aborted) markProbeFailed();
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+```
+
+Update `__resetForTests` to also clear the new flag:
+
+```typescript
+export function __resetForTests(): void {
+  probeFailed = false;
+  hasSucceededOnce = false;
+  session = null;
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm nx test personal-website`
+Expected: PASS, 10 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/personal-website/src/utils/ai/language-model.ts apps/personal-website/src/utils/ai/language-model.test.ts
+git commit -m "feat(ai): constrained tool selection with first-use capability probe"
+```
+
+---
+
+### Task 6: `destroy()`
+
+**Files:**
+- Modify: `apps/personal-website/src/utils/ai/language-model.ts`
+- Modify: `apps/personal-website/src/utils/ai/language-model.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `language-model.test.ts`:
+
+```typescript
+describe('destroy', () => {
+  it('releases the session and is safe to call twice', async () => {
+    const destroySpy = vi.fn();
+    Object.defineProperty(globalThis, 'LanguageModel', {
+      configurable: true,
+      writable: true,
+      value: {
+        availability: vi.fn(async () => 'available'),
+        create: vi.fn(async () => ({ prompt: vi.fn(), destroy: destroySpy })),
+      },
+    });
+
+    await enableModel();
+    destroy();
+    destroy();
+
+    expect(destroySpy).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+Add `destroy` to the import at the top of the file.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm nx test personal-website`
+Expected: FAIL — `destroy` is not exported.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `language-model.ts`:
+
+```typescript
+/** Sessions hold the model in memory; the platform guidance requires explicit release. */
+export function destroy(): void {
+  session?.destroy();
+  session = null;
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm nx test personal-website`
+Expected: PASS, 11 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/personal-website/src/utils/ai/language-model.ts apps/personal-website/src/utils/ai/language-model.test.ts
+git commit -m "feat(ai): release the model session explicitly"
+```
+
+---
+
+### Task 7: WebMCP registration
+
+**Files:**
+- Create: `apps/personal-website/src/utils/ai/webmcp.ts`
+- Create: `apps/personal-website/src/utils/ai/webmcp.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { registerAgentTools } from './webmcp';
+import type { ToolDescriptor } from './types';
+
+const TOOLS: ToolDescriptor[] = [
+  {
+    name: 'get_skills',
+    description: 'List technical skills',
+    inputSchema: { type: 'object', properties: {} },
+    execute: () => ['typescript'],
+  },
+];
+
+afterEach(() => {
+  Reflect.deleteProperty(document, 'modelContext');
+});
+
+describe('registerAgentTools', () => {
+  it('no-ops and reports false when WebMCP is absent', () => {
+    // This is every browser today — the default path, not an edge case.
+    expect(registerAgentTools(TOOLS, new AbortController().signal)).toBe(false);
+  });
+
+  it('registers each tool with the abort signal when WebMCP exists', () => {
+    const registerTool = vi.fn();
+    Object.defineProperty(document, 'modelContext', {
+      configurable: true,
+      value: { registerTool },
+    });
+    const controller = new AbortController();
+
+    expect(registerAgentTools(TOOLS, controller.signal)).toBe(true);
+    expect(registerTool).toHaveBeenCalledTimes(1);
+
+    const [descriptor, options] = registerTool.mock.calls[0];
+    expect(descriptor.name).toBe('get_skills');
+    expect(descriptor.inputSchema).toEqual(TOOLS[0].inputSchema);
+    expect(descriptor.annotations).toEqual({ readOnlyHint: true });
+    expect(options).toEqual({ signal: controller.signal });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm nx test personal-website`
+Expected: FAIL — cannot resolve `./webmcp`.
+
+- [ ] **Step 3: Write the implementation**
+
+```typescript
+import type { ToolDescriptor } from './types';
+
+type ModelContext = {
+  registerTool: (
+    descriptor: ToolDescriptor & { annotations: { readOnlyHint: boolean } },
+    options: { signal: AbortSignal },
+  ) => void;
+};
+
+/**
+ * Expose tools to external agents via WebMCP.
+ *
+ * `document.modelContext` exists in no shipping browser as of 2026-07-28 (verified: Chrome 150,
+ * Edge 150, Chromium 148), so this returns false and does nothing today. It is built now because
+ * WebMCP's `inputSchema` is JSON Schema — the same shape `selectTool()` passes as
+ * `responseConstraint` — so one descriptor serves both and they cannot drift.
+ *
+ * Deliberately NOT part of `AiState`: WebMCP availability is orthogonal to whether the local
+ * model can run, and conflating them would let one break the other.
+ *
+ * Unregistration is via `signal` only — WebMCP has no `unregisterTool()`. This function owns that
+ * contract so consumers cannot leak registrations across route changes.
+ */
+export function registerAgentTools(tools: ToolDescriptor[], signal: AbortSignal): boolean {
+  const context = (document as Document & { modelContext?: ModelContext }).modelContext;
+  if (!context?.registerTool) return false;
+
+  for (const tool of tools) {
+    // Every tool here reads profile data and mutates nothing.
+    context.registerTool({ ...tool, annotations: { readOnlyHint: true } }, { signal });
+  }
+  return true;
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm nx test personal-website`
+Expected: PASS, 13 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/personal-website/src/utils/ai/webmcp.ts apps/personal-website/src/utils/ai/webmcp.test.ts
+git commit -m "feat(ai): WebMCP tool registration, inert until browsers ship it"
+```
+
+---
+
+### Task 8: Vue composable
+
+**Files:**
+- Create: `apps/personal-website/src/utils/ai/use-language-model.ts`
+
+- [ ] **Step 1: Write the composable**
+
+```typescript
+import { onUnmounted, readonly, ref } from 'vue';
+
+import {
+  destroy,
+  detectCapability,
+  enableModel as enableModelCore,
+  selectTool as selectToolCore,
+} from './language-model';
+import type { AiState } from './types';
+
+/**
+ * Vue adapter over the framework-agnostic core. Holds no logic of its own beyond reactivity and
+ * cleanup — everything fragile lives in language-model.ts so a React consumer could reuse it.
+ */
+export function useLanguageModel() {
+  const state = ref<AiState>({ kind: 'unsupported' });
+  const error = ref<Error | null>(null);
+
+  async function refresh(): Promise<void> {
+    state.value = await detectCapability();
+  }
+
+  /** Must be invoked directly from a click handler — see enableModel() in the core. */
+  async function enable(): Promise<void> {
+    error.value = null;
+    try {
+      state.value = { kind: 'downloading', progress: 0 };
+      await enableModelCore((progress) => {
+        state.value = { kind: 'downloading', progress };
+      });
+      state.value = { kind: 'ready' };
+    } catch (cause) {
+      error.value = cause as Error;
+      await refresh();
+    }
+  }
+
+  async function selectTool<T>(query: string, schema: Record<string, unknown>): Promise<T | null> {
+    try {
+      return await selectToolCore<T>(query, schema);
+    } catch (cause) {
+      error.value = cause as Error;
+      // The core may have degraded ready -> unsupported on a first-call failure; re-read rather
+      // than assuming the previous state still holds.
+      await refresh();
+      return null;
+    }
+  }
+
+  onUnmounted(destroy);
+
+  return { state: readonly(state), error: readonly(error), refresh, enable, selectTool };
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `pnpm nx build personal-website`
+Expected: `Complete!` with no TypeScript errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/personal-website/src/utils/ai/use-language-model.ts
+git commit -m "feat(ai): Vue composable over the capability core"
+```
+
+---
+
+### Task 9: `AiCapability.vue`
+
+**Files:**
+- Create: `apps/personal-website/src/utils/ai/AiCapability.vue`
+
+- [ ] **Step 1: Write the component**
+
+```vue
+<script setup lang="ts">
+import { onMounted } from 'vue';
+
+import { useLanguageModel } from './use-language-model';
+
+// Slot per state. This component supplies no copy and no assets: D provides the recorded demo,
+// and because ⌘K degrades to deterministic search, the `unsupported` slot's default is the plain
+// search UI rather than an apology.
+const { state, error, refresh, enable } = useLanguageModel();
+
+onMounted(refresh);
+</script>
+
+<template>
+  <slot v-if="state.kind === 'ready'" name="ready" />
+  <slot
+    v-else-if="state.kind === 'downloading'"
+    name="downloading"
+    :progress="state.progress"
+  />
+  <slot v-else-if="state.kind === 'downloadable'" name="downloadable" :enable="enable" />
+  <slot v-else-if="state.kind === 'unavailable'" name="unavailable" />
+  <slot v-else name="unsupported" :error="error" />
+</template>
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `pnpm nx build personal-website`
+Expected: `Complete!` with no TypeScript errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/personal-website/src/utils/ai/AiCapability.vue
+git commit -m "feat(ai): slot-per-state capability wrapper"
+```
+
+---
+
+### Task 10: Barrel export and final verification
+
+**Files:**
+- Create: `apps/personal-website/src/utils/ai/index.ts`
+
+- [ ] **Step 1: Write the barrel**
+
+```typescript
+export { default as AiCapability } from './AiCapability.vue';
+export { destroy, detectCapability, enableModel, selectTool } from './language-model';
+export type { AiState, ToolDescriptor } from './types';
+export { useLanguageModel } from './use-language-model';
+export { registerAgentTools } from './webmcp';
+```
+
+- [ ] **Step 2: Run the full check**
+
+Run: `pnpm nx test personal-website && pnpm nx build personal-website && pnpm nx lint personal-website`
+Expected: 13 tests pass, build `Complete!`, lint reports no new errors.
+
+- [ ] **Step 3: Verify the dev server still starts clean**
+
+Run: `pnpm nx dev personal-website`
+Expected: server starts with no `$RefreshSig$` error. Stop it after confirming.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/personal-website/src/utils/ai/index.ts
+git commit -m "feat(ai): barrel export for the capability primitive"
+```
+
+---
+
+## Correction to spec §6
+
+The spec lists *"model output is untrusted — `textContent`, never `innerHTML`"* among the rules
+**E0 enforces**. E0 cannot enforce it: E0 never renders, and after this plan every rendering
+decision belongs to the slot content that E and D supply. Listing it as enforced would give false
+assurance.
+
+It is a real rule and it still applies — it just belongs to the **consumer**, so it moves to E's
+spec as a requirement on how tool results are displayed. No task here implements it, deliberately.
+
+## Definition of done
+
+- `pnpm nx test personal-website` passes with 13 tests, including the `ready → unsupported` transition and the WebMCP no-op path.
+- `pnpm nx build personal-website` and `pnpm nx lint personal-website` are clean.
+- No consumer wiring exists yet — E and D consume this next. E0 ships plumbing, not content.
+
+## Next
+
+**E** — the ⌘K palette: deterministic fuzzy search over `@rainforest-dev/personal-data`, with the tool catalog shared with `src/pages/mcp.ts` so the remote MCP surface and the local palette cannot drift, and the AI path layered on via `selectTool()`.

--- a/docs/superpowers/plans/2026-07-28-ai-capability-primitive.md
+++ b/docs/superpowers/plans/2026-07-28-ai-capability-primitive.md
@@ -405,7 +405,10 @@ describe('selectTool', () => {
   });
 
   it('passes the schema as responseConstraint', async () => {
-    const prompt = vi.fn(async () => '{"tool":"x"}');
+    // Explicit generic: an argumentless `vi.fn(async () => ...)` infers Mock<() => Promise<string>>,
+    // so `mock.calls` is typed `[][]` and `calls[0][1]` is out of bounds. Runtime is fine, but
+    // `astro check` type-checks test files and rejects it.
+    const prompt = vi.fn<(q: string, o?: unknown) => Promise<string>>(async () => '{"tool":"x"}');
     stubSession(prompt);
     await enableModel();
     await selectTool('q', SCHEMA);
@@ -878,6 +881,19 @@ assurance.
 
 It is a real rule and it still applies — it just belongs to the **consumer**, so it moves to E's
 spec as a requirement on how tool results are displayed. No task here implements it, deliberately.
+
+## Verification order matters
+
+`astro check` (run as part of `pnpm nx build personal-website`) type-checks **test files too**, so
+the suite must satisfy the app's strict TypeScript config — not merely run green under Vitest,
+whose transform does not type-check.
+
+Each task above verifies with `nx test` alone, which is correct for the TDD loop but means a
+type-only defect can survive several tasks before the build catches it. That happened during
+execution: the mock typing above passed every `nx test` run and only surfaced at the end.
+
+**When executing, run `pnpm nx build personal-website` after each task that touches a `.test.ts`
+file**, not just at the end.
 
 ## Definition of done
 

--- a/docs/superpowers/plans/2026-07-28-ai-capability-primitive.md
+++ b/docs/superpowers/plans/2026-07-28-ai-capability-primitive.md
@@ -16,7 +16,7 @@
 
 | File | Responsibility |
 |---|---|
-| `apps/personal-website/vitest.config.ts` | Test target for the app. Named `vitest.config.ts`, **not** `vite.config.ts`, so `@nx/vite/plugin` does not infer `build`/`serve`/`preview` targets that collide with Astro's. |
+| `apps/personal-website/vitest.config.ts` | **Already exists** (PR #224) and already yields an inferred `test` target. Modified only to switch `environment` to `jsdom`. See Task 1's correction note. |
 | `apps/personal-website/src/utils/ai/types.ts` | `AiState`, `ToolDescriptor`. No logic. |
 | `apps/personal-website/src/utils/ai/language-model.ts` | The core. Detection, session lifecycle, constrained call, bounds, probe-failure cache. |
 | `apps/personal-website/src/utils/ai/language-model.test.ts` | Unit tests against a stubbed `LanguageModel` global. |
@@ -32,47 +32,50 @@ Vue layer (`use-language-model.ts`, `AiCapability.vue`) is verified in the brows
 
 ### Task 1: Test infrastructure
 
-**Files:**
-- Create: `apps/personal-website/vitest.config.ts`
+> **Corrected 2026-07-28 during execution.** This task originally said *Create*
+> `apps/personal-website/vitest.config.ts` on the premise that the app had no test target. That
+> premise was wrong — the file has existed since commit `6212b2e` (PR #224), and Nx already
+> infers a `test` target from it. The original check missed it because in zsh
+> `ls vite.config.* vitest.config.*` aborts the whole command when the *first* glob has no match,
+> reporting "none" while the file was present.
+>
+> Landing the original content would also have **broken CI**: it dropped `passWithNoTests: true`,
+> and `pnpm nx affected -t lint test typecheck` would then fail `personal-website:test` in the
+> window before Task 3 adds the first test file.
 
-- [ ] **Step 1: Create the vitest config**
+**Files:**
+- Modify: `apps/personal-website/vitest.config.ts`
+
+- [ ] **Step 1: Make the minimal change**
+
+Change only the `environment` line, and add a comment in the voice of the existing one. Keep
+`include`, and keep `passWithNoTests: true` **and its full comment** — that comment records a real
+decision from PR #224 and is still accurate.
 
 ```typescript
-import { defineConfig } from 'vitest/config';
-
-// Deliberately `vitest.config.ts` and not `vite.config.ts`: @nx/vite/plugin infers
-// build/serve/preview targets from `vite.config.*`, which would collide with the Astro-based
-// `build` and `dev` targets declared in package.json. @nx/vitest infers only `test` from this
-// filename. Astro's own Vite config stays in astro.config.mjs and is untouched.
-export default defineConfig({
-  root: __dirname,
-  cacheDir: '../../node_modules/.vite/apps/personal-website',
-  test: {
-    watch: false,
-    globals: true,
-    // jsdom, not node: the capability core caches a probe failure in sessionStorage.
+    // jsdom rather than node: the on-device AI capability core (src/utils/ai/) caches a
+    // failed capability probe in sessionStorage, which node's environment doesn't provide.
     environment: 'jsdom',
-    include: ['src/**/*.test.ts'],
-    reporters: ['default'],
-    coverage: {
-      reportsDirectory: '../../coverage/apps/personal-website',
-      provider: 'v8',
-    },
-  },
-});
 ```
 
-- [ ] **Step 2: Verify Nx infers the test target**
+Do **not** add `root`, `cacheDir`, `watch`, `globals`, `reporters` or `coverage`. Nothing needs
+them — the tests import `describe`/`it`/`expect` explicitly from `vitest`, so `globals` is
+unnecessary — and churning a working config for cosmetics is not worth it.
 
-Run: `pnpm nx show project personal-website --json | python3 -c "import json,sys; print(sorted(json.load(sys.stdin)['targets']))"`
+- [ ] **Step 2: Verify nothing regressed**
 
-Expected: output includes `test` alongside `build` and `dev`.
+Run: `pnpm nx test personal-website`
+Expected: PASS. It reports no test files; `passWithNoTests` keeps that green, which is precisely
+why it stays.
+
+Run: `pnpm nx build personal-website`
+Expected: `Complete!`
 
 - [ ] **Step 3: Commit**
 
 ```bash
 git add apps/personal-website/vitest.config.ts
-git commit -m "test(personal-website): add vitest config so the app can unit-test"
+git commit -m "test(personal-website): run app tests in jsdom for the AI capability core"
 ```
 
 ---

--- a/docs/superpowers/plans/2026-07-28-ai-capability-primitive.md
+++ b/docs/superpowers/plans/2026-07-28-ai-capability-primitive.md
@@ -605,6 +605,12 @@ git commit -m "feat(ai): release the model session explicitly"
 
 ### Task 7: WebMCP registration
 
+> **Revised 2026-07-28 during execution.** The signature below took a required `AbortSignal`;
+> it now owns its own `AbortController` and returns `{ registered, dispose }`. See the spec's §8
+> revision note for why — in short, a required signal makes callers *look* responsible without
+> making them *be* responsible. The code blocks in this task are superseded by the shipped
+> implementation in `apps/personal-website/src/utils/ai/webmcp.ts`.
+
 **Files:**
 - Create: `apps/personal-website/src/utils/ai/webmcp.ts`
 - Create: `apps/personal-website/src/utils/ai/webmcp.test.ts`

--- a/docs/superpowers/specs/2026-07-28-ai-capability-primitive-design.md
+++ b/docs/superpowers/specs/2026-07-28-ai-capability-primitive-design.md
@@ -1,0 +1,139 @@
+# On-Device AI Capability Primitive (E0) — Design Spec
+
+- **Date:** 2026-07-28
+- **Branch:** `claude/ai-capability-primitive`
+- **Status:** Design approved in brainstorming; pending written-spec review → implementation plan.
+- **Chain:** step **E0** of [2026-07-27-browser-ai-chain-design.md](./2026-07-27-browser-ai-chain-design.md). A is merged (#255).
+
+## 1. Goal
+
+One module owning every fragile part of Chrome's Prompt API, consumed by both the ⌘K command
+palette (**E**) and the blog demos (**D**). Built once so the two cannot diverge on
+unsupported-browser behaviour — the failure this step exists to prevent is two different "your
+browser can't do this" experiences on the same site.
+
+E0 ships **plumbing, not content**. It knows which state the browser is in and what may legally be
+called in that state. It does not know what a tool is, what the palette looks like, or what the
+fallback says.
+
+### Decisions locked in brainstorming
+
+1. **Framework-agnostic core + thin Vue adapter.** Both current consumers are Vue, but the
+   portfolio library is React and the prior implementation this design derives from was React, so
+   the core carries no framework import.
+2. **⌘K degrades to deterministic search, not to an apology.** The palette is a fuzzy search over
+   `@rainforest-dev/personal-data` that works everywhere; on-device AI is an *upgrade* that adds
+   natural-language querying. This makes the unsupported path a working feature rather than a
+   recorded video, and it is why E0's fallback slot is cheap.
+3. **Feature detection only — no UA sniffing.** See §4; this reverses an earlier assumption and the
+   reversal is load-bearing.
+
+## 2. Module layout
+
+`apps/personal-website/src/utils/ai/`
+
+| File | Responsibility |
+|---|---|
+| `language-model.ts` | Framework-agnostic core. No Vue import. Owns detection, session lifecycle, the constrained call, and bounds. |
+| `use-language-model.ts` | Vue composable exposing the core as refs, plus lifecycle cleanup. |
+| `AiCapability.vue` | Slot-per-state wrapper. Maps `AiState` to whichever slot the consumer supplied. |
+
+`@types/dom-chromium-ai` is already in `apps/personal-website/tsconfig.json`'s `types` array, so
+`LanguageModel` is an ambient global. No import and no `declare global` shim.
+
+## 3. State machine
+
+One discriminated union — the only thing consumers switch on.
+
+```ts
+type AiState =
+  | { kind: 'unsupported' }                    // no global, or the constraint probe failed
+  | { kind: 'unavailable' }                    // availability() === 'unavailable' (hardware)
+  | { kind: 'downloadable' }                   // present and runnable, needs a gesture
+  | { kind: 'downloading'; progress: number }  // monitor → downloadprogress
+  | { kind: 'ready' };
+```
+
+`unsupported` and `unavailable` are kept distinct because they are different sentences to a user
+("this browser can't", versus "this machine can't") and because only the first is worth re-probing
+in a different browser.
+
+## 4. Detection is a first-use guard, not a pre-flight check
+
+The capability ladder has three rungs and **the third cannot be climbed early**:
+
+1. `typeof LanguageModel !== 'undefined'` — synchronous, free.
+2. `await LanguageModel.availability()` → `unavailable | downloadable | downloading | available` —
+   async, free, no session required.
+3. Does `responseConstraint` actually work? **Only answerable by prompting**, which requires a
+   session, which requires the model to be downloaded, which requires a user gesture.
+
+So rung 3 runs on **first real use**, after `ready`. If the constrained call fails, E0 transitions
+to `unsupported` *after* having reported `ready`, and caches that per session
+(`sessionStorage`, keyed by a version string so a browser update re-probes).
+
+Consumers must therefore tolerate a `ready → unsupported` transition mid-flight. This is the
+single most important thing to get right: a palette that renders "ready" and then throws on the
+first query is a worse experience than one that never claimed to be ready.
+
+**Why no UA gate.** An earlier design gated on `!/Edg\//.test(ua)` because Edge's `prompt()`
+rejects the `tool` role. That gate was correct for a *tool-role round-trip* architecture, which
+this design does not use — tool selection is a single `responseConstraint` call whose result is
+executed in JS, and Edge's documentation confirms `responseConstraint` (JSON schema or regex) is
+supported. A UA denylist would exclude a browser that can probably run this, and would rot as
+engines change. Feature detection is self-correcting; a regex is not.
+
+## 5. Public surface
+
+```ts
+detectCapability(): Promise<AiState>
+enableModel(onProgress?: (p: number) => void): Promise<void>
+selectTool<T>(query: string, schema: object, opts?: { signal?: AbortSignal }): Promise<T>
+destroy(): void
+```
+
+- **`enableModel()` must be called synchronously from a click handler.** The first `create()`
+  triggers a multi-hundred-MB download and throws `NotAllowedError` outside a user gesture. It
+  cannot be called on ⌘K-open or on keystroke. Consumers wire it to an explicit control.
+- **`selectTool()` is one constrained call per turn.** It returns schema-valid JSON by
+  construction; there is no parse step to fail.
+
+## 6. Rules E0 enforces
+
+Encoded in the module so consumers cannot get them wrong individually:
+
+| Rule | Why |
+|---|---|
+| One constrained call per turn; no multi-step loops | Multi-step is unreliable, and each call lengthens the main-thread freeze |
+| Wall-clock timeout on every run, via `AbortSignal` | On-device inference is single-threaded; a `setTimeout` watchdog cannot fire while the thread is blocked |
+| `session.destroy()` on unmount / navigation | Sessions hold the model in memory; the platform guide requires explicit release |
+| Model output is **untrusted** — `textContent`, never `innerHTML` | Marked MANDATORY by the platform guidance; output can contain injected markup |
+| Output pinned to English via `expectedOutputs` | Non-English output is unreliable on the current on-device models |
+
+## 7. Fallback contract
+
+`<AiCapability>` exposes one named slot per `AiState` kind. E0 supplies no copy and no assets — D
+produces the recorded demo later, and can only do so once E works.
+
+Because ⌘K degrades to deterministic search (§1, decision 2), the `unsupported` slot's default is
+the plain search UI. The recording is for the blog post's *demos*, not a crutch for the palette.
+
+## 8. Out of scope
+
+- The tool catalog and its descriptors — that is **E**, and it must be shared with
+  `src/mcp/profile.ts` so the remote MCP surface and the local palette cannot drift.
+- Server-model fallback, streaming chat UI, multi-step agent loops — excluded by the chain spec.
+- **WebMCP (`document.modelContext`)** — registering the same tools for external agents is a
+  genuinely attractive second consumer, but the descriptors belong to E. Revisit once E exists.
+
+## 9. Testing
+
+- Core is framework-agnostic, so it unit-tests under Vitest with a stubbed `LanguageModel` global.
+- Cover each ladder rung: absent global; `availability()` returning each value; a successful probe;
+  and **a probe that fails after `ready`**, which is the transition most likely to regress.
+- `enableModel()` outside a gesture must surface `NotAllowedError` rather than hanging.
+- Real-browser behaviour is verified in D, not here.
+
+## 10. Next step
+
+Implementation plan for E0, then **E** (⌘K palette) consuming it.

--- a/docs/superpowers/specs/2026-07-28-ai-capability-primitive-design.md
+++ b/docs/superpowers/specs/2026-07-28-ai-capability-primitive-design.md
@@ -144,8 +144,14 @@ Chrome 150, Edge 150 and Chromium 148 (§4). So E0 carries the *mechanism*, feat
 inert today, and gains a real consumer the moment the API lands.
 
 ```ts
-registerAgentTools(tools: ToolDescriptor[], signal: AbortSignal): boolean
+registerAgentTools(tools: ToolDescriptor[]): { registered: boolean; dispose: () => void }
 ```
+
+> **Revised 2026-07-28 during implementation.** This originally took a required `AbortSignal`.
+> A required parameter only catches *"forgot to pass anything"* — it does nothing about
+> `registerAgentTools(tools, new AbortController().signal)`, which type-checks and leaks exactly
+> as much as passing nothing. Owning the controller and returning `dispose` means a caller cannot
+> forget to abort a controller it never created.
 
 - Returns `false` and no-ops when `document.modelContext` is undefined. Never throws, never blocks
   startup, and is not part of the `AiState` machine — WebMCP availability is orthogonal to whether

--- a/docs/superpowers/specs/2026-07-28-ai-capability-primitive-design.md
+++ b/docs/superpowers/specs/2026-07-28-ai-capability-primitive-design.md
@@ -79,9 +79,23 @@ first query is a worse experience than one that never claimed to be ready.
 **Why no UA gate.** An earlier design gated on `!/Edg\//.test(ua)` because Edge's `prompt()`
 rejects the `tool` role. That gate was correct for a *tool-role round-trip* architecture, which
 this design does not use — tool selection is a single `responseConstraint` call whose result is
-executed in JS, and Edge's documentation confirms `responseConstraint` (JSON schema or regex) is
-supported. A UA denylist would exclude a browser that can probably run this, and would rot as
-engines change. Feature detection is self-correcting; a regex is not.
+executed in JS, and Edge documents `responseConstraint` (JSON schema or regex) as supported.
+
+Measured on 2026-07-28 rather than assumed, on this machine, default profiles, no flags:
+
+| Global | Chrome 150 stable | Edge 150 stable | Chromium 148 (in-app) |
+|---|---|---|---|
+| `LanguageModel` | ✅ | ❌ | ✅ (`availability()` → `downloadable`) |
+| `document.modelContext` | ❌ | ❌ | ❌ |
+| `Summarizer` / `Translator` / `LanguageDetector` | ✅ | ✅ | ✅ |
+| `Writer` / `Rewriter` / `Proofreader` | ❌ | ❌ | — |
+
+**Stable Edge does not expose `LanguageModel` at all** — the Prompt API remains Canary/Dev behind a
+flag. So a UA gate would have excluded a browser that already excludes itself, while risking a
+wrong answer the moment Edge ships. Feature detection is self-correcting; a regex is not.
+
+(`availability()` does not resolve under `--headless`, so the trustworthy reading is the
+non-headless `downloadable`. Headless numbers are not evidence of real-world availability.)
 
 ## 5. Public surface
 
@@ -118,22 +132,52 @@ produces the recorded demo later, and can only do so once E works.
 Because ⌘K degrades to deterministic search (§1, decision 2), the `unsupported` slot's default is
 the plain search UI. The recording is for the blog post's *demos*, not a crutch for the palette.
 
-## 8. Out of scope
+## 8. WebMCP — designed for, not depended on
 
-- The tool catalog and its descriptors — that is **E**, and it must be shared with
-  `src/mcp/profile.ts` so the remote MCP surface and the local palette cannot drift.
+`document.modelContext.registerTool()` (WebMCP) lets a page expose client-side JS functions as
+tools to external agents. That makes it a natural second consumer of the same descriptors the
+palette uses: one catalog would then serve the local model, remote MCP clients via
+`src/pages/mcp.ts`, and browser agents.
+
+**It does not exist in any browser available to test** — `document.modelContext` is `false` in
+Chrome 150, Edge 150 and Chromium 148 (§4). So E0 carries the *mechanism*, feature-detected and
+inert today, and gains a real consumer the moment the API lands.
+
+```ts
+registerAgentTools(tools: ToolDescriptor[], signal: AbortSignal): boolean
+```
+
+- Returns `false` and no-ops when `document.modelContext` is undefined. Never throws, never blocks
+  startup, and is not part of the `AiState` machine — WebMCP availability is orthogonal to whether
+  the *local* model can run, and conflating them would let one break the other.
+- **Unregistration is via `AbortSignal` only** — WebMCP has no `unregisterTool()`. E0 owns that
+  lifecycle so consumers cannot leak registrations across route changes.
+- `inputSchema` is JSON Schema — the *same shape* `selectTool()` passes as `responseConstraint`.
+  This is the reason to build both here: one descriptor type feeds local constrained decoding and
+  remote agent registration, so they cannot drift.
+
+The **descriptors themselves remain E's**, along with their `execute` implementations over
+`@rainforest-dev/personal-data`. E0 defines only the `ToolDescriptor` type and the registration
+plumbing.
+
+## 9. Out of scope
+
+- The tool catalog's contents and `execute` bodies — that is **E**, and the catalog must be shared
+  with `src/mcp/profile.ts` so the remote MCP surface and the local palette cannot drift.
 - Server-model fallback, streaming chat UI, multi-step agent loops — excluded by the chain spec.
-- **WebMCP (`document.modelContext`)** — registering the same tools for external agents is a
-  genuinely attractive second consumer, but the descriptors belong to E. Revisit once E exists.
+- The task-specific APIs (`Summarizer`, `Translator`, `LanguageDetector`) — present in both Chrome
+  and Edge stable per §4, and worth their own step later, but not part of this primitive.
 
-## 9. Testing
+## 10. Testing
 
 - Core is framework-agnostic, so it unit-tests under Vitest with a stubbed `LanguageModel` global.
 - Cover each ladder rung: absent global; `availability()` returning each value; a successful probe;
   and **a probe that fails after `ready`**, which is the transition most likely to regress.
 - `enableModel()` outside a gesture must surface `NotAllowedError` rather than hanging.
+- `registerAgentTools()` must return `false` and no-op with `document.modelContext` undefined —
+  which is every browser today, so this is the default path, not an edge case.
 - Real-browser behaviour is verified in D, not here.
 
-## 10. Next step
+## 11. Next step
 
 Implementation plan for E0, then **E** (⌘K palette) consuming it.

--- a/docs/superpowers/specs/2026-07-28-ai-capability-primitive-design.md
+++ b/docs/superpowers/specs/2026-07-28-ai-capability-primitive-design.md
@@ -22,7 +22,7 @@ fallback says.
    portfolio library is React and the prior implementation this design derives from was React, so
    the core carries no framework import.
 2. **⌘K degrades to deterministic search, not to an apology.** The palette is a fuzzy search over
-   `@rainforest-dev/personal-data` that works everywhere; on-device AI is an *upgrade* that adds
+   `@rainforest-dev/personal-data` that works everywhere; on-device AI is an _upgrade_ that adds
    natural-language querying. This makes the unsupported path a working feature rather than a
    recorded video, and it is why E0's fallback slot is cheap.
 3. **Feature detection only — no UA sniffing.** See §4; this reverses an earlier assumption and the
@@ -32,11 +32,11 @@ fallback says.
 
 `apps/personal-website/src/utils/ai/`
 
-| File | Responsibility |
-|---|---|
-| `language-model.ts` | Framework-agnostic core. No Vue import. Owns detection, session lifecycle, the constrained call, and bounds. |
-| `use-language-model.ts` | Vue composable exposing the core as refs, plus lifecycle cleanup. |
-| `AiCapability.vue` | Slot-per-state wrapper. Maps `AiState` to whichever slot the consumer supplied. |
+| File                    | Responsibility                                                                                               |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `language-model.ts`     | Framework-agnostic core. No Vue import. Owns detection, session lifecycle, the constrained call, and bounds. |
+| `use-language-model.ts` | Vue composable exposing the core as refs, plus lifecycle cleanup.                                            |
+| `AiCapability.vue`      | Slot-per-state wrapper. Maps `AiState` to whichever slot the consumer supplied.                              |
 
 `@types/dom-chromium-ai` is already in `apps/personal-website/tsconfig.json`'s `types` array, so
 `LanguageModel` is an ambient global. No import and no `declare global` shim.
@@ -47,10 +47,10 @@ One discriminated union — the only thing consumers switch on.
 
 ```ts
 type AiState =
-  | { kind: 'unsupported' }                    // no global, or the constraint probe failed
-  | { kind: 'unavailable' }                    // availability() === 'unavailable' (hardware)
-  | { kind: 'downloadable' }                   // present and runnable, needs a gesture
-  | { kind: 'downloading'; progress: number }  // monitor → downloadprogress
+  | { kind: 'unsupported' } // no global, or the constraint probe failed
+  | { kind: 'unavailable' } // availability() === 'unavailable' (hardware)
+  | { kind: 'downloadable' } // present and runnable, needs a gesture
+  | { kind: 'downloading'; progress: number } // monitor → downloadprogress
   | { kind: 'ready' };
 ```
 
@@ -69,7 +69,7 @@ The capability ladder has three rungs and **the third cannot be climbed early**:
    session, which requires the model to be downloaded, which requires a user gesture.
 
 So rung 3 runs on **first real use**, after `ready`. If the constrained call fails, E0 transitions
-to `unsupported` *after* having reported `ready`, and caches that per session
+to `unsupported` _after_ having reported `ready`, and caches that per session
 (`sessionStorage`, keyed by a version string so a browser update re-probes).
 
 Consumers must therefore tolerate a `ready → unsupported` transition mid-flight. This is the
@@ -77,18 +77,18 @@ single most important thing to get right: a palette that renders "ready" and the
 first query is a worse experience than one that never claimed to be ready.
 
 **Why no UA gate.** An earlier design gated on `!/Edg\//.test(ua)` because Edge's `prompt()`
-rejects the `tool` role. That gate was correct for a *tool-role round-trip* architecture, which
+rejects the `tool` role. That gate was correct for a _tool-role round-trip_ architecture, which
 this design does not use — tool selection is a single `responseConstraint` call whose result is
 executed in JS, and Edge documents `responseConstraint` (JSON schema or regex) as supported.
 
 Measured on 2026-07-28 rather than assumed, on this machine, default profiles, no flags:
 
-| Global | Chrome 150 stable | Edge 150 stable | Chromium 148 (in-app) |
-|---|---|---|---|
-| `LanguageModel` | ✅ | ❌ | ✅ (`availability()` → `downloadable`) |
-| `document.modelContext` | ❌ | ❌ | ❌ |
-| `Summarizer` / `Translator` / `LanguageDetector` | ✅ | ✅ | ✅ |
-| `Writer` / `Rewriter` / `Proofreader` | ❌ | ❌ | — |
+| Global                                           | Chrome 150 stable | Edge 150 stable | Chromium 148 (in-app)                  |
+| ------------------------------------------------ | ----------------- | --------------- | -------------------------------------- |
+| `LanguageModel`                                  | ✅                | ❌              | ✅ (`availability()` → `downloadable`) |
+| `document.modelContext`                          | ❌                | ❌              | ❌                                     |
+| `Summarizer` / `Translator` / `LanguageDetector` | ✅                | ✅              | ✅                                     |
+| `Writer` / `Rewriter` / `Proofreader`            | ❌                | ❌              | —                                      |
 
 **Stable Edge does not expose `LanguageModel` at all** — the Prompt API remains Canary/Dev behind a
 flag. So a UA gate would have excluded a browser that already excludes itself, while risking a
@@ -116,13 +116,13 @@ destroy(): void
 
 Encoded in the module so consumers cannot get them wrong individually:
 
-| Rule | Why |
-|---|---|
-| One constrained call per turn; no multi-step loops | Multi-step is unreliable, and each call lengthens the main-thread freeze |
-| Wall-clock timeout on every run, via `AbortSignal` | On-device inference is single-threaded; a `setTimeout` watchdog cannot fire while the thread is blocked |
-| `session.destroy()` on unmount / navigation | Sessions hold the model in memory; the platform guide requires explicit release |
-| Model output is **untrusted** — `textContent`, never `innerHTML` | Marked MANDATORY by the platform guidance; output can contain injected markup |
-| Output pinned to English via `expectedOutputs` | Non-English output is unreliable on the current on-device models |
+| Rule                                                             | Why                                                                                                     |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| One constrained call per turn; no multi-step loops               | Multi-step is unreliable, and each call lengthens the main-thread freeze                                |
+| Wall-clock timeout on every run, via `AbortSignal`               | On-device inference is single-threaded; a `setTimeout` watchdog cannot fire while the thread is blocked |
+| `session.destroy()` on unmount / navigation                      | Sessions hold the model in memory; the platform guide requires explicit release                         |
+| Model output is **untrusted** — `textContent`, never `innerHTML` | Marked MANDATORY by the platform guidance; output can contain injected markup                           |
+| Output pinned to English via `expectedOutputs`                   | Non-English output is unreliable on the current on-device models                                        |
 
 ## 7. Fallback contract
 
@@ -130,7 +130,7 @@ Encoded in the module so consumers cannot get them wrong individually:
 produces the recorded demo later, and can only do so once E works.
 
 Because ⌘K degrades to deterministic search (§1, decision 2), the `unsupported` slot's default is
-the plain search UI. The recording is for the blog post's *demos*, not a crutch for the palette.
+the plain search UI. The recording is for the blog post's _demos_, not a crutch for the palette.
 
 ## 8. WebMCP — designed for, not depended on
 
@@ -140,7 +140,7 @@ palette uses: one catalog would then serve the local model, remote MCP clients v
 `src/pages/mcp.ts`, and browser agents.
 
 **It does not exist in any browser available to test** — `document.modelContext` is `false` in
-Chrome 150, Edge 150 and Chromium 148 (§4). So E0 carries the *mechanism*, feature-detected and
+Chrome 150, Edge 150 and Chromium 148 (§4). So E0 carries the _mechanism_, feature-detected and
 inert today, and gains a real consumer the moment the API lands.
 
 ```ts
@@ -148,17 +148,17 @@ registerAgentTools(tools: ToolDescriptor[]): { registered: boolean; dispose: () 
 ```
 
 > **Revised 2026-07-28 during implementation.** This originally took a required `AbortSignal`.
-> A required parameter only catches *"forgot to pass anything"* — it does nothing about
+> A required parameter only catches _"forgot to pass anything"_ — it does nothing about
 > `registerAgentTools(tools, new AbortController().signal)`, which type-checks and leaks exactly
 > as much as passing nothing. Owning the controller and returning `dispose` means a caller cannot
 > forget to abort a controller it never created.
 
 - Returns `false` and no-ops when `document.modelContext` is undefined. Never throws, never blocks
   startup, and is not part of the `AiState` machine — WebMCP availability is orthogonal to whether
-  the *local* model can run, and conflating them would let one break the other.
+  the _local_ model can run, and conflating them would let one break the other.
 - **Unregistration is via `AbortSignal` only** — WebMCP has no `unregisterTool()`. E0 owns that
   lifecycle so consumers cannot leak registrations across route changes.
-- `inputSchema` is JSON Schema — the *same shape* `selectTool()` passes as `responseConstraint`.
+- `inputSchema` is JSON Schema — the _same shape_ `selectTool()` passes as `responseConstraint`.
   This is the reason to build both here: one descriptor type feeds local constrained decoding and
   remote agent registration, so they cannot drift.
 


### PR DESCRIPTION
The shared layer the ⌘K palette and the blog demos will both sit on, so they can't diverge on unsupported-browser behaviour. **Ships plumbing, not content** — nothing imports the barrel yet, and no page is wired up.

Spec: `docs/superpowers/specs/2026-07-28-ai-capability-primitive-design.md` · Plan: `docs/superpowers/plans/2026-07-28-ai-capability-primitive.md`

## The idea

Capability detection is a three-rung ladder, and **the third rung can't be climbed early**:

1. Is `LanguageModel` defined — sync, free
2. `await LanguageModel.availability()` — async, free
3. Does `responseConstraint` *actually* constrain output — **only answerable by prompting**, which needs a downloaded model, which needs a user gesture

So rung 3 runs on first real use, and state can move `ready → unsupported` mid-flight. Consumers must tolerate that; a palette that renders "ready" then throws on the first query is worse than one that never claimed to be ready.

## Browser support, measured rather than assumed (2026-07-28, default profiles, no flags)

| Global | Chrome 150 | Edge 150 | Chromium 148 |
|---|---|---|---|
| `LanguageModel` | ✅ | ❌ | ✅ (`availability()` → `downloadable`) |
| `document.modelContext` (WebMCP) | ❌ | ❌ | ❌ |
| `Summarizer` / `Translator` / `LanguageDetector` | ✅ | ✅ | ✅ |

**Stable Edge exposes no `LanguageModel` at all**, so an earlier plan to gate on `!/Edg\//.test(ua)` was dropped — it would have excluded a browser that already excludes itself, and would rot the moment Edge ships. Feature detection is self-correcting; a UA regex isn't.

Worth noting for later: both browsers ship the **task-specific** APIs while withholding the general Prompt API. Those need no download and no gesture.

## Design decisions worth review

- **Framework-agnostic core + thin Vue adapter.** Both current consumers are Vue, but `libs/personal-portfolio` is React, so the core carries no framework import.
- **The palette will degrade to deterministic search, not to an apology.** That's why the fallback slot is cheap and why a recorded demo serves the blog post rather than propping up the feature.
- **`registerAgentTools` owns its `AbortController` and returns `{ registered, dispose }`.** WebMCP has no `unregisterTool()`. A required `AbortSignal` parameter only catches "forgot to pass anything" — it does nothing about `registerAgentTools(tools, new AbortController().signal)`, which type-checks and leaks identically.
- **The session is reference-counted.** One session per page; destroying on first unmount would let an embedded demo kill the palette's session on a route change, and the palette can't recover because re-enabling needs a user gesture it cannot stage.

## Verification

**24 tests · build 0 errors · lint 0 errors.**

The riskiest behaviours are mutation-checked — removing each guard fails exactly its own test and nothing else:

- `ready → unsupported` on first-call failure, including an unparseable response
- Never degrading after one success (a later error is transient, not a verdict)
- Aborts never degrading in either direction — a timeout says nothing about support
- Session survives until the **last** consumer releases; repeated release can't drive the count negative

## Known limits, recorded rather than hidden

- The `LanguageModel` stubs use `Object.defineProperty(…, { value })`, and `PropertyDescriptor.value` is typed `any` — so **the stubs are never checked against the real ambient types**. If `@types/dom-chromium-ai` is bumped and signatures drift, this suite stays green while real code breaks. Re-verify in a browser after any such bump.
- The Vue layer has no unit tests; it's verified in a real browser in the demos workstream.
- WebMCP registration is inert in every shipping browser. Built now because its `inputSchema` is JSON Schema — the same shape `selectTool()` passes as `responseConstraint` — so one descriptor serves both and they can't drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)