### PR TITLE
Close the .astro hole in the format gate

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,4 @@
 {
   "singleQuote": true,
-  "plugins": ["prettier-plugin-tailwindcss"]
+  "plugins": ["prettier-plugin-astro", "prettier-plugin-tailwindcss"]
 }

--- a/apps/personal-website/src/components/blog/navigation.astro
+++ b/apps/personal-website/src/components/blog/navigation.astro
@@ -22,19 +22,19 @@ const {
 const pathname = new URL(Astro.request.url).pathname;
 ---
 
-<div class="h-10 bg-card rounded-full shadow-lg">
+<div class="bg-card h-10 rounded-full shadow-lg">
   {
     links.map((link) => (
       <a
         href={link.path}
         class={clsx(
-          'px-4 py-2 rounded-full flex-center inline-flex relative z-0',
-          pathname === link.path && 'text-primary-foreground'
+          'flex-center relative z-0 inline-flex rounded-full px-4 py-2',
+          pathname === link.path && 'text-primary-foreground',
         )}
       >
         {pathname === link.path && (
           <span
-            class="absolute inset-0 rounded-full bg-primary"
+            class="bg-primary absolute inset-0 rounded-full"
             transition:name="active-link"
           />
         )}

--- a/apps/personal-website/src/components/blog/post.astro
+++ b/apps/personal-website/src/components/blog/post.astro
@@ -16,13 +16,17 @@ const { Content } = await render(Astro.props);
 const tags = _tags.filter((e) => !e.includes(':'));
 ---
 
-<div
-  class="w-full p-10 bg-card rounded-lg prose dark:bg-card max-w-none"
->
+<div class="bg-card prose dark:bg-card w-full max-w-none rounded-lg p-10">
   <h1>{title}</h1>
   <p>{format(pubDate, 'd MMM, yyyy')}<br />By {author.name}</p>
   <Content />
-  <div class="flex flex-wrap gap-2 mt-10">
-    {tags.map((tag) => <Badge variant="secondary" class="capitalize">{tag}</Badge>)}
+  <div class="mt-10 flex flex-wrap gap-2">
+    {
+      tags.map((tag) => (
+        <Badge variant="secondary" class="capitalize">
+          {tag}
+        </Badge>
+      ))
+    }
   </div>
 </div>

--- a/apps/personal-website/src/components/home/contact-form.astro
+++ b/apps/personal-website/src/components/home/contact-form.astro
@@ -27,7 +27,7 @@ const { t } = await useTranslation(lang);
   <Button
     as="a"
     data-contact-submit
-    class="mt-4 px-6 w-1/2 self-end"
+    class="mt-4 w-1/2 self-end px-6"
     href={`mailto:${info.email}`}>{t('contact-me-submit')}</Button
   >
 </contact-form>
@@ -38,19 +38,19 @@ const { t } = await useTranslation(lang);
   class ContactForm extends HTMLElement {
     connectedCallback() {
       const nameField = this.querySelector(
-        'input[name="name"]'
+        'input[name="name"]',
       ) as HTMLInputElement;
       const companyField = this.querySelector(
-        'input[name="company"]'
+        'input[name="company"]',
       ) as HTMLInputElement;
       const subjectField = this.querySelector(
-        'input[name="subject"]'
+        'input[name="subject"]',
       ) as HTMLInputElement;
       const messageField = this.querySelector(
-        'textarea[name="message"]'
+        'textarea[name="message"]',
       ) as HTMLTextAreaElement;
       const submitButton = this.querySelector(
-        '[data-contact-submit]'
+        '[data-contact-submit]',
       ) as HTMLAnchorElement;
 
       const handleFormChange = () => {

--- a/apps/personal-website/src/components/home/experiences/index.astro
+++ b/apps/personal-website/src/components/home/experiences/index.astro
@@ -17,8 +17,7 @@ const experiences = (
   <div class="size-full">
     <ul
       id="experiences"
-      class="flex flex-col gap-4 sm:gap-5 relative
-              after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-foreground after:left-0 after:-translate-x-1/2 after:sm:left-1/2"
+      class="after:bg-foreground relative flex flex-col gap-4 after:absolute after:left-0 after:h-full after:w-0.5 after:-translate-x-1/2 after:content-[''] sm:gap-5 after:sm:left-1/2"
     >
       {
         experiences.map((experience) => {

--- a/apps/personal-website/src/components/home/experiences/item.astro
+++ b/apps/personal-website/src/components/home/experiences/item.astro
@@ -51,7 +51,7 @@ const {Content} = await render(Astro.props)
         return icon ? (
           <iconify-icon icon={icon} class="size-5" height="none" />
         ) : (
-          <></>
+          null
         );
       })}
     </div>

--- a/apps/personal-website/src/components/home/experiences/item.astro
+++ b/apps/personal-website/src/components/home/experiences/item.astro
@@ -9,7 +9,7 @@ import Project from './project.astro';
 type Props = DataEntryMap['experiences'][string];
 
 const { data } = Astro.props;
-const { startAt, position } = data
+const { startAt, position } = data;
 
 const organization = (await getEntry(data.organization)).data;
 const projects = await getEntries(data.projects || []);
@@ -19,41 +19,41 @@ const technologies = getTopTechnologies({
     technologies: project.data.technologies,
   })),
 });
-const {Content} = await render(Astro.props)
+const { Content } = await render(Astro.props);
 ---
 
 <li
-  class="flex flex-col *:flex-1 pl-[1em] relative
-          sm:pl-0 sm:flex-row sm:items-center sm:even:flex-row-reverse sm:even:*:last:text-right sm:odd:*:first:text-right sm:gap-10"
+  class="relative flex flex-col pl-[1em] *:flex-1 sm:flex-row sm:items-center sm:gap-10 sm:pl-0 sm:odd:*:first:text-right sm:even:flex-row-reverse sm:even:*:last:text-right"
 >
   <div class="text-xs sm:text-base">
     {format(new Date(startAt), resumeDateFormat)}
   </div>
   <div
-    class="absolute size-2 bg-foreground rounded-full
-                      left-0 -translate-x-1/2 top-7 
-                      sm:top-auto sm:left-1/2 sm:-translate-x-1/2"
-  />
+    class="bg-foreground absolute left-0 top-7 size-2 -translate-x-1/2 rounded-full sm:left-1/2 sm:top-auto sm:-translate-x-1/2"
+  >
+  </div>
   <div>
     <h3 class="sm:text-2xl">{organization.name}</h3>
-    <p class="text-sm sm:text-lg text-primary/85">{position}</p>
+    <p class="text-primary/85 text-sm sm:text-lg">{position}</p>
     <Content />
     {
-      <ul>
-        {projects.map((project) => (
-          <Project {...project} />
-        ))}
-      </ul>
+      (
+        <ul>
+          {projects.map((project) => (
+            <Project {...project} />
+          ))}
+        </ul>
+      )
     }
-    <div class="inline-flex gap-2 mt-4">
-      {technologies.map((tag) => {
-        const icon = getBrandIconName(tag);
-        return icon ? (
-          <iconify-icon icon={icon} class="size-5" height="none" />
-        ) : (
-          null
-        );
-      })}
+    <div class="mt-4 inline-flex gap-2">
+      {
+        technologies.map((tag) => {
+          const icon = getBrandIconName(tag);
+          return icon ? (
+            <iconify-icon icon={icon} class="size-5" height="none" />
+          ) : null;
+        })
+      }
     </div>
   </div>
 </li>

--- a/apps/personal-website/src/components/home/experiences/project.astro
+++ b/apps/personal-website/src/components/home/experiences/project.astro
@@ -20,7 +20,7 @@ const { Content } = await render(Astro.props);
 <li
   class="**:[li]:list-disc **:[li]:list-inside **:[li]:text-xs sm:**:[li]:text-base"
 >
-  <h4 class="text-sm mb-0.5 mt-2 sm:text-lg sm:mb-1.5 sm:mt-3">
+  <h4 class="mb-0.5 mt-2 text-sm sm:mb-1.5 sm:mt-3 sm:text-lg">
     {
       caseStudyHref ? (
         <a href={caseStudyHref} class="text-primary hover:underline">

--- a/apps/personal-website/src/components/home/footer.astro
+++ b/apps/personal-website/src/components/home/footer.astro
@@ -4,7 +4,7 @@ import Links from './links.astro';
 ---
 
 <footer
-  class="container md:flex flex-wrap gap-10 hidden justify-between pt-10 pb-20"
+  class="container hidden flex-wrap justify-between gap-10 pb-20 pt-10 md:flex"
 >
   <Links />
   <ContactForm id="contact-form-footer" />

--- a/apps/personal-website/src/components/home/hero/one-column.astro
+++ b/apps/personal-website/src/components/home/hero/one-column.astro
@@ -17,11 +17,11 @@ const { t } = await useTranslation(lang, 'home');
 const translatePath = useTranslatedPath(lang);
 ---
 
-<div class="flex flex-col size-full">
+<div class="flex size-full flex-col">
   <div class="relative aspect-square max-h-[600px]">
     <div
       id="hero-dark-panel"
-      class="size-full bg-foreground rounded-b-3xl origin-top-right skew-y-12 overflow-clip absolute top-0 z-0"
+      class="bg-foreground absolute top-0 z-0 size-full origin-top-right skew-y-12 overflow-clip rounded-b-3xl"
     >
       <Picture
         src={props.profile}
@@ -32,20 +32,20 @@ const translatePath = useTranslatedPath(lang);
           class:
             'h-full z-10 absolute -bottom-10 md:-bottom-20 left-1/2 -translate-x-1/2 ',
         }}
-        class="object-cover object-top -skew-y-12 size-full"
+        class="size-full -skew-y-12 object-cover object-top"
       />
     </div>
     <div
-      class="text-9xl text-background/50 rotate-270 origin-bottom inline-block m-4"
+      class="text-background/50 rotate-270 m-4 inline-block origin-bottom text-9xl"
     >
       {year}
     </div>
   </div>
-  <div class="flex container">
-    <div class="flex flex-col w-full">
-      <div class="flex-row-center justify-between flex-wrap gap-2">
+  <div class="container flex">
+    <div class="flex w-full flex-col">
+      <div class="flex-row-center flex-wrap justify-between gap-2">
         <div>
-          <h1 class="text-4xl text-secondary-foreground">
+          <h1 class="text-secondary-foreground text-4xl">
             {props.name.first}
           </h1>
           <p>{props.jobPosition}</p>
@@ -54,20 +54,19 @@ const translatePath = useTranslatedPath(lang);
           <Button
             id="contact-me-button"
             href="#contact-form-footer"
-            class="px-6"
-            >{t('contact-me-title')}</Button
+            class="px-6">{t('contact-me-title')}</Button
           >
           <Button
             variant="outline"
             href={translatePath('/resume')}
             target="_blank"
-            class="px-6 gap-2"
+            class="gap-2 px-6"
             >{t('resume')}
             <Icon icon={ExternalLink} />
           </Button>
         </div>
       </div>
-      <ul class="list-disc list-inside mt-4">
+      <ul class="mt-4 list-inside list-disc">
         {props.summaries.map((summary) => <li>{summary}</li>)}
       </ul>
     </div>
@@ -79,9 +78,11 @@ const translatePath = useTranslatedPath(lang);
   import { removeUrlHashAfterNavigation } from '@utils';
 
   const contactMeButton = document.getElementById(
-    'contact-me-button'
+    'contact-me-button',
   ) as HTMLAnchorElement;
-  const menuButton = document.getElementById('menu-trigger') as HTMLButtonElement;
+  const menuButton = document.getElementById(
+    'menu-trigger',
+  ) as HTMLButtonElement;
   const handleOpenContactForm = () => {
     menuButton?.click();
   };
@@ -113,7 +114,7 @@ const translatePath = useTranslatedPath(lang);
   };
 
   const breakpointMd = getComputedStyle(
-    document.documentElement
+    document.documentElement,
   ).getPropertyValue('--breakpoint-md');
   handleMatches(window.matchMedia(`(max-width: ${breakpointMd})`).matches);
   window

--- a/apps/personal-website/src/components/home/hero/three-columns.astro
+++ b/apps/personal-website/src/components/home/hero/three-columns.astro
@@ -18,18 +18,17 @@ const translatePath = useTranslatedPath(lang);
 ---
 
 <div
-  class="h-3/4 w-full flex-row-center justify-between py-10 px-20 relative z-0 rounded-xl shadow-lg"
+  class="flex-row-center relative z-0 h-3/4 w-full justify-between rounded-xl px-20 py-10 shadow-lg"
 >
-  <div class="absolute -z-10 inset-0 rounded-[inherit] overflow-clip">
+  <div class="absolute inset-0 -z-10 overflow-clip rounded-[inherit]">
     <div
-      class="size-full relative z-0 bg-muted overflow-clip
-                  after:bg-foreground after:h-full after:w-1/2 after:absolute after:-skew-x-[45deg] after:scale-200 after:-z-10 after:-right-1/4 after:top-0"
+      class="bg-muted after:bg-foreground after:scale-200 relative z-0 size-full overflow-clip after:absolute after:-right-1/4 after:top-0 after:-z-10 after:h-full after:w-1/2 after:-skew-x-[45deg]"
     >
     </div>
   </div>
   <div class="flex flex-col justify-center">
     <p>{year}</p>
-    <h1 class="text-7xl mt-1 mb-16 text-secondary-foreground">
+    <h1 class="text-secondary-foreground mb-16 mt-1 text-7xl">
       {props.name.fullname}
     </h1>
     <div class="flex-row-center gap-4">
@@ -40,7 +39,7 @@ const translatePath = useTranslatedPath(lang);
         variant="outline"
         href={translatePath('/resume')}
         target="_blank"
-        class="px-6 gap-2"
+        class="gap-2 px-6"
         >{t('resume')}
         <Icon icon={ExternalLink} />
       </Button>
@@ -54,9 +53,9 @@ const translatePath = useTranslatedPath(lang);
     pictureAttributes={{
       class: 'self-end -mb-10 h-[120%] w-full',
     }}
-    class="object-cover object-center h-full w-max mx-auto"
+    class="mx-auto h-full w-max object-cover object-center"
   />
-  <div class="flex flex-col justify-center text-background gap-6">
+  <div class="text-background flex flex-col justify-center gap-6">
     <ul class="list-disc">
       <li>
         {t('home:hero-brief')}
@@ -79,7 +78,7 @@ const translatePath = useTranslatedPath(lang);
   import { removeUrlHashAfterNavigation } from '@utils';
 
   const contactMeButton = document.querySelector(
-    'a[href="#contact-form-footer"]'
+    'a[href="#contact-form-footer"]',
   );
   contactMeButton?.addEventListener('click', removeUrlHashAfterNavigation);
 </script>

--- a/apps/personal-website/src/components/pages/CaseStudyPage.astro
+++ b/apps/personal-website/src/components/pages/CaseStudyPage.astro
@@ -38,14 +38,19 @@ const forceScheme =
       <article data-project={study.slug} class="mx-auto max-w-4xl px-6 py-20">
         <a
           href={portfolioHref}
-          class="group text-foreground/60 hover:text-foreground inline-flex items-center gap-1.5 text-sm transition-colors"
+          class="text-foreground/60 hover:text-foreground group inline-flex items-center gap-1.5 text-sm transition-colors"
         >
-          <span aria-hidden="true" class="transition-transform group-hover:-translate-x-0.5">
+          <span
+            aria-hidden="true"
+            class="transition-transform group-hover:-translate-x-0.5"
+          >
             ←
           </span>{' '}
           {t('back')}
         </a>
-        <p class="text-primary/70 mt-8 text-xs uppercase tracking-widest">{t('case-study')}</p>
+        <p class="text-primary/70 mt-8 text-xs uppercase tracking-widest">
+          {t('case-study')}
+        </p>
         <h1 transition:name={`case-study-${study.slug}`} class="mt-2 text-5xl">
           {study.title}
         </h1>
@@ -55,7 +60,9 @@ const forceScheme =
         <p class="mt-6 max-w-2xl">{study.tagline}</p>
         <ul class="mt-6 flex flex-wrap gap-2">
           {study.stack.map((tech) => (
-            <li class="bg-primary/10 text-primary rounded px-3 py-1 text-sm">{tech}</li>
+            <li class="bg-primary/10 text-primary rounded px-3 py-1 text-sm">
+              {tech}
+            </li>
           ))}
         </ul>
         <CaseStudyGallery images={getProjectGallery(study.slug)} />

--- a/apps/personal-website/src/components/pages/HomePage.astro
+++ b/apps/personal-website/src/components/pages/HomePage.astro
@@ -25,7 +25,7 @@ interface Props {
 const { lang } = Astro.props;
 
 const profiles = import.meta.glob<{ default: ImageMetadata }>(
-  '/src/assets/images/profile/*.{jpeg,jpg,png,gif,webp}'
+  '/src/assets/images/profile/*.{jpeg,jpg,png,gif,webp}',
 );
 // randomly select a image from dict
 const profile =
@@ -85,7 +85,7 @@ const skills = (
 ).sort(
   (a, b) =>
     Number(b.data.tags.includes('prioritized')) -
-    Number(a.data.tags.includes('prioritized'))
+    Number(a.data.tags.includes('prioritized')),
 );
 
 // schema.org WebSite + Person for the home — the primary page humans and AI agents
@@ -126,34 +126,34 @@ const homeSchema = {
       </Fragment>
     </Nav>
     <!-- hero -->
-    <section class="flex-center container h-screen xl:flex hidden">
+    <section class="flex-center container hidden h-screen xl:flex">
       <ThreeColumns {...heroProps} />
     </section>
-    <section class="flex xl:hidden w-full min-h-screen">
+    <section class="flex min-h-screen w-full xl:hidden">
       <OneColumns {...heroProps} />
     </section>
     <!-- experience -->
     <section id="experience" class="py-10">
-      <div class="container flex-col-center size-full">
-        <h2 class="text-4xl mb-10">{t('experience')}</h2>
+      <div class="flex-col-center container size-full">
+        <h2 class="mb-10 text-4xl">{t('experience')}</h2>
         <Experiences />
       </div>
     </section>
-    <section id="skills" class="py-10 min-h-screen flex flex-col">
-      <div class="container grow min-h-[90vh]">
-        <h2 class="text-4xl mb-10">{t('skills')}</h2>
-        <ul class="grid md:grid-cols-2 xl:grid-cols-3 gap-4 xl:gap-8">
+    <section id="skills" class="flex min-h-screen flex-col py-10">
+      <div class="container min-h-[90vh] grow">
+        <h2 class="mb-10 text-4xl">{t('skills')}</h2>
+        <ul class="grid gap-4 md:grid-cols-2 xl:grid-cols-3 xl:gap-8">
           {
             skills.map(async (skill) => {
               const { Content } = await render(skill);
               if (!skill.body) return null;
               return (
-                <li class="min-w-80 bg-card text-foreground px-5 py-4 rounded min-h-80 shadow-lg flex flex-col gap-5 relative **:[li]:list-disc **:[li]:list-inside">
+                <li class="bg-card text-foreground **:[li]:list-disc **:[li]:list-inside relative flex min-h-80 min-w-80 flex-col gap-5 rounded px-5 py-4 shadow-lg">
                   <h3 class="text-xl capitalize">{skill.data.name}</h3>
                   <Content />
                   <iconify-icon
                     icon={getBrandIconName(skill.data.icon)}
-                    class="absolute right-5 bottom-4 size-12"
+                    class="absolute bottom-4 right-5 size-12"
                     height="none"
                   />
                 </li>
@@ -171,7 +171,7 @@ const homeSchema = {
       @apply snap-y snap-mandatory overscroll-none scroll-smooth;
     }
     main > section {
-      @apply snap-always snap-start;
+      @apply snap-start snap-always;
     }
   </style>
 </Layout>

--- a/apps/personal-website/src/components/pages/HomePage.astro
+++ b/apps/personal-website/src/components/pages/HomePage.astro
@@ -146,7 +146,7 @@ const homeSchema = {
           {
             skills.map(async (skill) => {
               const { Content } = await render(skill);
-              if (!skill.body) return <></>;
+              if (!skill.body) return null;
               return (
                 <li class="min-w-80 bg-card text-foreground px-5 py-4 rounded min-h-80 shadow-lg flex flex-col gap-5 relative **:[li]:list-disc **:[li]:list-inside">
                   <h3 class="text-xl capitalize">{skill.data.name}</h3>

--- a/apps/personal-website/src/components/pages/PortfolioIndexPage.astro
+++ b/apps/personal-website/src/components/pages/PortfolioIndexPage.astro
@@ -2,8 +2,14 @@
 import '@rainforest-dev/personal-portfolio/theme.css';
 
 import Layout from '@layouts/index.astro';
-import { getProjects, type ResolvedProject } from '@rainforest-dev/personal-data';
-import { getCaseStudy, hasCaseStudy } from '@rainforest-dev/personal-portfolio/content';
+import {
+  getProjects,
+  type ResolvedProject,
+} from '@rainforest-dev/personal-data';
+import {
+  getCaseStudy,
+  hasCaseStudy,
+} from '@rainforest-dev/personal-portfolio/content';
 import { useTranslation } from '@utils/i18n';
 import { getRelativeLocaleUrl } from 'astro:i18n';
 
@@ -30,7 +36,12 @@ const projects = (await getProjects({ lang })).sort(
 const slugOf = (p: ResolvedProject) => p.id.split('/').pop()!;
 ---
 
-<Layout title={t('title')} description={description} viewTransition={{ enabled: true }} shell>
+<Layout
+  title={t('title')}
+  description={description}
+  viewTransition={{ enabled: true }}
+  shell
+>
   <main class="mx-auto max-w-4xl px-6 py-20">
     <h1 class="mb-2 text-4xl">{t('title')}</h1>
     <p class="text-foreground/70 mb-10 max-w-2xl">{description}</p>
@@ -38,8 +49,12 @@ const slugOf = (p: ResolvedProject) => p.id.split('/').pop()!;
       {
         projects.map((p) => {
           const slug = slugOf(p);
-          const study = hasCaseStudy(slug) ? getCaseStudy(slug, lang) : undefined;
-          const href = study ? getRelativeLocaleUrl(lang, `/portfolio/${slug}`) : undefined;
+          const study = hasCaseStudy(slug)
+            ? getCaseStudy(slug, lang)
+            : undefined;
+          const href = study
+            ? getRelativeLocaleUrl(lang, `/portfolio/${slug}`)
+            : undefined;
           const title = study?.title ?? p.name;
           const tagline = study?.tagline ?? p.organization.name;
           const stack = study?.stack ?? p.technologies;
@@ -48,13 +63,18 @@ const slugOf = (p: ResolvedProject) => p.id.split('/').pop()!;
               class="bg-card flex flex-col gap-4 rounded-lg border p-6 transition-shadow hover:shadow-md"
               data-project={study ? slug : undefined}
             >
-              <h2 class="text-2xl" transition:name={study ? `case-study-${slug}` : undefined}>
+              <h2
+                class="text-2xl"
+                transition:name={study ? `case-study-${slug}` : undefined}
+              >
                 {title}
               </h2>
               <p class="text-foreground/70">{tagline}</p>
               <ul class="flex flex-wrap gap-2">
                 {stack.map((tech) => (
-                  <li class="bg-primary/10 text-primary rounded px-2.5 py-1 text-xs">{tech}</li>
+                  <li class="bg-primary/10 text-primary rounded px-2.5 py-1 text-xs">
+                    {tech}
+                  </li>
                 ))}
               </ul>
               <div class="mt-auto pt-2">

--- a/apps/personal-website/src/components/pages/ResumePage.astro
+++ b/apps/personal-website/src/components/pages/ResumePage.astro
@@ -60,7 +60,9 @@ const [skills, workExperience, education] = await Promise.all([
   getWorkExperience({ lang }),
   getEducation({ lang }),
 ]);
-const mostRecentJob = workExperience.toSorted((a, b) => b.startAt.valueOf() - a.startAt.valueOf())[0];
+const mostRecentJob = workExperience.toSorted(
+  (a, b) => b.startAt.valueOf() - a.startAt.valueOf(),
+)[0];
 const caseStudies = listCaseStudies();
 const personSchema = {
   '@context': 'https://schema.org',
@@ -72,12 +74,21 @@ const personSchema = {
   jobTitle: resumeProps.jobPosition,
   url: info.links.website,
   email: `mailto:${info.email}`,
-  sameAs: [getLinkedInUrl(info.links.linkedin), getGitHubUrl(info.links.github)],
+  sameAs: [
+    getLinkedInUrl(info.links.linkedin),
+    getGitHubUrl(info.links.github),
+  ],
   knowsAbout: skills.map((s) => s.name),
   ...(mostRecentJob && {
-    worksFor: { '@type': 'Organization', name: mostRecentJob.organization.name },
+    worksFor: {
+      '@type': 'Organization',
+      name: mostRecentJob.organization.name,
+    },
   }),
-  alumniOf: education.map((e) => ({ '@type': 'EducationalOrganization', name: e.organization.name })),
+  alumniOf: education.map((e) => ({
+    '@type': 'EducationalOrganization',
+    name: e.organization.name,
+  })),
   // Interactive case studies for shipped work — the same registry backing the portfolio
   // routes, so this list can't name a project without a live page to back it. Locale-correct
   // canonical: /portfolio/<slug> for the default locale, /<lang>/portfolio/<slug> otherwise.
@@ -97,12 +108,10 @@ const personSchema = {
 >
   <script type="application/ld+json" set:html={JSON.stringify(personSchema)} />
   <main
-    class="w-screen h-screen flex-col-center p-10 bg-foreground overflow-scroll
-            print:justify-start print:items-start print:p-0 print:overflow-visible"
+    class="flex-col-center bg-foreground h-screen w-screen overflow-scroll p-10 print:items-start print:justify-start print:overflow-visible print:p-0"
   >
     <div
-      class="w-[75rem] h-[105rem] origin-top scale-30 sm:scale-50 md:scale-75 lg:scale-100
-              print:scale-100 print:origin-top-left"
+      class="scale-30 h-[105rem] w-[75rem] origin-top sm:scale-50 md:scale-75 lg:scale-100 print:origin-top-left print:scale-100"
     >
       <ATSFriendly {...resumeProps} />
     </div>

--- a/apps/personal-website/src/components/resume/ats-friendly.astro
+++ b/apps/personal-website/src/components/resume/ats-friendly.astro
@@ -36,19 +36,17 @@ const education = (
 const skillSections = ['frontend', 'backend', 'devops', 'languages', 'tools'];
 const skills = groupBy(
   await getCollection('skills', (item) => item.id.startsWith(lang)),
-  (item) => skillSections.find((section) => item.data.tags.includes(section))
+  (item) => skillSections.find((section) => item.data.tags.includes(section)),
 );
 ---
 
 <article
-  class="size-full bg-background text-foreground py-10 px-20 font-resume-serif
-                prose prose-sm max-w-none
-                prose-headings:text-foreground prose-a:text-foreground prose-li:text-foreground prose-headings:m-0 prose-h2:mb-3 prose-li:m-0 prose-p:mt-0 prose-p:mb-2"
+  class="bg-background text-foreground font-resume-serif prose prose-sm prose-headings:text-foreground prose-a:text-foreground prose-li:text-foreground prose-headings:m-0 prose-h2:mb-3 prose-li:m-0 prose-p:mt-0 prose-p:mb-2 size-full max-w-none px-20 py-10"
 >
   <section>
     <h1>{info.name.fullname}</h1>
     <h2>{info.jobPosition}</h2>
-    <ul class="list-none pl-0 mt-4 mb-5">
+    <ul class="mb-5 mt-4 list-none pl-0">
       <li><a href={`tel:${info.phone}`}>{info.phone}</a></li>
       <li><a href={`mailto:${info.email}`}>{info.email}</a></li>
       <li>{info.location.city}, {info.location.country}</li>
@@ -122,7 +120,7 @@ const skills = groupBy(
       }
     </ul>
   </section>
-  <section class="grid grid-cols-2 w-full break-after-auto">
+  <section class="grid w-full break-after-auto grid-cols-2">
     <section>
       <h2>{t('education')}</h2>
       <ul>

--- a/apps/personal-website/src/components/shell/SettingsMenu.astro
+++ b/apps/personal-website/src/components/shell/SettingsMenu.astro
@@ -25,9 +25,11 @@ const themes = [
 ];
 ---
 
-{/* One combined preferences menu: theme + language. Uses <details> so it opens
+{
+  /* One combined preferences menu: theme + language. Uses <details> so it opens
     without JS (language links still work); the theme options and outside-click /
-    Escape close are wired by the inline head script via the data-* hooks. */}
+    Escape close are wired by the inline head script via the data-* hooks. */
+}
 <details class="settings-menu relative" data-menu>
   <summary
     aria-label={t('settings')}
@@ -68,24 +70,64 @@ const themes = [
           class="theme-opt text-foreground/80 hover:bg-muted flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm transition-colors"
         >
           {th.key === 'system' && (
-            <svg class="size-4 opacity-70" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <svg
+              class="size-4 opacity-70"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
               <rect width="20" height="14" x="2" y="3" rx="2" />
               <path d="M8 21h8M12 17v4" />
             </svg>
           )}
           {th.key === 'light' && (
-            <svg class="size-4 opacity-70" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <svg
+              class="size-4 opacity-70"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
               <circle cx="12" cy="12" r="4" />
               <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
             </svg>
           )}
           {th.key === 'dark' && (
-            <svg class="size-4 opacity-70" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <svg
+              class="size-4 opacity-70"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
               <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
             </svg>
           )}
           <span>{th.label}</span>
-          <svg class="opt-check text-primary ml-auto size-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <svg
+            class="opt-check text-primary ml-auto size-4"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
             <path d="M20 6 9 17l-5-5" />
           </svg>
         </button>
@@ -113,7 +155,17 @@ const themes = [
         >
           <span>{l.label}</span>
           {l.active && (
-            <svg class="text-primary ml-auto size-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <svg
+              class="text-primary ml-auto size-4"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
               <path d="M20 6 9 17l-5-5" />
             </svg>
           )}
@@ -130,17 +182,37 @@ const themes = [
   .settings-menu .theme-opt .opt-check {
     opacity: 0;
   }
-  :root:not([data-theme-pref]) .settings-menu .theme-opt[data-theme-set='system'],
-  :root[data-theme-pref='system'] .settings-menu .theme-opt[data-theme-set='system'],
-  :root[data-theme-pref='light'] .settings-menu .theme-opt[data-theme-set='light'],
-  :root[data-theme-pref='dark'] .settings-menu .theme-opt[data-theme-set='dark'] {
+  :root:not([data-theme-pref])
+    .settings-menu
+    .theme-opt[data-theme-set='system'],
+  :root[data-theme-pref='system']
+    .settings-menu
+    .theme-opt[data-theme-set='system'],
+  :root[data-theme-pref='light']
+    .settings-menu
+    .theme-opt[data-theme-set='light'],
+  :root[data-theme-pref='dark']
+    .settings-menu
+    .theme-opt[data-theme-set='dark'] {
     color: var(--primary);
     font-weight: 500;
   }
-  :root:not([data-theme-pref]) .settings-menu .theme-opt[data-theme-set='system'] .opt-check,
-  :root[data-theme-pref='system'] .settings-menu .theme-opt[data-theme-set='system'] .opt-check,
-  :root[data-theme-pref='light'] .settings-menu .theme-opt[data-theme-set='light'] .opt-check,
-  :root[data-theme-pref='dark'] .settings-menu .theme-opt[data-theme-set='dark'] .opt-check {
+  :root:not([data-theme-pref])
+    .settings-menu
+    .theme-opt[data-theme-set='system']
+    .opt-check,
+  :root[data-theme-pref='system']
+    .settings-menu
+    .theme-opt[data-theme-set='system']
+    .opt-check,
+  :root[data-theme-pref='light']
+    .settings-menu
+    .theme-opt[data-theme-set='light']
+    .opt-check,
+  :root[data-theme-pref='dark']
+    .settings-menu
+    .theme-opt[data-theme-set='dark']
+    .opt-check {
     opacity: 1;
   }
 </style>

--- a/apps/personal-website/src/components/shell/SiteHeader.astro
+++ b/apps/personal-website/src/components/shell/SiteHeader.astro
@@ -17,7 +17,12 @@ interface NavItem {
 }
 
 const nav: NavItem[] = [
-  { key: 'home', label: t('home'), href: getRelativeLocaleUrl(lang, '/'), isActive: (p) => p === '/' },
+  {
+    key: 'home',
+    label: t('home'),
+    href: getRelativeLocaleUrl(lang, '/'),
+    isActive: (p) => p === '/',
+  },
   {
     key: 'portfolio',
     label: t('portfolio'),
@@ -49,7 +54,9 @@ const langs = [
   { key: 'zh', label: '中' },
 ] as const;
 const langHref = (l: string) =>
-  localeAgnostic ? getRelativeLocaleUrl(l, '/') : getRelativeLocaleUrl(l, stripped);
+  localeAgnostic
+    ? getRelativeLocaleUrl(l, '/')
+    : getRelativeLocaleUrl(l, stripped);
 const langItems = langs.map((l) => ({
   key: l.key,
   label: t(l.key),
@@ -97,7 +104,7 @@ const home = getRelativeLocaleUrl(lang, '/');
 
       <details class="relative md:hidden" data-menu>
         <summary
-          class="flex-center hover:bg-muted list-none cursor-pointer rounded-md p-2 [&::-webkit-details-marker]:hidden"
+          class="flex-center hover:bg-muted cursor-pointer list-none rounded-md p-2 [&::-webkit-details-marker]:hidden"
           aria-label="Menu"
         >
           <svg

--- a/apps/personal-website/src/components/tag.astro
+++ b/apps/personal-website/src/components/tag.astro
@@ -16,11 +16,22 @@ const { t } = await useTranslation('en', 'common');
 ---
 
 <div
-  class={clsx('flex-row-center gap-2 py-1 px-2 rounded-full capitalize', containerClass)}
+  class={clsx(
+    'flex-row-center gap-2 py-1 px-2 rounded-full capitalize',
+    containerClass,
+  )}
 >
-  {iconName ? <iconify-icon icon={iconName} height="none" class={clsx("size-4", iconClass)}></iconify-icon> : null}
+  {
+    iconName ? (
+      <iconify-icon
+        icon={iconName}
+        height="none"
+        class={clsx('size-4', iconClass)}
+      />
+    ) : null
+  }
   {t(name)}
 </div>
 <script>
-import 'iconify-icon';
+  import 'iconify-icon';
 </script>

--- a/apps/personal-website/src/components/tag.astro
+++ b/apps/personal-website/src/components/tag.astro
@@ -18,7 +18,7 @@ const { t } = await useTranslation('en', 'common');
 <div
   class={clsx('flex-row-center gap-2 py-1 px-2 rounded-full capitalize', containerClass)}
 >
-  {iconName ? <iconify-icon icon={iconName} height="none" class={clsx("size-4", iconClass)}></iconify-icon> : <></>}
+  {iconName ? <iconify-icon icon={iconName} height="none" class={clsx("size-4", iconClass)}></iconify-icon> : null}
   {t(name)}
 </div>
 <script>

--- a/apps/personal-website/src/components/theme-provider.astro
+++ b/apps/personal-website/src/components/theme-provider.astro
@@ -15,10 +15,10 @@ const sourceColor =
 // Tailwind plugin's CSS relative-color-syntax derivation of `--seed`.
 const theme = themeFromSourceColor(argbFromHex(sourceColor));
 const themeColorLight = hexFromArgb(
-  getSchemeProperties(theme.schemes.light)['--md-sys-color-surface']
+  getSchemeProperties(theme.schemes.light)['--md-sys-color-surface'],
 );
 const themeColorDark = hexFromArgb(
-  getSchemeProperties(theme.schemes.dark)['--md-sys-color-surface']
+  getSchemeProperties(theme.schemes.dark)['--md-sys-color-surface'],
 );
 
 const styleRaw = `

--- a/apps/personal-website/src/layouts/blog.astro
+++ b/apps/personal-website/src/layouts/blog.astro
@@ -25,7 +25,11 @@ const postSchema = {
   headline: title,
   description,
   datePublished: new Date(pubDate).toISOString(),
-  author: { '@type': 'Person', name: 'Rainforest Cheng', url: info.links.website },
+  author: {
+    '@type': 'Person',
+    name: 'Rainforest Cheng',
+    url: info.links.website,
+  },
   url: canonicalUrl,
   mainEntityOfPage: canonicalUrl,
   ...(image?.src && { image: new URL(image.src, Astro.site).href }),
@@ -47,7 +51,7 @@ const postSchema = {
         width={512}
         height={512}
         alt={image?.alt}
-        class="w-full max-h-75 md:max-h-1/2 object-cover"
+        class="max-h-75 md:max-h-1/2 w-full object-cover"
         transition:name={`blog-${id}`}
       />
     )
@@ -55,7 +59,7 @@ const postSchema = {
   <article
     class={clsx(
       'container prose md:prose-xl lg:prose-2xl py-4',
-      image?.src && '-mt-0 md:-mt-75'
+      image?.src && '-mt-0 md:-mt-75',
     )}
   >
     <p class="text-center">{format(pubDate, 'd MMM, yyyy')}</p>

--- a/apps/personal-website/src/layouts/head.astro
+++ b/apps/personal-website/src/layouts/head.astro
@@ -40,13 +40,15 @@ const xDefaultHref = isLocalized
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width" />
 
-  {/* Resolve the colour scheme before first paint (no FOUC). Precedence:
+  {
+    /* Resolve the colour scheme before first paint (no FOUC). Precedence:
       a page's product-locked `data-force-scheme` (case studies) always wins;
       otherwise the visitor's stored light/dark preference; otherwise `system`
       (unset → the shadcn plugin follows the OS via prefers-color-scheme).
       `data-theme-pref` mirrors the raw preference so the header toggle shows
       the right icon with no flash. Re-applied on the *incoming* document during
-      view-transition swaps so client-side navigation never flashes either. */}
+      view-transition swaps so client-side navigation never flashes either. */
+  }
   <script is:inline>
     (function () {
       const ORDER = ['system', 'light', 'dark'];
@@ -88,7 +90,9 @@ const xDefaultHref = isLocalized
               const commit = () => applyTo(document.documentElement);
               // Cross-fade the scheme change via the View Transitions API,
               // respecting reduced-motion; instant swap where unsupported.
-              const reduce = matchMedia('(prefers-reduced-motion: reduce)').matches;
+              const reduce = matchMedia(
+                '(prefers-reduced-motion: reduce)',
+              ).matches;
               if (document.startViewTransition && !reduce) {
                 document.startViewTransition(commit);
               } else {
@@ -104,11 +108,9 @@ const xDefaultHref = isLocalized
         });
         document.addEventListener('keydown', (e) => {
           if (e.key !== 'Escape') return;
-          document
-            .querySelectorAll('details[data-menu][open]')
-            .forEach((d) => {
-              d.open = false;
-            });
+          document.querySelectorAll('details[data-menu][open]').forEach((d) => {
+            d.open = false;
+          });
         });
       }
     })();
@@ -126,8 +128,16 @@ const xDefaultHref = isLocalized
   <link rel="sitemap" href="/sitemap-index.xml" />
 
   <link rel="canonical" href={canonical} />
-  {alternates.map((a) => <link rel="alternate" hreflang={a.hreflang} href={a.href} />)}
-  {xDefaultHref && <link rel="alternate" hreflang="x-default" href={xDefaultHref} />}
+  {
+    alternates.map((a) => (
+      <link rel="alternate" hreflang={a.hreflang} href={a.href} />
+    ))
+  }
+  {
+    xDefaultHref && (
+      <link rel="alternate" hreflang="x-default" href={xDefaultHref} />
+    )
+  }
 
   <!-- Open Graph and Twitter Card Metadata  -->
   <title>{title}</title>

--- a/apps/personal-website/src/layouts/index.astro
+++ b/apps/personal-website/src/layouts/index.astro
@@ -35,7 +35,7 @@ const dir = _dir(lang);
     {shell && <SiteFooter />}
     {
       !hideSourceColorPicker && (
-        <div class="fixed right-10 bottom-10 z-10 print:hidden">
+        <div class="fixed bottom-10 right-10 z-10 print:hidden">
           <SourceColor client:only="vue" showTheme={!shell} />
         </div>
       )

--- a/apps/personal-website/src/pages/blog/index.astro
+++ b/apps/personal-website/src/pages/blog/index.astro
@@ -15,7 +15,7 @@ export const prerender = true;
 const posts = (
   await getCollection(
     'blog',
-    (entry) => !entry.data.tags.includes('type:quick-post')
+    (entry) => !entry.data.tags.includes('type:quick-post'),
   )
 ).sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 const { t } = await useTranslation('en', 'blog');
@@ -29,25 +29,22 @@ const translatePath = useTranslatedPath(Astro.currentLocale);
   shell
 >
   <main class="container py-10">
-    <h1 class="text-5xl md:text-9xl text-center mb-10">Rainforest Cheng</h1>
+    <h1 class="mb-10 text-center text-5xl md:text-9xl">Rainforest Cheng</h1>
     <div
-      class="grid grid-flow-row grid-cols-1 sm:grid-cols-3 md:grid-cols-3 lg:grid-cols-5 gap-5 auto-rows-max"
+      class="grid grid-flow-row auto-rows-max grid-cols-1 gap-5 sm:grid-cols-3 md:grid-cols-3 lg:grid-cols-5"
     >
       {
         posts.map(({ data: post, id }) => (
           <a
             href={translatePath(`/blog/${id}`)}
-            class="
-              md:first:col-span-full lg:first:h-[30dvh] md:first:h-[20dvh] bg-card rounded-lg overflow-hidden hover:shadow
-              @container prose-sm max-w-none
-              flex gap-4 flex-col md:first:flex-row-center"
+            class="bg-card @container prose-sm md:first:flex-row-center flex max-w-none flex-col gap-4 overflow-hidden rounded-lg hover:shadow md:first:col-span-full md:first:h-[20dvh] lg:first:h-[30dvh]"
           >
-            <div class="md:@2xl:h-full @2xl:w-auto w-full aspect-square flex-center">
+            <div class="md:@2xl:h-full @2xl:w-auto flex-center aspect-square w-full">
               {post.image?.src ? (
                 <Image
                   width={128}
                   height={128}
-                  class="size-full object-cover m-0!"
+                  class="m-0! size-full object-cover"
                   src={post.image.src}
                   alt={post.image.alt}
                   transition:name={`blog-${id}`}

--- a/apps/personal-website/src/pages/posts/index.astro
+++ b/apps/personal-website/src/pages/posts/index.astro
@@ -9,12 +9,12 @@ import QuickPostLayout from '@/layouts/quick-post.astro';
 export const prerender = true;
 
 const posts = await getCollection('blog', ({ data }) =>
-  data.tags.includes('type:quick-post')
+  data.tags.includes('type:quick-post'),
 );
 ---
 
 <Layout title="Quick Posts" viewTransition={{ enabled: true }} shell>
-  <main class="container py-10 space-y-8">
+  <main class="container space-y-8 py-10">
     {
       posts
         .sort((a, b) => {

--- a/apps/personal-website/src/pages/settings.astro
+++ b/apps/personal-website/src/pages/settings.astro
@@ -7,12 +7,12 @@ import Layout from '@layouts/index.astro';
 ---
 
 <Layout title="Settings">
-  <main class="container flex-col-center gap-3 py-10">
-    <div class="flex flex-col lg:flex-row size-full">
-      <div class="w-full bg-background p-8 border" data-scheme="light">
+  <main class="flex-col-center container gap-3 py-10">
+    <div class="flex size-full flex-col lg:flex-row">
+      <div class="bg-background w-full border p-8" data-scheme="light">
         <ColorSystem client:load />
       </div>
-      <div class="w-full bg-background p-8" data-scheme="dark">
+      <div class="bg-background w-full p-8" data-scheme="dark">
         <ColorSystem client:load />
       </div>
     </div>

--- a/apps/rss-manager/src/pages/index.astro
+++ b/apps/rss-manager/src/pages/index.astro
@@ -5,10 +5,13 @@ import FeedValidator from '../components/FeedValidator.tsx';
 import '../styles/global.css';
 
 const VALID_TABS = ['sources', 'topics', 'validate'] as const;
-type Tab = typeof VALID_TABS[number];
+type Tab = (typeof VALID_TABS)[number];
 const rawTab = Astro.url.searchParams.get('tab') ?? 'sources';
-const tab: Tab = (VALID_TABS as readonly string[]).includes(rawTab) ? (rawTab as Tab) : 'sources';
+const tab: Tab = (VALID_TABS as readonly string[]).includes(rawTab)
+  ? (rawTab as Tab)
+  : 'sources';
 ---
+
 <!doctype html>
 <html lang="en">
   <head>
@@ -17,26 +20,30 @@ const tab: Tab = (VALID_TABS as readonly string[]).includes(rawTab) ? (rawTab as
     <title>RSS Manager — Rainforest Tools</title>
   </head>
   <body class="min-h-screen bg-[#0f1117] text-gray-200">
-    <div class="max-w-5xl mx-auto px-6 py-8">
+    <div class="mx-auto max-w-5xl px-6 py-8">
       <header class="mb-8">
         <h1 class="text-2xl font-semibold text-gray-100">RSS Manager</h1>
-        <p class="text-gray-500 text-sm mt-1">Browse and validate your Readwise RSS feeds.</p>
+        <p class="mt-1 text-sm text-gray-500">
+          Browse and validate your Readwise RSS feeds.
+        </p>
       </header>
 
       <!-- Tabs -->
-      <nav class="flex gap-1 mb-6 border-b border-gray-800">
-        {(['sources', 'topics', 'validate'] as const).map((t) => (
-          <a
-            href={`?tab=${t}`}
-            class={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
-              tab === t
-                ? 'border-violet-500 text-violet-400'
-                : 'border-transparent text-gray-500 hover:text-gray-300'
-            }`}
-          >
-            {t.charAt(0).toUpperCase() + t.slice(1)}
-          </a>
-        ))}
+      <nav class="mb-6 flex gap-1 border-b border-gray-800">
+        {
+          (['sources', 'topics', 'validate'] as const).map((t) => (
+            <a
+              href={`?tab=${t}`}
+              class={`-mb-px border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
+                tab === t
+                  ? 'border-violet-500 text-violet-400'
+                  : 'border-transparent text-gray-500 hover:text-gray-300'
+              }`}
+            >
+              {t.charAt(0).toUpperCase() + t.slice(1)}
+            </a>
+          ))
+        }
       </nav>
 
       <!-- Tab content -->

--- a/docs/superpowers/plans/2026-06-22-auth-service.md
+++ b/docs/superpowers/plans/2026-06-22-auth-service.md
@@ -784,6 +784,7 @@ if (!registrationToken || token !== registrationToken) {
   return Astro.redirect('/login');
 }
 ---
+
 <!doctype html>
 <html lang="en">
   <head>
@@ -791,13 +792,19 @@ if (!registrationToken || token !== registrationToken) {
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Register Passkey — Rainforest Tools</title>
     <style>
-      body { background: #0f1117; color: #e2e4ed; font-family: system-ui, sans-serif; }
+      body {
+        background: #0f1117;
+        color: #e2e4ed;
+        font-family: system-ui, sans-serif;
+      }
     </style>
   </head>
-  <body class="min-h-screen flex items-center justify-center">
-    <div class="text-center space-y-6">
+  <body class="flex min-h-screen items-center justify-center">
+    <div class="space-y-6 text-center">
       <h1 class="text-2xl font-semibold">Register Passkey</h1>
-      <p class="text-gray-400 text-sm">One-time setup. Use your device's biometric or PIN.</p>
+      <p class="text-sm text-gray-400">
+        One-time setup. Use your device's biometric or PIN.
+      </p>
       <PasskeyRegister client:load />
     </div>
   </body>
@@ -965,6 +972,7 @@ import PasskeyLogin from '../components/PasskeyLogin.tsx';
 
 const redirect = Astro.url.searchParams.get('redirect') ?? '/';
 ---
+
 <!doctype html>
 <html lang="en">
   <head>
@@ -972,13 +980,17 @@ const redirect = Astro.url.searchParams.get('redirect') ?? '/';
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Sign In — Rainforest Tools</title>
     <style>
-      body { background: #0f1117; color: #e2e4ed; font-family: system-ui, sans-serif; }
+      body {
+        background: #0f1117;
+        color: #e2e4ed;
+        font-family: system-ui, sans-serif;
+      }
     </style>
   </head>
-  <body class="min-h-screen flex items-center justify-center">
-    <div class="text-center space-y-6">
+  <body class="flex min-h-screen items-center justify-center">
+    <div class="space-y-6 text-center">
       <h1 class="text-2xl font-semibold">Rainforest Tools</h1>
-      <p class="text-gray-400 text-sm">Use your passkey to sign in.</p>
+      <p class="text-sm text-gray-400">Use your passkey to sign in.</p>
       <PasskeyLogin redirect={redirect} client:load />
     </div>
   </body>

--- a/docs/superpowers/plans/2026-06-22-rss-manager.md
+++ b/docs/superpowers/plans/2026-06-22-rss-manager.md
@@ -1134,8 +1134,12 @@ import SourceTable from '../components/SourceTable.tsx';
 import TopicList from '../components/TopicList.tsx';
 import FeedValidator from '../components/FeedValidator.tsx';
 
-const tab = (Astro.url.searchParams.get('tab') ?? 'sources') as 'sources' | 'topics' | 'validate';
+const tab = (Astro.url.searchParams.get('tab') ?? 'sources') as
+  | 'sources'
+  | 'topics'
+  | 'validate';
 ---
+
 <!doctype html>
 <html lang="en">
   <head>
@@ -1143,30 +1147,38 @@ const tab = (Astro.url.searchParams.get('tab') ?? 'sources') as 'sources' | 'top
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>RSS Manager — Rainforest Tools</title>
     <style>
-      body { background: #0f1117; color: #e2e4ed; font-family: system-ui, sans-serif; }
+      body {
+        background: #0f1117;
+        color: #e2e4ed;
+        font-family: system-ui, sans-serif;
+      }
     </style>
   </head>
   <body class="min-h-screen">
-    <div class="max-w-5xl mx-auto px-6 py-8">
+    <div class="mx-auto max-w-5xl px-6 py-8">
       <header class="mb-8">
         <h1 class="text-2xl font-semibold text-gray-100">RSS Manager</h1>
-        <p class="text-gray-500 text-sm mt-1">Browse and validate your Readwise RSS feeds.</p>
+        <p class="mt-1 text-sm text-gray-500">
+          Browse and validate your Readwise RSS feeds.
+        </p>
       </header>
 
       <!-- Tabs -->
-      <nav class="flex gap-1 mb-6 border-b border-gray-800">
-        {(['sources', 'topics', 'validate'] as const).map((t) => (
-          <a
-            href={`?tab=${t}`}
-            class={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
-              tab === t
-                ? 'border-violet-500 text-violet-400'
-                : 'border-transparent text-gray-500 hover:text-gray-300'
-            }`}
-          >
-            {t.charAt(0).toUpperCase() + t.slice(1)}
-          </a>
-        ))}
+      <nav class="mb-6 flex gap-1 border-b border-gray-800">
+        {
+          (['sources', 'topics', 'validate'] as const).map((t) => (
+            <a
+              href={`?tab=${t}`}
+              class={`-mb-px border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
+                tab === t
+                  ? 'border-violet-500 text-violet-400'
+                  : 'border-transparent text-gray-500 hover:text-gray-300'
+              }`}
+            >
+              {t.charAt(0).toUpperCase() + t.slice(1)}
+            </a>
+          ))
+        }
       </nav>
 
       <!-- Tab content -->

--- a/docs/superpowers/plans/2026-07-10-personal-website-shadcn-migration.md
+++ b/docs/superpowers/plans/2026-07-10-personal-website-shadcn-migration.md
@@ -477,10 +477,10 @@ const sourceColor =
 // Tailwind plugin's CSS relative-color-syntax derivation of `--seed`.
 const theme = themeFromSourceColor(argbFromHex(sourceColor));
 const themeColorLight = hexFromArgb(
-  getSchemeProperties(theme.schemes.light)['--md-sys-color-surface']
+  getSchemeProperties(theme.schemes.light)['--md-sys-color-surface'],
 );
 const themeColorDark = hexFromArgb(
-  getSchemeProperties(theme.schemes.dark)['--md-sys-color-surface']
+  getSchemeProperties(theme.schemes.dark)['--md-sys-color-surface'],
 );
 
 const styleRaw = `
@@ -1523,18 +1523,17 @@ const translatePath = useTranslatedPath(lang);
 ---
 
 <div
-  class="h-3/4 w-full flex-row-center justify-between py-10 px-20 relative z-0 rounded-xl shadow-lg"
+  class="flex-row-center relative z-0 h-3/4 w-full justify-between rounded-xl px-20 py-10 shadow-lg"
 >
-  <div class="absolute -z-10 inset-0 rounded-[inherit] overflow-clip">
+  <div class="absolute inset-0 -z-10 overflow-clip rounded-[inherit]">
     <div
-      class="size-full relative z-0 bg-muted overflow-clip
-                  after:bg-foreground after:h-full after:w-1/2 after:absolute after:-skew-x-[45deg] after:scale-200 after:-z-10 after:-right-1/4 after:top-0"
+      class="bg-muted after:bg-foreground after:scale-200 relative z-0 size-full overflow-clip after:absolute after:-right-1/4 after:top-0 after:-z-10 after:h-full after:w-1/2 after:-skew-x-[45deg]"
     >
     </div>
   </div>
   <div class="flex flex-col justify-center">
     <p>{year}</p>
-    <h1 class="text-7xl mt-1 mb-16 text-secondary-foreground">
+    <h1 class="text-secondary-foreground mb-16 mt-1 text-7xl">
       {props.name.fullname}
     </h1>
     <div class="flex-row-center gap-4">
@@ -1545,7 +1544,7 @@ const translatePath = useTranslatedPath(lang);
         variant="outline"
         href={translatePath('/resume')}
         target="_blank"
-        class="px-6 gap-2"
+        class="gap-2 px-6"
         >{t('resume')}
         <Icon icon={ExternalLink} />
       </Button>
@@ -1558,9 +1557,9 @@ const translatePath = useTranslatedPath(lang);
     pictureAttributes={{
       class: 'self-end -mb-10 h-[120%] w-full',
     }}
-    class="object-cover object-center h-full w-max mx-auto"
+    class="mx-auto h-full w-max object-cover object-center"
   />
-  <div class="flex flex-col justify-center text-background gap-6">
+  <div class="text-background flex flex-col justify-center gap-6">
     <ul class="list-disc">
       <li>
         {t('home:hero-brief')}
@@ -1583,7 +1582,7 @@ const translatePath = useTranslatedPath(lang);
   import { removeUrlHashAfterNavigation } from '@utils';
 
   const contactMeButton = document.querySelector(
-    'a[href="#contact-form-footer"]'
+    'a[href="#contact-form-footer"]',
   );
   contactMeButton?.addEventListener('click', removeUrlHashAfterNavigation);
 </script>
@@ -1615,11 +1614,11 @@ const { t } = await useTranslation(lang, 'home');
 const translatePath = useTranslatedPath(lang);
 ---
 
-<div class="flex flex-col size-full">
+<div class="flex size-full flex-col">
   <div class="relative aspect-square">
     <div
       id="hero-dark-panel"
-      class="size-full bg-foreground rounded-b-3xl origin-top-right skew-y-12 overflow-clip absolute top-0 z-0"
+      class="bg-foreground absolute top-0 z-0 size-full origin-top-right skew-y-12 overflow-clip rounded-b-3xl"
     >
       <Picture
         src={props.profile}
@@ -1629,20 +1628,20 @@ const translatePath = useTranslatedPath(lang);
           class:
             'h-full z-10 absolute -bottom-10 md:-bottom-20 left-1/2 -translate-x-1/2 ',
         }}
-        class="object-cover object-top -skew-y-12 size-full"
+        class="size-full -skew-y-12 object-cover object-top"
       />
     </div>
     <div
-      class="text-9xl text-background/50 rotate-270 origin-bottom inline-block m-4"
+      class="text-background/50 rotate-270 m-4 inline-block origin-bottom text-9xl"
     >
       {year}
     </div>
   </div>
-  <div class="flex container">
-    <div class="flex flex-col w-full">
-      <div class="flex-row-center justify-between flex-wrap gap-2">
+  <div class="container flex">
+    <div class="flex w-full flex-col">
+      <div class="flex-row-center flex-wrap justify-between gap-2">
         <div>
-          <h1 class="text-4xl text-secondary-foreground">
+          <h1 class="text-secondary-foreground text-4xl">
             {props.name.first}
           </h1>
           <p>{props.jobPosition}</p>
@@ -1651,20 +1650,19 @@ const translatePath = useTranslatedPath(lang);
           <Button
             id="contact-me-button"
             href="#contact-form-footer"
-            class="px-6"
-            >{t('contact-me-title')}</Button
+            class="px-6">{t('contact-me-title')}</Button
           >
           <Button
             variant="outline"
             href={translatePath('/resume')}
             target="_blank"
-            class="px-6 gap-2"
+            class="gap-2 px-6"
             >{t('resume')}
             <Icon icon={ExternalLink} />
           </Button>
         </div>
       </div>
-      <ul class="list-disc list-inside mt-4">
+      <ul class="mt-4 list-inside list-disc">
         {props.summaries.map((summary) => <li>{summary}</li>)}
       </ul>
     </div>
@@ -1676,9 +1674,11 @@ const translatePath = useTranslatedPath(lang);
   import { removeUrlHashAfterNavigation } from '@utils';
 
   const contactMeButton = document.getElementById(
-    'contact-me-button'
+    'contact-me-button',
   ) as HTMLAnchorElement;
-  const menuButton = document.getElementById('menu-trigger') as HTMLButtonElement;
+  const menuButton = document.getElementById(
+    'menu-trigger',
+  ) as HTMLButtonElement;
   const handleOpenContactForm = () => {
     menuButton?.click();
   };
@@ -1710,7 +1710,7 @@ const translatePath = useTranslatedPath(lang);
   };
 
   const breakpointMd = getComputedStyle(
-    document.documentElement
+    document.documentElement,
   ).getPropertyValue('--breakpoint-md');
   handleMatches(window.matchMedia(`(max-width: ${breakpointMd})`).matches);
   window
@@ -1849,7 +1849,7 @@ const { t } = await useTranslation(lang);
   <Button
     as="a"
     data-contact-submit
-    class="mt-4 px-6 w-1/2 self-end"
+    class="mt-4 w-1/2 self-end px-6"
     href={`mailto:${info.email}`}>{t('contact-me-submit')}</Button
   >
 </contact-form>
@@ -1860,19 +1860,19 @@ const { t } = await useTranslation(lang);
   class ContactForm extends HTMLElement {
     connectedCallback() {
       const nameField = this.querySelector(
-        'input[name="name"]'
+        'input[name="name"]',
       ) as HTMLInputElement;
       const companyField = this.querySelector(
-        'input[name="company"]'
+        'input[name="company"]',
       ) as HTMLInputElement;
       const subjectField = this.querySelector(
-        'input[name="subject"]'
+        'input[name="subject"]',
       ) as HTMLInputElement;
       const messageField = this.querySelector(
-        'textarea[name="message"]'
+        'textarea[name="message"]',
       ) as HTMLTextAreaElement;
       const submitButton = this.querySelector(
-        '[data-contact-submit]'
+        '[data-contact-submit]',
       ) as HTMLAnchorElement;
 
       const handleFormChange = () => {
@@ -1915,7 +1915,7 @@ import Links from './links.astro';
 ---
 
 <footer
-  class="container md:flex flex-wrap gap-10 hidden justify-between pt-10 pb-20"
+  class="container hidden flex-wrap justify-between gap-10 pb-20 pt-10 md:flex"
 >
   <Links />
   <ContactForm id="contact-form-footer" />
@@ -2052,14 +2052,18 @@ const { Content } = await render(Astro.props);
 const tags = _tags.filter((e) => !e.includes(':'));
 ---
 
-<div
-  class="w-full p-10 bg-card rounded-lg prose dark:bg-card max-w-none"
->
+<div class="bg-card prose dark:bg-card w-full max-w-none rounded-lg p-10">
   <h1>{title}</h1>
   <p>{format(pubDate, 'd MMM, yyyy')}<br />By {author.name}</p>
   <Content />
-  <div class="flex flex-wrap gap-2 mt-10">
-    {tags.map((tag) => <Badge variant="secondary" class="capitalize">{tag}</Badge>)}
+  <div class="mt-10 flex flex-wrap gap-2">
+    {
+      tags.map((tag) => (
+        <Badge variant="secondary" class="capitalize">
+          {tag}
+        </Badge>
+      ))
+    }
   </div>
 </div>
 ```
@@ -2091,7 +2095,7 @@ import { Navigation } from '@/components/blog';
 const posts = (
   await getCollection(
     'blog',
-    (entry) => !entry.data.tags.includes('type:quick-post')
+    (entry) => !entry.data.tags.includes('type:quick-post'),
   )
 ).sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 const { t } = await useTranslation('en', 'blog');
@@ -2103,7 +2107,7 @@ const translatePath = useTranslatedPath(Astro.currentLocale);
   description={t('metadata-description')}
   viewTransition={{ enabled: true }}
 >
-  <nav class="flex-row-center justify-between container">
+  <nav class="flex-row-center container justify-between">
     <div>
       <Button variant="ghost" size="icon" href="/">
         <Icon icon={Home} />
@@ -2131,25 +2135,22 @@ const translatePath = useTranslatedPath(Astro.currentLocale);
     </div>
   </nav>
   <main class="container py-10">
-    <h1 class="text-5xl md:text-9xl text-center mb-10">Rainforest Cheng</h1>
+    <h1 class="mb-10 text-center text-5xl md:text-9xl">Rainforest Cheng</h1>
     <div
-      class="grid grid-flow-row grid-cols-1 sm:grid-cols-3 md:grid-cols-3 lg:grid-cols-5 gap-5 auto-rows-max"
+      class="grid grid-flow-row auto-rows-max grid-cols-1 gap-5 sm:grid-cols-3 md:grid-cols-3 lg:grid-cols-5"
     >
       {
         posts.map(({ data: post, id }) => (
           <a
             href={translatePath(`/blog/${id}`)}
-            class="
-              md:first:col-span-full lg:first:h-[30dvh] md:first:h-[20dvh] bg-card rounded-lg overflow-hidden hover:shadow
-              @container prose-sm max-w-none
-              flex gap-4 flex-col md:first:flex-row-center"
+            class="bg-card @container prose-sm md:first:flex-row-center flex max-w-none flex-col gap-4 overflow-hidden rounded-lg hover:shadow md:first:col-span-full md:first:h-[20dvh] lg:first:h-[30dvh]"
           >
-            <div class="md:@2xl:h-full @2xl:w-auto w-full aspect-square flex-center">
+            <div class="md:@2xl:h-full @2xl:w-auto flex-center aspect-square w-full">
               {post.image?.src ? (
                 <Image
                   width={128}
                   height={128}
-                  class="size-full object-cover m-0!"
+                  class="m-0! size-full object-cover"
                   src={post.image.src}
                   alt={post.image.alt}
                   transition:name={`blog-${id}`}
@@ -2169,7 +2170,7 @@ const translatePath = useTranslatedPath(Astro.currentLocale);
     <div class="fixed bottom-10 left-1/2 -translate-x-1/2">
       <Navigation />
     </div>
-    <div class="fixed right-10 bottom-10 z-10">
+    <div class="fixed bottom-10 right-10 z-10">
       <SourceColor client:only="vue" />
     </div>
   </main>
@@ -2220,7 +2221,7 @@ const {
         width={512}
         height={512}
         alt={image?.alt}
-        class="w-full max-h-75 md:max-h-1/2 object-cover"
+        class="max-h-75 md:max-h-1/2 w-full object-cover"
         transition:name={`blog-${id}`}
       />
     )
@@ -2229,14 +2230,14 @@ const {
     variant="secondary"
     size="icon"
     onclick="history.back()"
-    class="fixed top-10 left-10 rounded-full text-primary"
+    class="text-primary fixed left-10 top-10 rounded-full"
   >
     <Icon icon={ArrowLeft} />
   </Button>
   <article
     class={clsx(
       'container prose md:prose-xl lg:prose-2xl py-4',
-      image?.src && '-mt-0 md:-mt-75'
+      image?.src && '-mt-0 md:-mt-75',
     )}
   >
     <p class="text-center">{format(pubDate, 'd MMM, yyyy')}</p>

--- a/docs/superpowers/plans/2026-07-21-portfolio-case-studies.md
+++ b/docs/superpowers/plans/2026-07-21-portfolio-case-studies.md
@@ -701,23 +701,34 @@ Expected: PASS.
 import type { Section } from '../content/types';
 import { islandFor } from './island-registry';
 
-interface Props { section: Section }
+interface Props {
+  section: Section;
+}
 const { section } = Astro.props;
 const Island = islandFor(section.interaction);
 ---
+
 <section class="py-16" aria-labelledby={`sec-${section.id}`}>
-  <p class="text-xs tracking-widest uppercase text-primary/70">{section.title}</p>
-  <h3 id={`sec-${section.id}`} class="text-2xl mt-2">{section.feature}</h3>
-  <p class="italic mt-4 border-l-2 border-primary/50 pl-4">{section.contribution}</p>
-  <p class="mt-4 text-foreground/80" set:html={section.tech} />
-  {Island && (
-    <div class="mt-8">
-      <Island client:visible />
-    </div>
-  )}
-  {section.sourceRef && (
-    <p class="mt-4 text-xs text-foreground/50">Mirrors {section.sourceRef}</p>
-  )}
+  <p class="text-primary/70 text-xs uppercase tracking-widest">
+    {section.title}
+  </p>
+  <h3 id={`sec-${section.id}`} class="mt-2 text-2xl">{section.feature}</h3>
+  <p class="border-primary/50 mt-4 border-l-2 pl-4 italic">
+    {section.contribution}
+  </p>
+  <p class="text-foreground/80 mt-4" set:html={section.tech} />
+  {
+    Island && (
+      <div class="mt-8">
+        <Island client:visible />
+      </div>
+    )
+  }
+  {
+    section.sourceRef && (
+      <p class="text-foreground/50 mt-4 text-xs">Mirrors {section.sourceRef}</p>
+    )
+  }
 </section>
 ```
 
@@ -836,7 +847,10 @@ pnpm nx sync
 ---
 import '@rainforest-dev/portfolio/theme.css';
 import CaseStudySection from '@rainforest-dev/portfolio/sections/CaseStudySection.astro';
-import { getCaseStudy, listCaseStudies } from '@rainforest-dev/portfolio/content';
+import {
+  getCaseStudy,
+  listCaseStudies,
+} from '@rainforest-dev/portfolio/content';
 import Layout from '@layouts/index.astro';
 import { supportedLngs } from '@utils/i18n';
 
@@ -851,14 +865,21 @@ const { slug } = Astro.params;
 const study = getCaseStudy(slug!);
 if (!study) return Astro.redirect('/404');
 ---
+
 <Layout title={`${study.title} — Case study`} description={study.tagline}>
   <article data-project={study.slug} class="container py-20">
-    <p class="text-xs tracking-widest uppercase text-primary/70">Case study</p>
-    <h1 class="text-5xl mt-2">{study.title}</h1>
+    <p class="text-primary/70 text-xs uppercase tracking-widest">Case study</p>
+    <h1 class="mt-2 text-5xl">{study.title}</h1>
     <p class="text-foreground/70 mt-2">{study.role} · {study.period}</p>
     <p class="mt-6 max-w-2xl">{study.tagline}</p>
-    <ul class="flex flex-wrap gap-2 mt-6">
-      {study.stack.map((t) => <li class="px-3 py-1 rounded bg-primary/10 text-primary text-sm">{t}</li>)}
+    <ul class="mt-6 flex flex-wrap gap-2">
+      {
+        study.stack.map((t) => (
+          <li class="bg-primary/10 text-primary rounded px-3 py-1 text-sm">
+            {t}
+          </li>
+        ))
+      }
     </ul>
     {study.sections.map((section) => <CaseStudySection section={section} />)}
   </article>
@@ -883,23 +904,41 @@ export function getStaticPaths() {
 }
 const lang = Astro.currentLocale === 'zh' ? 'zh' : 'en';
 const projects = (await getProjects({ lang })).sort(
-  (a, b) => Number(b.featured) - Number(a.featured) || (a.order ?? 99) - (b.order ?? 99),
+  (a, b) =>
+    Number(b.featured) - Number(a.featured) ||
+    (a.order ?? 99) - (b.order ?? 99),
 );
 ---
-<Layout title="Portfolio" description="Selected work — interactive case studies.">
+
+<Layout
+  title="Portfolio"
+  description="Selected work — interactive case studies."
+>
   <main class="container py-20">
-    <h1 class="text-4xl mb-10">Portfolio</h1>
+    <h1 class="mb-10 text-4xl">Portfolio</h1>
     <ul class="grid gap-8 md:grid-cols-2">
-      {projects.map((p) => {
-        const href = hasCaseStudy(p.slug) ? getRelativeLocaleUrl(lang, `/portfolio/${p.slug}`) : undefined;
-        return (
-          <li class="rounded-lg border p-6" data-project={hasCaseStudy(p.slug) ? p.slug : undefined}>
-            <h2 class="text-2xl">{p.name}</h2>
-            {href ? <a class="text-primary underline mt-4 inline-block" href={href}>View case study →</a>
-                  : <p class="text-foreground/60 mt-4 text-sm">Summary</p>}
-          </li>
-        );
-      })}
+      {
+        projects.map((p) => {
+          const href = hasCaseStudy(p.slug)
+            ? getRelativeLocaleUrl(lang, `/portfolio/${p.slug}`)
+            : undefined;
+          return (
+            <li
+              class="rounded-lg border p-6"
+              data-project={hasCaseStudy(p.slug) ? p.slug : undefined}
+            >
+              <h2 class="text-2xl">{p.name}</h2>
+              {href ? (
+                <a class="text-primary mt-4 inline-block underline" href={href}>
+                  View case study →
+                </a>
+              ) : (
+                <p class="text-foreground/60 mt-4 text-sm">Summary</p>
+              )}
+            </li>
+          );
+        })
+      }
     </ul>
   </main>
 </Layout>

--- a/libs/personal-portfolio/src/sections/CaseStudySection.astro
+++ b/libs/personal-portfolio/src/sections/CaseStudySection.astro
@@ -67,17 +67,23 @@ const hasIsland = HYDRATED_KINDS.includes(section.interaction);
 
 <section class="py-14" aria-labelledby={`sec-${section.id}`}>
   <div class="max-w-prose">
-    <p class="text-xs tracking-widest uppercase text-primary/70">{section.title}</p>
-    <h3 id={`sec-${section.id}`} class="mt-2 text-2xl leading-snug">{section.feature}</h3>
-    <p class="mt-4 border-l-2 border-primary/50 pl-4 italic">{section.contribution}</p>
-    <p class="mt-4 leading-relaxed text-foreground/80">
+    <p class="text-primary/70 text-xs uppercase tracking-widest">
+      {section.title}
+    </p>
+    <h3 id={`sec-${section.id}`} class="mt-2 text-2xl leading-snug">
+      {section.feature}
+    </h3>
+    <p class="border-primary/50 mt-4 border-l-2 pl-4 italic">
+      {section.contribution}
+    </p>
+    <p class="text-foreground/80 mt-4 leading-relaxed">
       {
         techSegments.map((seg) =>
           seg.code ? (
-            <code class="rounded bg-muted px-1 py-0.5 text-sm">{seg.text}</code>
+            <code class="bg-muted rounded px-1 py-0.5 text-sm">{seg.text}</code>
           ) : (
             <span>{seg.text}</span>
-          )
+          ),
         )
       }
     </p>
@@ -90,23 +96,41 @@ const hasIsland = HYDRATED_KINDS.includes(section.interaction);
         {section.interaction === 'live-ledger' && <LiveLedger client:load />}
         {section.interaction === 'idle-lock' && <IdleLock client:load />}
         {section.interaction === 'relay-gate' && <RelayGate client:load />}
-        {section.interaction === 'virtualized-search' && <VirtualizedSearch client:load />}
+        {section.interaction === 'virtualized-search' && (
+          <VirtualizedSearch client:load />
+        )}
         {section.interaction === 'order-book' && <OrderBook client:load />}
-        {section.interaction === 'fetch-then-stream' && <FetchThenStream client:load />}
-        {section.interaction === 'wallet-state-machine' && <WalletStateMachine client:load />}
-        {section.interaction === 'patch-vs-refetch' && <PatchVsRefetch client:load />}
+        {section.interaction === 'fetch-then-stream' && (
+          <FetchThenStream client:load />
+        )}
+        {section.interaction === 'wallet-state-machine' && (
+          <WalletStateMachine client:load />
+        )}
+        {section.interaction === 'patch-vs-refetch' && (
+          <PatchVsRefetch client:load />
+        )}
         {section.interaction === 'amm-quote' && <AmmQuote client:load />}
         {section.interaction === 'offer-state' && <OfferState client:load />}
-        {section.interaction === 'zap-liquidity' && <ZapLiquidity client:load />}
+        {section.interaction === 'zap-liquidity' && (
+          <ZapLiquidity client:load />
+        )}
         {section.interaction === 'env-deploy' && <EnvDeploy client:load />}
         {section.interaction === 'i18n-card' && <I18nCard client:load />}
         {section.interaction === 'jwt-decode' && <JwtDecode client:load />}
         {section.interaction === 'role-shell' && <RoleShell client:load />}
-        {section.interaction === 'casbin-playground' && <CasbinPlayground client:load />}
+        {section.interaction === 'casbin-playground' && (
+          <CasbinPlayground client:load />
+        )}
         {section.interaction === 'phi-encrypt' && <PhiEncrypt client:load />}
-        {section.interaction === 'affected-pipeline' && <AffectedPipeline client:load />}
+        {section.interaction === 'affected-pipeline' && (
+          <AffectedPipeline client:load />
+        )}
       </div>
     )
   }
-  {section.sourceRef && <p class="mt-4 text-xs text-foreground/50">Mirrors {section.sourceRef}</p>}
+  {
+    section.sourceRef && (
+      <p class="text-foreground/50 mt-4 text-xs">Mirrors {section.sourceRef}</p>
+    )
+  }
 </section>

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "lit": "catalog:",
     "nx": "23.1.0",
     "prettier": "^3.6.2",
+    "prettier-plugin-astro": "^0.14.1",
     "prettier-plugin-tailwindcss": "0.6.11",
     "storybook": "10.5.3",
     "tslib": "^2.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,9 +165,12 @@ importers:
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
+      prettier-plugin-astro:
+        specifier: ^0.14.1
+        version: 0.14.1
       prettier-plugin-tailwindcss:
         specifier: 0.6.11
-        version: 0.6.11(prettier@3.6.2)
+        version: 0.6.11(prettier-plugin-astro@0.14.1)(prettier@3.6.2)
       storybook:
         specifier: 10.5.3
         version: 10.5.3(@types/react@19.2.9)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -475,7 +478,7 @@ importers:
     devDependencies:
       '@astrojs/check':
         specifier: ^0.9.9
-        version: 0.9.9(prettier@3.8.4)(typescript@6.0.3)
+        version: 0.9.9(prettier-plugin-astro@0.14.1)(prettier@3.8.4)(typescript@6.0.3)
       '@tailwindcss/forms':
         specifier: ^0.5.11
         version: 0.5.11(tailwindcss@4.2.2)
@@ -11862,6 +11865,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  prettier-plugin-astro@0.14.1:
+    resolution: {integrity: sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==}
+    engines: {node: ^14.15.0 || >=16.0.0}
+
   prettier-plugin-tailwindcss@0.6.11:
     resolution: {integrity: sha512-YxaYSIvZPAqhrrEpRtonnrXdghZg1irNg4qrjboCXrpybLWVs55cW2N3juhspVJiO0JBvYJT8SYsJpc8OQSnsA==}
     engines: {node: '>=14.21.3'}
@@ -12423,6 +12430,9 @@ packages:
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
+  s.color@0.0.15:
+    resolution: {integrity: sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==}
+
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
@@ -12567,6 +12577,9 @@ packages:
     resolution: {integrity: sha512-Ut8wlQSk19tm7jMK6mz6cF1+e+E7tUnW2tM02zQDPnOTcVbV8qCQG8UWxZkkNlY50+hV3hqP24OOkUlMz8xBpw==}
     engines: {node: '>=16.0.0'}
     hasBin: true
+
+  sass-formatter@0.7.9:
+    resolution: {integrity: sha512-CWZ8XiSim+fJVG0cFLStwDvft1VI7uvXdCNJYXhDvowiv+DsbD1nXLiQ4zrE5UBvj5DWZJ93cwN0NX5PMsr1Pw==}
 
   sass-loader@16.0.8:
     resolution: {integrity: sha512-hcov4ZwZJIGbEuyNr9EmiTmZueyrxSToE6GOzoZnq5JM7ecRO7ttyvilPn+VmRsqiP16+VYZzVnGZj/hzZgKBA==}
@@ -13171,6 +13184,9 @@ packages:
     resolution: {integrity: sha512-ZIdT8eUv8tegmqy1tTIdJv9We2DumkNZFdCF5mz/Kpq3OcTaxSuCAYZge6HKK2CmNC02G1eJig2RV7XTw5hQrA==}
     engines: {node: '>=16'}
     hasBin: true
+
+  suf-log@2.5.3:
+    resolution: {integrity: sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==}
 
   super-regex@1.1.0:
     resolution: {integrity: sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==}
@@ -14843,9 +14859,9 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@astrojs/check@0.9.9(prettier@3.8.4)(typescript@6.0.3)':
+  '@astrojs/check@0.9.9(prettier-plugin-astro@0.14.1)(prettier@3.8.4)(typescript@6.0.3)':
     dependencies:
-      '@astrojs/language-server': 2.16.10(prettier@3.8.4)(typescript@6.0.3)
+      '@astrojs/language-server': 2.16.10(prettier-plugin-astro@0.14.1)(prettier@3.8.4)(typescript@6.0.3)
       chokidar: 4.0.3
       kleur: 4.1.5
       typescript: 6.0.3
@@ -14936,7 +14952,7 @@ snapshots:
       smol-toml: 1.6.1
       unified: 11.0.5
 
-  '@astrojs/language-server@2.16.10(prettier@3.8.4)(typescript@6.0.3)':
+  '@astrojs/language-server@2.16.10(prettier-plugin-astro@0.14.1)(prettier@3.8.4)(typescript@6.0.3)':
     dependencies:
       '@astrojs/compiler': 2.13.1
       '@astrojs/yaml2ts': 0.2.4
@@ -14958,6 +14974,7 @@ snapshots:
       vscode-uri: 3.1.0
     optionalDependencies:
       prettier: 3.8.4
+      prettier-plugin-astro: 0.14.1
     transitivePeerDependencies:
       - typescript
 
@@ -29456,9 +29473,17 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-tailwindcss@0.6.11(prettier@3.6.2):
+  prettier-plugin-astro@0.14.1:
+    dependencies:
+      '@astrojs/compiler': 2.13.1
+      prettier: 3.8.4
+      sass-formatter: 0.7.9
+
+  prettier-plugin-tailwindcss@0.6.11(prettier-plugin-astro@0.14.1)(prettier@3.6.2):
     dependencies:
       prettier: 3.6.2
+    optionalDependencies:
+      prettier-plugin-astro: 0.14.1
 
   prettier@3.6.2: {}
 
@@ -30121,6 +30146,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  s.color@0.0.15: {}
+
   safe-array-concat@1.1.3:
     dependencies:
       call-bind: 1.0.8
@@ -30244,6 +30271,10 @@ snapshots:
       sass-embedded-unknown-all: 1.100.0
       sass-embedded-win32-arm64: 1.100.0
       sass-embedded-win32-x64: 1.100.0
+
+  sass-formatter@0.7.9:
+    dependencies:
+      suf-log: 2.5.3
 
   sass-loader@16.0.8(@rspack/core@1.6.8(@swc/helpers@0.5.18))(sass-embedded@1.100.0)(sass@1.101.0)(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.28.1)(postcss@8.5.15)):
     dependencies:
@@ -31091,6 +31122,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
     optional: true
+
+  suf-log@2.5.3:
+    dependencies:
+      s.color: 0.0.15
 
   super-regex@1.1.0:
     dependencies:


### PR DESCRIPTION
## Problem

PR #256 added `format:check` to CI, but Prettier has no built-in `.astro` parser. All **41 tracked `.astro` files** — every page and component of the site — were silently skipped. `pnpm exec prettier --check path/to/x.astro` failed outright with *"No parser could be inferred"*, so the gate was reporting green over a blind spot.

## Change

Three commits, deliberately separate so the mechanical reformat is reviewable apart from the decisions:

1. **`cb05290` — config only.** Adds `prettier-plugin-astro` and registers it. Plugin order matters: `prettier-plugin-tailwindcss` must stay **last** or class sorting stops running.
2. **`0e07203` — one real code change.** `prettier-plugin-astro` cannot round-trip `<></>`: it emits `< />` and then fails to reparse its own output. Three files hit this. Replaced with `null`, which is also the clearer way to say "render nothing" in a ternary else-branch or an early return.
3. **`98b850c` — the reformat.** 26 `.astro` + 4 markdown files. Line-wrapping plus first-time Tailwind class sorting. No markup or logic altered.

## Verification

| Gate | Result |
|---|---|
| `pnpm nx run-many -t test --all` | ✅ 5 projects |
| `pnpm nx run-many -t build --all` | ✅ 6 projects |
| `pnpm format:check` | ✅ exit 0 |
| `pnpm nx lint personal-website` | ✅ 0 errors (7 pre-existing warnings) |

The site's pages are `.astro`, so the build passing is the real proof a bad reformat didn't land. Frontmatter fences were checked for balance across every touched file, and the inline `<style>`/`<script>` blocks (in `SettingsMenu`, `theme-provider`, `head`, `HomePage`, `ResumePage`) reformatted as wrapping only.

## Note for reviewers

Reading `prettier --check .` output: it **misattributes error messages to the wrong filenames** when files are processed concurrently. Ten markdown files appeared in the failure list and were all clean when checked individually. Only per-file checks are trustworthy for diagnosing a parse failure.

Refs: no-ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up: verified against build output, not just the exit code

Diffing the 24 prerendered pages before vs after showed all 24 differing — but a **control build of the same commit twice also differs on all 24**, so that is the noise floor, not a signal. The per-build randomness is: server-island UUIDs, encrypted island payloads, Vue hydration uids, a style-prefix counter, a randomly-selected hero image, and the DEX demo's randomly-generated market data.

Excluding those, **20 of 24 pages are byte-identical** and the remaining 4 differ only in the random hero image and demo numbers.

One genuine output change: the CSS bundle is **37 bytes smaller**. `prettier-plugin-tailwindcss` sorted `@apply snap-always snap-start` → `@apply snap-start snap-always` in `HomePage.astro`, which dropped the standalone `.snap-always{scroll-snap-stop:always}` utility from the bundle.

That utility was **dead code** — `snap-always` appears exactly once in the entire repo, inside that `@apply`, and never as a class attribute. It was only ever emitted because Tailwind's content scanner picks up bare words from source text, and `snap-always;` (terminated by the semicolon) no longer registers as a candidate where ` snap-always ` did.

The rule that actually styles the page is unchanged, byte for byte:

```css
main[data-astro-cid-irahaz3f]>section[data-astro-cid-irahaz3f]{scroll-snap-align:start;scroll-snap-stop:always}
```

Tailwind emits `@apply` declarations in its own canonical order, so reordering the source has no effect on output. Net result: identical rendering, 37 bytes less dead CSS.