### PR TITLE
⌘K command palette, powered by on-device AI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ deploy/.env.dev
 .worktrees/
 
 libs/portfolio/.reference/
+
+# superpowers brainstorming mockups
+.superpowers/

--- a/apps/personal-website/package.json
+++ b/apps/personal-website/package.json
@@ -89,6 +89,11 @@
           "^build"
         ],
         "cache": true
+      },
+      "test": {
+        "dependsOn": [
+          "^build"
+        ]
       }
     }
   }

--- a/apps/personal-website/package.json
+++ b/apps/personal-website/package.json
@@ -69,6 +69,7 @@
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@vite-pwa/astro": "^1.2.0",
+    "@vue/test-utils": "^2.4.11",
     "@webgpu/types": "^0.1.69",
     "astro-compress": "^2.4.1",
     "eslint-plugin-astro": "^1.7.0",

--- a/apps/personal-website/src/components/blog/SummarizeButton.vue
+++ b/apps/personal-website/src/components/blog/SummarizeButton.vue
@@ -3,7 +3,7 @@ import { computed, onMounted } from 'vue';
 
 import { Button } from '@/components/ui/button';
 import { useSummarizer } from '@utils/ai';
-import { isSummarizable, toProse } from '@utils/article-text';
+import { isSummarizable, toBullets, toProse } from '@utils/article-text';
 
 // `text` is the post's MDX body, passed from the layout rather than scraped from the DOM.
 // Scraping would pick up the nav, the comment widget and the footer; the collection body is
@@ -21,6 +21,7 @@ const { state, summary, failure, busy, progress, refresh, run, reset } =
 onMounted(refresh);
 
 const prose = computed(() => toProse(props.text));
+const bullets = computed(() => (summary.value ? toBullets(summary.value) : []));
 
 /**
  * Posts that are mostly imports, headings and live island tags have nothing to summarize. Asking
@@ -97,9 +98,12 @@ const FAILURE_COPY: Record<string, string> = {
         <p class="text-muted-foreground mb-2 text-xs uppercase">
           On-device summary
         </p>
-        <!-- Rendered as text, not markdown: this is model output, and injecting it as HTML would
-             hand an unreviewed generator a path into the page. -->
-        <p class="whitespace-pre-line text-sm">{{ summary }}</p>
+        <!-- The list markup is ours; only the words are the model's. Each bullet is
+             interpolated as text — never v-html — so an unreviewed generator has no path
+             into the page. -->
+        <ul class="list-inside list-disc space-y-1 text-sm">
+          <li v-for="(point, i) in bullets" :key="i">{{ point }}</li>
+        </ul>
       </div>
 
       <p

--- a/apps/personal-website/src/components/blog/SummarizeButton.vue
+++ b/apps/personal-website/src/components/blog/SummarizeButton.vue
@@ -1,0 +1,115 @@
+<script setup lang="ts">
+import { computed, onMounted } from 'vue';
+
+import { Button } from '@/components/ui/button';
+import { useSummarizer } from '@utils/ai';
+import { isSummarizable, toProse } from '@utils/article-text';
+
+// `text` is the post's MDX body, passed from the layout rather than scraped from the DOM.
+// Scraping would pick up the nav, the comment widget and the footer; the collection body is
+// exactly the article and nothing else.
+const props = defineProps<{ text: string }>();
+
+// key-points over tldr: these are technical posts, and a reader deciding whether to invest ten
+// minutes is served better by "what is in here" than by a compressed narrative.
+const { state, summary, failure, busy, progress, refresh, run, reset } =
+  useSummarizer({ type: 'key-points', format: 'markdown', length: 'short' });
+
+// Probe on mount, not at module load: `Summarizer` is only meaningful in the browser. Re-probing
+// per mount also matters under ClientRouter, which remounts on every navigation — a verdict from
+// the previous page would otherwise linger.
+onMounted(refresh);
+
+const prose = computed(() => toProse(props.text));
+
+/**
+ * Posts that are mostly imports, headings and live island tags have nothing to summarize. Asking
+ * anyway does not fail — it returns the source echoed back, which reads as a broken feature. Found
+ * by running this against web-ai.mdx, whose body is almost entirely demo components.
+ */
+const worthSummarizing = computed(() => isSummarizable(props.text));
+
+const canRender = computed(
+  () =>
+    worthSummarizing.value &&
+    state.value.kind !== 'unsupported' &&
+    state.value.kind !== 'unavailable',
+);
+
+const FAILURE_COPY: Record<string, string> = {
+  timeout:
+    'The on-device model took too long. The article is below, unchanged.',
+  'too-long': 'This article is too long for the on-device model to summarize.',
+  'needs-gesture':
+    'The model download needs a direct click to start. Try the button again.',
+  failed: "The on-device model couldn't summarize this one.",
+};
+</script>
+
+<template>
+  <!--
+    Renders only when the browser can actually do this AND the post has prose worth reducing.
+    `unsupported` (no Summarizer — Firefox/Safari today) and `unavailable` (present, but this
+    machine can't serve it) both render nothing rather than a control that would fail on click.
+  -->
+  <div v-if="canRender" class="not-prose my-6">
+    <!--
+      Its own opaque surface, not just the article wrapper's. On a post with a hero image the
+      article is pulled up over the photo, and `bg-background/25 backdrop-blur-sm` is not enough
+      to keep small muted text legible against a photograph — it was measurably unreadable there.
+    -->
+    <div class="bg-card rounded-lg border p-3">
+      <div class="flex flex-wrap items-center gap-x-3 gap-y-2">
+        <Button
+          variant="outline"
+          size="default"
+          :disabled="busy"
+          @click="summary || failure ? reset() : run(prose)"
+        >
+          <span v-if="busy">Summarizing…</span>
+          <span v-else-if="summary || failure">Hide summary</span>
+          <span v-else-if="state.kind === 'downloadable'"
+            >Summarize on-device (downloads a model)</span
+          >
+          <span v-else>Summarize this post</span>
+        </Button>
+        <!--
+          The download is hundreds of megabytes, so a first run would otherwise look like a hang.
+          Naming it as a download is the difference between "slow" and "broken".
+        -->
+        <span
+          v-if="busy && state.kind === 'downloading'"
+          class="text-foreground/80 text-sm"
+        >
+          Downloading the model… {{ Math.round(progress * 100) }}%
+        </span>
+        <span class="text-muted-foreground text-xs">
+          Runs entirely in your browser — the article is never sent anywhere.
+        </span>
+      </div>
+
+      <div
+        v-if="summary"
+        class="border-border mt-3 border-t pt-3"
+        role="region"
+        aria-label="On-device summary"
+      >
+        <p class="text-muted-foreground mb-2 text-xs uppercase">
+          On-device summary
+        </p>
+        <!-- Rendered as text, not markdown: this is model output, and injecting it as HTML would
+             hand an unreviewed generator a path into the page. -->
+        <p class="whitespace-pre-line text-sm">{{ summary }}</p>
+      </div>
+
+      <p
+        v-else-if="failure"
+        class="text-muted-foreground mt-3 text-sm"
+        role="status"
+        aria-live="polite"
+      >
+        {{ FAILURE_COPY[failure] }}
+      </p>
+    </div>
+  </div>
+</template>

--- a/apps/personal-website/src/components/blog/TranslateButton.vue
+++ b/apps/personal-website/src/components/blog/TranslateButton.vue
@@ -1,0 +1,164 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref } from 'vue';
+
+import { Button } from '@/components/ui/button';
+import {
+  type AiState,
+  destroyTranslator,
+  detectTranslatorCapability,
+  TranslateError,
+  type TranslateFailure,
+  translateChunks,
+} from '@utils/ai';
+
+/**
+ * Translates the rendered article in place, on-device.
+ *
+ * This fills a real gap rather than duplicating i18n: the site's UI is already bilingual through
+ * i18next, but every blog post exists only in English. There is nothing to switch to, so the
+ * choice is between machine translation in the reader's browser and nothing at all.
+ *
+ * A separate control from the summarize one, in its own card, because the two capabilities
+ * degrade independently — a browser can ship Summarizer and still not have this language pair.
+ */
+const props = defineProps<{ target?: string }>();
+
+const PAIR = {
+  sourceLanguage: 'en',
+  targetLanguage: props.target ?? 'zh-Hant',
+};
+
+const state = ref<AiState>({ kind: 'unsupported' });
+const busy = ref(false);
+const translated = ref(false);
+const failure = ref<TranslateFailure | null>(null);
+const done = ref(0);
+const total = ref(0);
+
+/**
+ * The nodes whose text gets replaced, paired with their original text so the toggle can restore
+ * them without a reload.
+ *
+ * Deliberately narrow: paragraphs, list items and headings. Code blocks, inline code and KaTeX
+ * output are excluded — translating a code sample corrupts it, and the math nodes carry rendered
+ * markup whose text content is not prose at all.
+ */
+let originals: Array<{ node: HTMLElement; text: string }> = [];
+
+function collectProseNodes(): Array<{ node: HTMLElement; text: string }> {
+  const article = document.querySelector('article');
+  if (!article) return [];
+  const candidates = article.querySelectorAll<HTMLElement>('p, li, h2, h3, h4');
+  return [...candidates]
+    .filter((node) => {
+      if (node.closest('pre, code, .katex, .not-prose')) return false;
+      // A paragraph that only wraps a KaTeX block has no prose of its own.
+      if (node.querySelector('pre, code, .katex')) return false;
+      const text = node.textContent?.trim() ?? '';
+      return text.length > 0;
+    })
+    .map((node) => ({ node, text: node.textContent ?? '' }));
+}
+
+async function refresh() {
+  state.value = await detectTranslatorCapability(PAIR);
+}
+
+async function run() {
+  if (busy.value) return;
+
+  // Toggling back is local: the originals are held in memory, so restoring costs nothing and
+  // never re-runs the model.
+  if (translated.value) {
+    for (const { node, text } of originals) node.textContent = text;
+    translated.value = false;
+    return;
+  }
+
+  busy.value = true;
+  failure.value = null;
+  done.value = 0;
+  originals = collectProseNodes();
+  total.value = originals.length;
+
+  try {
+    await translateChunks(
+      originals.map((entry) => entry.text),
+      PAIR,
+      {
+        onProgress: (value) => {
+          if (value < 1) state.value = { kind: 'downloading', progress: value };
+        },
+        // Swapped in as each lands rather than all at the end: a page-length article takes long
+        // enough that a motionless page reads as a hang.
+        onChunk: (index, text) => {
+          const entry = originals[index];
+          if (entry) entry.node.textContent = text;
+          done.value = index + 1;
+        },
+      },
+    );
+    translated.value = true;
+    state.value = { kind: 'ready' };
+  } catch (cause) {
+    failure.value = cause instanceof TranslateError ? cause.reason : 'failed';
+    // Put back whatever was already swapped, so a partial failure never leaves the article
+    // half in one language and half in the other.
+    for (const { node, text } of originals) node.textContent = text;
+    translated.value = false;
+    await refresh();
+  } finally {
+    busy.value = false;
+  }
+}
+
+onMounted(refresh);
+onUnmounted(destroyTranslator);
+
+const FAILURE_COPY: Record<string, string> = {
+  timeout: '翻譯逾時，已還原原文。',
+  'too-long': '這篇文章太長，裝置端模型無法翻譯。',
+  'needs-gesture': '模型下載需要直接點擊才能開始，請再按一次。',
+  failed: '裝置端翻譯失敗，已還原原文。',
+};
+</script>
+
+<template>
+  <div
+    v-if="state.kind !== 'unsupported' && state.kind !== 'unavailable'"
+    class="not-prose my-6"
+  >
+    <!-- Its own opaque surface, same reason as the summarize control: on a post with a hero image
+         the article is pulled up over the photo, where muted text is unreadable. -->
+    <div class="bg-card rounded-lg border p-3">
+      <div class="flex flex-wrap items-center gap-x-3 gap-y-2">
+        <Button variant="outline" :disabled="busy" @click="run">
+          <span v-if="busy">翻譯中… {{ done }}/{{ total }}</span>
+          <span v-else-if="translated">顯示原文</span>
+          <span v-else-if="state.kind === 'downloadable'"
+            >翻譯成中文（需下載模型）</span
+          >
+          <span v-else>翻譯成中文</span>
+        </Button>
+        <span
+          v-if="busy && state.kind === 'downloading'"
+          class="text-foreground/80 text-sm"
+        >
+          正在下載翻譯模型…
+        </span>
+        <span class="text-muted-foreground text-xs">
+          完全在你的瀏覽器內執行，文章不會傳送到任何地方。程式碼與數學式維持原樣。
+        </span>
+      </div>
+
+      <p
+        v-if="failure"
+        class="text-muted-foreground mt-3 text-sm"
+        role="status"
+        aria-live="polite"
+      >
+        {{ FAILURE_COPY[failure] }}
+      </p>
+    </div>
+  </div>
+</template>

--- a/apps/personal-website/src/components/blog/demo/edge-ai/index.ts
+++ b/apps/personal-website/src/components/blog/demo/edge-ai/index.ts
@@ -1,0 +1,3 @@
+import SupportTable from './support-table.vue';
+
+export { SupportTable };

--- a/apps/personal-website/src/components/blog/demo/edge-ai/support-table.vue
+++ b/apps/personal-website/src/components/blog/demo/edge-ai/support-table.vue
@@ -1,0 +1,134 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+
+import {
+  type AiState,
+  detectCapability,
+  detectSummarizerCapability,
+  detectTranslatorCapability,
+} from '@utils/ai';
+
+/**
+ * Probes the three built-in AI APIs in the reader's own browser and reports what it found.
+ *
+ * A live probe rather than a compatibility table copied from a doc, because the interesting fact
+ * about this platform right now is how *unevenly* it has landed — and a static table cannot show
+ * you your own browser. Measured 2026-07-29, Chrome 150 and Edge 150 are both Chromium 150 and
+ * still disagree: Edge ships Summarizer and Translator with no Prompt API at all. Version
+ * sniffing would get this wrong; only feature detection gets it right.
+ *
+ * Every row degrades on its own. A browser with none of them sees an honest "not here yet" rather
+ * than an empty table or a thrown error — unlike ../webgpu/check-gpu.vue, which throws outright
+ * when WebGPU is absent.
+ */
+
+type Row = {
+  name: string;
+  what: string;
+  state: AiState | null;
+};
+
+const rows = ref<Row[]>([
+  {
+    name: 'Prompt API',
+    what: 'Free-form generation and tool selection',
+    state: null,
+  },
+  {
+    name: 'Summarizer',
+    what: 'Condenses a passage into key points',
+    state: null,
+  },
+  {
+    name: 'Translator',
+    what: 'Translates between a language pair',
+    state: null,
+  },
+]);
+
+const probing = ref(true);
+
+onMounted(async () => {
+  // Probed with the exact options each feature would use: availability is answered per
+  // configuration and per language pair, so a bare probe can report "ready" about something the
+  // caller never asked for.
+  const [prompt, summarizer, translator] = await Promise.all([
+    detectCapability(),
+    detectSummarizerCapability({
+      type: 'key-points',
+      format: 'markdown',
+      length: 'short',
+    }),
+    detectTranslatorCapability({
+      sourceLanguage: 'en',
+      targetLanguage: 'zh-Hant',
+    }),
+  ]);
+  rows.value[0]!.state = prompt;
+  rows.value[1]!.state = summarizer;
+  rows.value[2]!.state = translator;
+  probing.value = false;
+});
+
+const LABELS: Record<AiState['kind'], string> = {
+  unsupported: 'Not in this browser',
+  unavailable: 'Present, unavailable here',
+  downloadable: 'Available — needs a download',
+  downloading: 'Downloading',
+  ready: 'Ready now',
+};
+
+const supported = (state: AiState | null) =>
+  state !== null &&
+  state.kind !== 'unsupported' &&
+  state.kind !== 'unavailable';
+
+const noneSupported = computed(
+  () => !probing.value && rows.value.every((row) => !supported(row.state)),
+);
+</script>
+
+<template>
+  <div class="not-prose my-6 rounded-lg border p-4">
+    <p class="text-muted-foreground mb-3 text-xs uppercase">
+      Your browser, right now
+    </p>
+
+    <p v-if="probing" class="text-muted-foreground text-sm">Checking…</p>
+
+    <table v-else class="w-full text-sm">
+      <thead>
+        <tr class="text-muted-foreground text-left text-xs uppercase">
+          <th class="pb-2 font-normal">API</th>
+          <th class="pb-2 font-normal">What it does</th>
+          <th class="pb-2 font-normal">Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="row in rows" :key="row.name" class="border-t">
+          <td class="py-2 pr-3 font-medium">{{ row.name }}</td>
+          <td class="text-muted-foreground py-2 pr-3">{{ row.what }}</td>
+          <td class="py-2">
+            <span
+              :class="
+                supported(row.state) ? 'text-primary' : 'text-muted-foreground'
+              "
+            >
+              {{ row.state ? LABELS[row.state.kind] : '—' }}
+            </span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <!--
+      The fallback that matters. A reader on Firefox or Safari today sees all three unsupported,
+      and telling them plainly beats an empty table — the point of the post is that this is uneven,
+      so "nothing here yet" is itself the result, not a failure.
+    -->
+    <p v-if="noneSupported" class="text-muted-foreground mt-3 text-sm">
+      None of these are in this browser yet. That is the normal case today — the
+      recording below shows what the features look like where they do run.
+    </p>
+  </div>
+</template>

--- a/apps/personal-website/src/components/blog/demo/index.ts
+++ b/apps/personal-website/src/components/blog/demo/index.ts
@@ -1,2 +1,3 @@
+export * from './edge-ai';
 export * from './quick-posts';
 export * from './webgpu';

--- a/apps/personal-website/src/components/blog/demo/webgpu/check-gpu.vue
+++ b/apps/personal-website/src/components/blog/demo/webgpu/check-gpu.vue
@@ -1,5 +1,8 @@
 <template>
-  <table>
+  <p v-if="unsupported" class="not-prose text-muted-foreground text-sm">
+    {{ unsupported }}
+  </p>
+  <table v-else>
     <thead>
       <tr>
         <th>Architecture</th>
@@ -22,17 +25,23 @@
 import { onMounted, ref } from 'vue';
 
 const adapter = ref<GPUAdapter | null>(null);
+const unsupported = ref<string | null>(null);
 onMounted(() => {
   init();
 });
 async function init() {
+  // Reported, not thrown. A reader whose browser lacks WebGPU is the ordinary case for this post,
+  // and an uncaught error left the table rendered but permanently blank with the reason only in
+  // the console.
   if (!navigator.gpu) {
-    throw Error('WebGPU not supported.');
+    unsupported.value = 'This browser has no WebGPU.';
+    return;
   }
 
   adapter.value = await navigator.gpu.requestAdapter();
   if (!adapter.value) {
-    throw Error("Couldn't request WebGPU adapter.");
+    unsupported.value = 'WebGPU is present, but no adapter was available.';
+    return;
   }
 
   const device = await adapter.value.requestDevice();

--- a/apps/personal-website/src/components/blog/index.ts
+++ b/apps/personal-website/src/components/blog/index.ts
@@ -2,3 +2,4 @@ export { default as Baseline } from './baseline.astro';
 export { default as Comments } from './comments.astro';
 export { default as Navigation } from './navigation.astro';
 export { default as Post } from './post.astro';
+export { default as SummarizeButton } from './SummarizeButton.vue';

--- a/apps/personal-website/src/components/blog/index.ts
+++ b/apps/personal-website/src/components/blog/index.ts
@@ -3,3 +3,4 @@ export { default as Comments } from './comments.astro';
 export { default as Navigation } from './navigation.astro';
 export { default as Post } from './post.astro';
 export { default as SummarizeButton } from './SummarizeButton.vue';
+export { default as TranslateButton } from './TranslateButton.vue';

--- a/apps/personal-website/src/components/shell/CommandPalette.test.ts
+++ b/apps/personal-website/src/components/shell/CommandPalette.test.ts
@@ -1,0 +1,153 @@
+// The answer strip's three states, which until now were only ever verified by driving a real
+// browser by hand. Each of them was, at some point, silently wrong: the strip vanished instead of
+// answering (no session), vanished instead of reporting a rejected argument (schema near-miss),
+// and said "couldn't answer" when it meant "took too long" (the composable converts a throw into
+// null, so the timeout never reached the catch that classified it).
+//
+// The AI composable and the tool catalog are mocked rather than exercised: the point here is the
+// component's own branching, and the catalog's real implementation drags in the content library.
+// selectTool's behaviour has its own tests in utils/ai/language-model.test.ts.
+import type { AiState } from '@utils/ai';
+import { flushPromises, mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+
+const aiState = ref<AiState>({ kind: 'ready' });
+const aiError = ref<Error | null>(null);
+const selectToolMock = vi.fn();
+const executeMock = vi.fn();
+
+vi.mock('@utils/ai', () => ({
+  useLanguageModel: () => ({
+    state: aiState,
+    error: aiError,
+    refresh: vi.fn(),
+    enable: vi.fn(),
+    selectTool: selectToolMock,
+  }),
+  registerAgentTools: () => ({ registered: [], dispose: vi.fn() }),
+}));
+
+vi.mock('../../mcp/catalog', () => ({
+  PROFILE_TOOLS: [
+    {
+      name: 'get_projects',
+      description: 'Portfolio projects',
+      params: {},
+      run: vi.fn(),
+      summarise: () => 'vue appears in 0 projects.',
+    },
+  ],
+  toToolDescriptors: () => [
+    {
+      name: 'get_projects',
+      description: 'Portfolio projects',
+      inputSchema: {},
+      execute: executeMock,
+    },
+  ],
+}));
+
+const { default: CommandPalette } = await import('./CommandPalette.vue');
+
+const RECORDS = [
+  {
+    id: 'p1',
+    kind: 'project' as const,
+    title: 'Hoogii Wallet',
+    keywords: ['react'],
+    href: '/portfolio/hoogii-wallet',
+  },
+];
+
+/** Opens the palette, types `query`, and activates the Ask row. */
+async function ask(query: string) {
+  const wrapper = mount(CommandPalette, {
+    props: { records: RECORDS, lang: 'en' as const },
+    attachTo: document.body,
+  });
+  window.dispatchEvent(
+    new KeyboardEvent('keydown', { key: 'k', metaKey: true }),
+  );
+  await flushPromises();
+
+  const input = wrapper.find('input');
+  await input.setValue(query);
+
+  const askRow = wrapper
+    .findAll('[role="option"]')
+    .find((row) => row.text().includes('Ask:'));
+  if (!askRow) throw new Error('no Ask row rendered');
+  await askRow.trigger('click');
+  await flushPromises();
+  return wrapper;
+}
+
+describe('CommandPalette answer strip', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    aiState.value = { kind: 'ready' };
+    aiError.value = null;
+  });
+
+  it('states the answer when the ask succeeds', async () => {
+    selectToolMock.mockResolvedValue({ tool: 'get_projects' });
+    executeMock.mockResolvedValue([]);
+
+    const wrapper = await ask('what projects use vue?');
+
+    expect(wrapper.text()).toContain('vue appears in 0 projects.');
+  });
+
+  // The composable returns null and parks the cause in `error` rather than rethrowing, so this
+  // case reaches the `!choice` branch — not the catch. Classifying only in the catch left this
+  // message unreachable, which is exactly the bug this pins.
+  it('says the model took too long when the run was aborted', async () => {
+    selectToolMock.mockResolvedValue(null);
+    aiError.value = new DOMException('aborted', 'AbortError');
+
+    const wrapper = await ask('what projects use vue?');
+
+    expect(wrapper.text()).toContain('took too long');
+    expect(wrapper.text()).not.toContain("Couldn't answer");
+  });
+
+  it('says it could not answer when the failure is not an abort', async () => {
+    selectToolMock.mockResolvedValue(null);
+    aiError.value = new Error('kErrorUnknown');
+
+    const wrapper = await ask('what projects use vue?');
+
+    expect(wrapper.text()).toContain("Couldn't answer");
+    expect(wrapper.text()).not.toContain('took too long');
+  });
+
+  // A rejected argument is a distinct path from a failed selection: the model chose a tool, and
+  // `execute` refused its arguments. It used to render as the same silent nothing.
+  it('reports a rejected argument rather than showing nothing', async () => {
+    selectToolMock.mockResolvedValue({ tool: 'get_projects' });
+    executeMock.mockRejectedValue(new Error('invalid enum value'));
+
+    const wrapper = await ask('what projects use vue?');
+
+    expect(wrapper.text()).toContain("Couldn't answer");
+  });
+
+  it('offers no Ask row when the model is not ready', async () => {
+    aiState.value = { kind: 'unsupported' };
+    const wrapper = mount(CommandPalette, {
+      props: { records: RECORDS, lang: 'en' as const },
+      attachTo: document.body,
+    });
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'k', metaKey: true }),
+    );
+    await flushPromises();
+    await wrapper.find('input').setValue('what projects use vue?');
+
+    expect(
+      wrapper.findAll('[role="option"]').some((r) => r.text().includes('Ask:')),
+    ).toBe(false);
+    expect(selectToolMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/personal-website/src/components/shell/CommandPalette.vue
+++ b/apps/personal-website/src/components/shell/CommandPalette.vue
@@ -10,6 +10,7 @@ import {
   registerAgentTools,
   useLanguageModel,
 } from '@utils/ai';
+import { tags } from '@utils/constants';
 import { searchRecords, type Searchable } from '@utils/search';
 
 // `lang` is unused by search, but a later task gates the AI path on locale. Accepting it now
@@ -72,7 +73,12 @@ const SELECTION_SCHEMA = {
   additionalProperties: false,
   properties: {
     tool: { type: 'string', enum: PROFILE_TOOLS.map((tool) => tool.name) },
-    technology: { type: 'string' },
+    // The same enum the tools' own params use, not a free string. Constrained decoding can only
+    // emit a member, so the model cannot answer "Vue" where the data says "vue" — it did exactly
+    // that when this was `{ type: 'string' }`, and `execute` then (correctly) rejected the near
+    // miss, leaving the strip blank. Making the wrong value unrepresentable beats validating it
+    // after the fact.
+    technology: { type: 'string', enum: tags.skills },
     query: { type: 'string' },
   },
 };

--- a/apps/personal-website/src/components/shell/CommandPalette.vue
+++ b/apps/personal-website/src/components/shell/CommandPalette.vue
@@ -5,7 +5,11 @@ import { computed, nextTick, onMounted, onUnmounted, ref } from 'vue';
 // astro.config.mjs — Astro reads aliases from tsconfig `paths`, and none exists), so this is a
 // relative import rather than the `@mcp/catalog` shown in the plan.
 import { PROFILE_TOOLS, toToolDescriptors } from '../../mcp/catalog';
-import { useLanguageModel } from '@utils/ai';
+import {
+  type AgentToolRegistration,
+  registerAgentTools,
+  useLanguageModel,
+} from '@utils/ai';
 import { searchRecords, type Searchable } from '@utils/search';
 
 // `lang` is unused by search, but a later task gates the AI path on locale. Accepting it now
@@ -73,8 +77,8 @@ const SELECTION_SCHEMA = {
   },
 };
 
-// Same JSON Schema descriptors `catalog.ts` builds for the MCP route — used here so `ask()`
-// validates the model's chosen args through the real per-tool schema before running anything.
+// Built once and shared by the ask flow above and the WebMCP registration at the bottom of this
+// file — one array of descriptors, not two independently-constructed schema trees.
 const toolDescriptors = toToolDescriptors();
 
 async function ask() {
@@ -180,6 +184,20 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown));
 // remounts this component on every navigation, so a stale verdict from a previous page never
 // lingers into the next one.
 onMounted(refresh);
+
+// No-ops in every shipping browser today — document.modelContext exists in none of them
+// (verified 2026-07-28: Chrome 150, Edge 150, Chromium 148). Wired now because the descriptors
+// already exist and the dispose handle makes it leak-free.
+//
+// Registered inside onMounted, not at setup() top level: setup() also runs during Astro's SSR
+// prerender, where there is no `document` at all, and registerAgentTools() dereferences it
+// unconditionally. onMounted is the standard Vue SSR-safe boundary — it never runs on the
+// server — which is why the ⌘K keydown listener above is wired the same way.
+let registration: AgentToolRegistration | undefined;
+onMounted(() => {
+  registration = registerAgentTools(toolDescriptors);
+});
+onUnmounted(() => registration?.dispose());
 </script>
 
 <template>

--- a/apps/personal-website/src/components/shell/CommandPalette.vue
+++ b/apps/personal-website/src/components/shell/CommandPalette.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref } from 'vue';
 
+// No `@mcp` path alias is configured for this app (checked tsconfig.json/tsconfig.base.json and
+// astro.config.mjs — Astro reads aliases from tsconfig `paths`, and none exists), so this is a
+// relative import rather than the `@mcp/catalog` shown in the plan.
+import { PROFILE_TOOLS, toToolDescriptors } from '../../mcp/catalog';
+import { useLanguageModel } from '@utils/ai';
 import { searchRecords, type Searchable } from '@utils/search';
 
 // `lang` is unused by search, but a later task gates the AI path on locale. Accepting it now
@@ -14,12 +19,103 @@ const inputEl = ref<HTMLInputElement | null>(null);
 
 const results = computed(() => searchRecords(query.value, props.records));
 
+const { state, refresh, enable, selectTool } = useLanguageModel();
+const answer = ref<string | null>(null);
+const asking = ref(false);
+
+// No answer strip in zh: E0 pins model output to English because non-English replies are
+// unreliable, and English prose above Chinese records reads as a bug rather than a decision.
+const canAsk = computed(
+  () => props.lang === 'en' && state.value.kind === 'ready',
+);
+
+// Gates the enable/downloading chrome the same way canAsk gates the answer strip — the whole AI
+// surface stays invisible in zh, not just the sentence, so a reopened zh palette is
+// pixel-identical to before this task.
+const showAiChrome = computed(() => props.lang === 'en');
+
+const downloadProgress = computed(() =>
+  state.value.kind === 'downloading'
+    ? Math.round(state.value.progress * 100)
+    : 0,
+);
+
+type Row = Omit<Searchable, 'kind'> & { kind: Searchable['kind'] | 'ask' };
+
 /**
- * Rows, not modes. A later task prepends an "Ask" row when on-device AI is available; keeping
- * activation as "activate the selected row" means Enter never changes meaning — only the
- * contents of the list do.
+ * Rows, not modes. Row 0 becomes an "Ask" row when on-device AI can answer and there is
+ * something to ask about; keeping activation as "activate the selected row" means Enter never
+ * changes meaning — only the contents of the list do.
  */
-const rows = computed(() => results.value);
+const rows = computed<Row[]>(() =>
+  canAsk.value && query.value.trim()
+    ? [
+        {
+          id: '__ask__',
+          kind: 'ask',
+          title: `Ask: "${query.value}"`,
+          keywords: [],
+          href: '',
+        },
+        ...results.value,
+      ]
+    : results.value,
+);
+
+const SELECTION_SCHEMA = {
+  type: 'object',
+  required: ['tool'],
+  additionalProperties: false,
+  properties: {
+    tool: { type: 'string', enum: PROFILE_TOOLS.map((tool) => tool.name) },
+    technology: { type: 'string' },
+    query: { type: 'string' },
+  },
+};
+
+// Same JSON Schema descriptors `catalog.ts` builds for the MCP route — used here so `ask()`
+// validates the model's chosen args through the real per-tool schema before running anything.
+const toolDescriptors = toToolDescriptors();
+
+async function ask() {
+  if (asking.value) return;
+  asking.value = true;
+  answer.value = null;
+  try {
+    const choice = await selectTool<{
+      tool: string;
+      technology?: string;
+      query?: string;
+    }>(query.value, SELECTION_SCHEMA);
+    // null means the call failed; selectTool has already re-read capability state, and the
+    // search results below are unaffected.
+    if (!choice) return;
+    const tool = PROFILE_TOOLS.find((entry) => entry.name === choice.tool);
+    const descriptor = toolDescriptors.find(
+      (entry) => entry.name === choice.tool,
+    );
+    if (!tool || !descriptor) return;
+    const args = {
+      technology: choice.technology,
+      query: choice.query,
+      lang: props.lang,
+    };
+    // Go through the validated `execute`, not `tool.run` directly: SELECTION_SCHEMA's
+    // `technology`/`query` are unconstrained strings, unlike the real per-tool params (e.g. an
+    // enum of known skill tags). Calling `run` on a near-miss value would still return a *real*
+    // but wrong result — "typescript" vs "TypeScript" silently yields 0 roles — and the strip
+    // would present that confidently. `execute` rejects it instead, so the strip shows nothing
+    // rather than a plausible-looking wrong answer.
+    const result = await descriptor.execute(args);
+    // The sentence comes from the real result, never from the model.
+    answer.value = tool.summarise(result as never, args as never);
+  } catch {
+    // A failed ask must not break search. Leave the strip empty and let the list stand.
+    answer.value = null;
+  } finally {
+    asking.value = false;
+  }
+}
 
 /**
  * Opens with a clean slate — otherwise a second ⌘K reopens with the previous search still in
@@ -35,8 +131,14 @@ function togglePalette() {
   }
   query.value = '';
   selected.value = 0;
+  answer.value = null;
   open.value = true;
   nextTick(() => inputEl.value?.focus());
+}
+
+function onQueryInput() {
+  selected.value = 0;
+  answer.value = null;
 }
 
 function onKeydown(event: KeyboardEvent) {
@@ -63,13 +165,21 @@ function onKeydown(event: KeyboardEvent) {
 
 function activate(index: number) {
   const row = rows.value[index];
-  if (row) window.location.href = row.href;
+  if (!row) return;
+  if (row.id === '__ask__') void ask();
+  else window.location.href = row.href;
 }
 
 // Removed on unmount because the layout uses Astro's ClientRouter: components remount on every
 // navigation, so a listener left behind would accumulate and fire ⌘K more than once.
 onMounted(() => window.addEventListener('keydown', onKeydown));
 onUnmounted(() => window.removeEventListener('keydown', onKeydown));
+
+// Re-probes on every mount rather than once globally: state can go ready -> unsupported
+// mid-flight (E0 confirms responseConstraint actually works on first real use), and ClientRouter
+// remounts this component on every navigation, so a stale verdict from a previous page never
+// lingers into the next one.
+onMounted(refresh);
 </script>
 
 <template>
@@ -88,8 +198,38 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown));
         class="w-full border-b bg-transparent px-4 py-3 outline-none"
         placeholder="Search experience, projects, skills…"
         aria-label="Search"
-        @input="selected = 0"
+        @input="onQueryInput"
       />
+      <div
+        v-if="showAiChrome && state.kind === 'downloadable'"
+        class="border-b px-4 py-2 text-sm"
+      >
+        <button
+          type="button"
+          class="text-primary hover:underline"
+          @click="enable"
+        >
+          Enable on-device AI
+        </button>
+      </div>
+      <div
+        v-else-if="showAiChrome && state.kind === 'downloading'"
+        class="text-muted-foreground border-b px-4 py-2 text-sm"
+      >
+        Downloading on-device model… {{ downloadProgress }}%
+      </div>
+      <div v-if="asking" class="border-b px-4 py-2 text-sm">
+        <span class="text-muted-foreground mr-2 text-xs uppercase"
+          >On-device answer</span
+        >
+        <p class="text-muted-foreground">Thinking…</p>
+      </div>
+      <div v-else-if="answer" class="border-b px-4 py-2 text-sm">
+        <span class="text-muted-foreground mr-2 text-xs uppercase"
+          >On-device answer</span
+        >
+        <p>{{ answer }}</p>
+      </div>
       <ul class="max-h-80 overflow-y-auto py-1" role="listbox">
         <li
           v-for="(row, index) in rows"

--- a/apps/personal-website/src/components/shell/CommandPalette.vue
+++ b/apps/personal-website/src/components/shell/CommandPalette.vue
@@ -112,7 +112,17 @@ const SELECTION_SCHEMA = {
     // miss, leaving the strip blank. Making the wrong value unrepresentable beats validating it
     // after the fact.
     technology: { type: 'string', enum: tags.skills },
-    query: { type: 'string' },
+    // A single token, not free text — `search_by_technology` substring-matches technology names
+    // ('tailwindcss', 'github-actions'), so a phrase could never match one anyway.
+    //
+    // This is also, unexpectedly, the entire latency story. Left as `{ type: 'string' }` the model
+    // treats the field as room to answer the question itself: measured against Chrome 150 it wrote
+    // 2,805 characters of prose — a hallucinated list naming Shopify, Discord and Grafana as Vue
+    // projects — and took 39s to do it. That is what the run timeout kept cutting off, and what
+    // made latency look bimodal. Denying it spaces collapses the same call to ~1s and yields an
+    // actual search term ("script", "Vue.js"). Constraining the output shape turned out to be
+    // worth more than any timeout tuning.
+    query: { type: 'string', pattern: '^[A-Za-z0-9.#+-]{1,24}$' },
   },
 };
 

--- a/apps/personal-website/src/components/shell/CommandPalette.vue
+++ b/apps/personal-website/src/components/shell/CommandPalette.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref } from 'vue';
+import { computed, nextTick, onMounted, onUnmounted, ref } from 'vue';
 
 import { searchRecords, type Searchable } from '@utils/search';
 
@@ -10,6 +10,7 @@ const props = defineProps<{ records: Searchable[]; lang: 'en' | 'zh' }>();
 const open = ref(false);
 const query = ref('');
 const selected = ref(0);
+const inputEl = ref<HTMLInputElement | null>(null);
 
 const results = computed(() => searchRecords(query.value, props.records));
 
@@ -20,10 +21,28 @@ const results = computed(() => searchRecords(query.value, props.records));
  */
 const rows = computed(() => results.value);
 
+/**
+ * Opens with a clean slate — otherwise a second ⌘K reopens with the previous search still in
+ * the box — and focuses the input explicitly. The `autofocus` attribute doesn't fire here: this
+ * element is never present at initial page parse (it's inserted by `v-if`), which is exactly
+ * the case the HTML attribute doesn't cover. Without this, ⌘K immediately followed by typing —
+ * precisely the reflex the shortcut exists to serve — drops the first keystrokes.
+ */
+function togglePalette() {
+  if (open.value) {
+    open.value = false;
+    return;
+  }
+  query.value = '';
+  selected.value = 0;
+  open.value = true;
+  nextTick(() => inputEl.value?.focus());
+}
+
 function onKeydown(event: KeyboardEvent) {
   if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
     event.preventDefault();
-    open.value = !open.value;
+    togglePalette();
     return;
   }
   if (!open.value) return;
@@ -64,11 +83,11 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown));
       aria-modal="true"
     >
       <input
+        ref="inputEl"
         v-model="query"
         class="w-full border-b bg-transparent px-4 py-3 outline-none"
         placeholder="Search experience, projects, skills…"
         aria-label="Search"
-        autofocus
         @input="selected = 0"
       />
       <ul class="max-h-80 overflow-y-auto py-1" role="listbox">

--- a/apps/personal-website/src/components/shell/CommandPalette.vue
+++ b/apps/personal-website/src/components/shell/CommandPalette.vue
@@ -24,9 +24,42 @@ const inputEl = ref<HTMLInputElement | null>(null);
 
 const results = computed(() => searchRecords(query.value, props.records));
 
-const { state, refresh, enable, selectTool } = useLanguageModel();
+const {
+  state,
+  // The composable turns a failed run into `null` + this ref rather than rethrowing, so a
+  // timeout never reaches the catch below — reading it here is the only way to tell "took too
+  // long" apart from "could not answer".
+  error: aiError,
+  refresh,
+  enable,
+  selectTool,
+} = useLanguageModel();
 const answer = ref<string | null>(null);
 const asking = ref(false);
+/**
+ * Why a failed ask is shown rather than swallowed.
+ *
+ * This started as a bare `catch` that set `answer` to null, on the reasoning that a failed ask
+ * must not break search. It doesn't — but it also made three separate defects indistinguishable
+ * from "the model had nothing to say": a missing session, a schema near-miss, and a timeout all
+ * rendered as the same silent nothing, with no error in the console either. Two of them survived
+ * a full review and only surfaced when the feature was driven by hand in a real browser.
+ *
+ * 'timeout' is kept distinct from 'failed' because the two ask different things of the reader:
+ * one is worth retrying, the other isn't.
+ */
+const askError = ref<'timeout' | 'failed' | null>(null);
+
+/** Both the run timeout and a caller abort surface as an AbortError; nothing else does. */
+const isAbort = (cause: unknown): boolean =>
+  cause instanceof DOMException && cause.name === 'AbortError';
+
+/** Both halves of the answer strip, cleared together — three call sites reset this, and a
+ *  stale error under a fresh answer is exactly the drift separate assignments invite. */
+function resetAnswer() {
+  answer.value = null;
+  askError.value = null;
+}
 
 // No answer strip in zh: E0 pins model output to English because non-English replies are
 // unreliable, and English prose above Chinese records reads as a bug rather than a decision.
@@ -90,7 +123,7 @@ const toolDescriptors = toToolDescriptors();
 async function ask() {
   if (asking.value) return;
   asking.value = true;
-  answer.value = null;
+  resetAnswer();
   try {
     const choice = await selectTool<{
       tool: string;
@@ -98,30 +131,42 @@ async function ask() {
       query?: string;
     }>(query.value, SELECTION_SCHEMA);
     // null means the call failed; selectTool has already re-read capability state, and the
-    // search results below are unaffected.
-    if (!choice) return;
+    // search results below are unaffected. This — not the catch — is the path a timeout takes,
+    // because the composable converts a throw into null.
+    if (!choice) {
+      askError.value = isAbort(aiError.value) ? 'timeout' : 'failed';
+      return;
+    }
     const tool = PROFILE_TOOLS.find((entry) => entry.name === choice.tool);
     const descriptor = toolDescriptors.find(
       (entry) => entry.name === choice.tool,
     );
-    if (!tool || !descriptor) return;
+    // The model named a tool that isn't in the catalog. `tool` is enum-constrained, so this
+    // should be unreachable — but it is a silent dead end if it ever is reached, which is the
+    // failure mode this whole strip exists to eliminate.
+    if (!tool || !descriptor) {
+      askError.value = 'failed';
+      return;
+    }
     const args = {
       technology: choice.technology,
       query: choice.query,
       lang: props.lang,
     };
-    // Go through the validated `execute`, not `tool.run` directly: SELECTION_SCHEMA's
-    // `technology`/`query` are unconstrained strings, unlike the real per-tool params (e.g. an
-    // enum of known skill tags). Calling `run` on a near-miss value would still return a *real*
-    // but wrong result — "typescript" vs "TypeScript" silently yields 0 roles — and the strip
-    // would present that confidently. `execute` rejects it instead, so the strip shows nothing
-    // rather than a plausible-looking wrong answer.
+    // Go through the validated `execute`, not `tool.run` directly. `technology` is now
+    // enum-constrained above, but `query` is still a free string and `responseConstraint` is a
+    // request to the platform, not a guarantee we control — a model that ignores the schema is
+    // the exact failure E0 exists to catch. Calling `run` on a near-miss value would return a
+    // *real* but wrong result ("typescript" vs "TypeScript" silently yields 0 roles) and the
+    // strip would state it confidently. `execute` rejects it instead.
     const result = await descriptor.execute(args);
     // The sentence comes from the real result, never from the model.
     answer.value = tool.summarise(result as never, args as never);
-  } catch {
-    // A failed ask must not break search. Leave the strip empty and let the list stand.
+  } catch (error) {
+    // A failed ask still must not break search — the list below stands untouched. What changed is
+    // that the reader is told, instead of being shown a strip that silently disappears.
     answer.value = null;
+    askError.value = isAbort(error) ? 'timeout' : 'failed';
   } finally {
     asking.value = false;
   }
@@ -141,14 +186,14 @@ function togglePalette() {
   }
   query.value = '';
   selected.value = 0;
-  answer.value = null;
+  resetAnswer();
   open.value = true;
   nextTick(() => inputEl.value?.focus());
 }
 
 function onQueryInput() {
   selected.value = 0;
-  answer.value = null;
+  resetAnswer();
 }
 
 function onKeydown(event: KeyboardEvent) {
@@ -253,6 +298,23 @@ onUnmounted(() => registration?.dispose());
           >On-device answer</span
         >
         <p>{{ answer }}</p>
+      </div>
+      <div
+        v-else-if="askError"
+        class="border-b px-4 py-2 text-sm"
+        role="status"
+        aria-live="polite"
+      >
+        <span class="text-muted-foreground mr-2 text-xs uppercase"
+          >On-device answer</span
+        >
+        <p class="text-muted-foreground">
+          {{
+            askError === 'timeout'
+              ? 'The on-device model took too long. Your search results are below.'
+              : "Couldn't answer that one. Your search results are below."
+          }}
+        </p>
       </div>
       <ul class="max-h-80 overflow-y-auto py-1" role="listbox">
         <li

--- a/apps/personal-website/src/components/shell/CommandPalette.vue
+++ b/apps/personal-website/src/components/shell/CommandPalette.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from 'vue';
+
+import { searchRecords, type Searchable } from '@utils/search';
+
+// `lang` is unused by search, but a later task gates the AI path on locale. Accepting it now
+// keeps this component's public signature stable when that lands.
+const props = defineProps<{ records: Searchable[]; lang: 'en' | 'zh' }>();
+
+const open = ref(false);
+const query = ref('');
+const selected = ref(0);
+
+const results = computed(() => searchRecords(query.value, props.records));
+
+/**
+ * Rows, not modes. A later task prepends an "Ask" row when on-device AI is available; keeping
+ * activation as "activate the selected row" means Enter never changes meaning — only the
+ * contents of the list do.
+ */
+const rows = computed(() => results.value);
+
+function onKeydown(event: KeyboardEvent) {
+  if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+    event.preventDefault();
+    open.value = !open.value;
+    return;
+  }
+  if (!open.value) return;
+
+  if (event.key === 'Escape') {
+    open.value = false;
+  } else if (event.key === 'ArrowDown') {
+    event.preventDefault();
+    selected.value = Math.min(selected.value + 1, rows.value.length - 1);
+  } else if (event.key === 'ArrowUp') {
+    event.preventDefault();
+    selected.value = Math.max(selected.value - 1, 0);
+  } else if (event.key === 'Enter') {
+    event.preventDefault();
+    activate(selected.value);
+  }
+}
+
+function activate(index: number) {
+  const row = rows.value[index];
+  if (row) window.location.href = row.href;
+}
+
+// Removed on unmount because the layout uses Astro's ClientRouter: components remount on every
+// navigation, so a listener left behind would accumulate and fire ⌘K more than once.
+onMounted(() => window.addEventListener('keydown', onKeydown));
+onUnmounted(() => window.removeEventListener('keydown', onKeydown));
+</script>
+
+<template>
+  <div
+    v-if="open"
+    class="fixed inset-0 z-50 flex items-start justify-center bg-black/40 pt-24"
+  >
+    <div
+      class="bg-card w-full max-w-xl rounded-lg border shadow-lg"
+      role="dialog"
+      aria-modal="true"
+    >
+      <input
+        v-model="query"
+        class="w-full border-b bg-transparent px-4 py-3 outline-none"
+        placeholder="Search experience, projects, skills…"
+        aria-label="Search"
+        autofocus
+        @input="selected = 0"
+      />
+      <ul class="max-h-80 overflow-y-auto py-1" role="listbox">
+        <li
+          v-for="(row, index) in rows"
+          :key="row.id"
+          :aria-selected="index === selected"
+          role="option"
+          class="cursor-pointer px-4 py-2"
+          :class="index === selected ? 'bg-muted' : ''"
+          @click="activate(index)"
+          @mouseenter="selected = index"
+        >
+          <span class="text-muted-foreground mr-2 text-xs uppercase">{{
+            row.kind
+          }}</span>
+          {{ row.title }}
+        </li>
+        <li v-if="rows.length === 0" class="text-muted-foreground px-4 py-2">
+          No matches
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>

--- a/apps/personal-website/src/data/blog/web-ai.mdx
+++ b/apps/personal-website/src/data/blog/web-ai.mdx
@@ -12,7 +12,15 @@ tags:
 ---
 
 import { Baseline } from '@components/blog';
-import { CheckGPU } from '@components/blog/demo';
+import { CheckGPU, SupportTable } from '@components/blog/demo';
+
+## What your browser can do
+
+The three built-in AI APIs have landed unevenly, and not along the lines you would guess. Chrome 150
+and Edge 150 are both Chromium 150, and they still disagree — Edge ships Summarizer and Translator
+with no Prompt API at all. This table is a live probe, not a copied compatibility chart:
+
+<SupportTable client:load />
 
 ## GPU support check
 

--- a/apps/personal-website/src/layouts/blog.astro
+++ b/apps/personal-website/src/layouts/blog.astro
@@ -1,5 +1,5 @@
 ---
-import { Comments } from '@components/blog';
+import { Comments, SummarizeButton } from '@components/blog';
 import { info } from '@utils/constants';
 import { Image } from 'astro:assets';
 import type { CollectionEntry } from 'astro:content';
@@ -60,6 +60,16 @@ const postSchema = {
   >
     <p class="text-center">{format(pubDate, 'd MMM, yyyy')}</p>
     <div class={clsx(image?.src && 'bg-background/25 px-4 backdrop-blur-sm')}>
+      {/*
+        Inside the blurred wrapper, not above it. On a post with a hero image the article is pulled
+        up over the photo (`md:-mt-75`), and only this wrapper's backdrop makes text on top of it
+        legible — placed above, the control sat directly on the photograph.
+
+        client:only="vue" rather than client:idle: the component renders nothing at all in a browser
+        without the Summarizer API, and server-rendering a shell we then remove would flash an
+        affordance most visitors can't use.
+      */}
+      <SummarizeButton text={Astro.props.body ?? ''} client:only="vue" />
       <slot />
     </div>
   </article>

--- a/apps/personal-website/src/layouts/blog.astro
+++ b/apps/personal-website/src/layouts/blog.astro
@@ -64,7 +64,8 @@ const postSchema = {
   >
     <p class="text-center">{format(pubDate, 'd MMM, yyyy')}</p>
     <div class={clsx(image?.src && 'bg-background/25 px-4 backdrop-blur-sm')}>
-      {/*
+      {
+        /*
         Inside the blurred wrapper, not above it. On a post with a hero image the article is pulled
         up over the photo (`md:-mt-75`), and only this wrapper's backdrop makes text on top of it
         legible — placed above, the control sat directly on the photograph.
@@ -72,10 +73,13 @@ const postSchema = {
         client:only="vue" rather than client:idle: the component renders nothing at all in a browser
         without the Summarizer API, and server-rendering a shell we then remove would flash an
         affordance most visitors can't use.
-      */}
+      */
+      }
       <SummarizeButton text={Astro.props.body ?? ''} client:only="vue" />
-      {/* Separate control, separate card: a browser can ship Summarizer without the en->zh-Hant
-          translation pair, so the two degrade independently. */}
+      {
+        /* Separate control, separate card: a browser can ship Summarizer without the en->zh-Hant
+          translation pair, so the two degrade independently. */
+      }
       <TranslateButton client:only="vue" />
       <slot />
     </div>

--- a/apps/personal-website/src/layouts/blog.astro
+++ b/apps/personal-website/src/layouts/blog.astro
@@ -1,5 +1,5 @@
 ---
-import { Comments, SummarizeButton } from '@components/blog';
+import { Comments, SummarizeButton, TranslateButton } from '@components/blog';
 import { info } from '@utils/constants';
 import { Image } from 'astro:assets';
 import type { CollectionEntry } from 'astro:content';
@@ -70,6 +70,9 @@ const postSchema = {
         affordance most visitors can't use.
       */}
       <SummarizeButton text={Astro.props.body ?? ''} client:only="vue" />
+      {/* Separate control, separate card: a browser can ship Summarizer without the en->zh-Hant
+          translation pair, so the two degrade independently. */}
+      <TranslateButton client:only="vue" />
       <slot />
     </div>
   </article>

--- a/apps/personal-website/src/layouts/index.astro
+++ b/apps/personal-website/src/layouts/index.astro
@@ -2,9 +2,17 @@
 import '../app.css';
 
 import { SourceColor, ThemeProvider } from '@components';
+import CommandPalette from '@components/shell/CommandPalette.vue';
 import SiteFooter from '@components/shell/SiteFooter.astro';
 import SiteHeader from '@components/shell/SiteHeader.astro';
+import {
+  getProjects,
+  getSkills,
+  getWorkExperience,
+} from '@rainforest-dev/personal-data';
+import type { Searchable } from '@utils/search';
 import SpeedInsights from '@vercel/speed-insights/astro';
+import { getCollection } from 'astro:content';
 import { ClientRouter } from 'astro:transitions';
 import { dir as _dir } from 'i18next';
 
@@ -19,8 +27,49 @@ const {
   ...rest
 } = Astro.props;
 
-const lang = Astro.currentLocale;
+const lang = Astro.currentLocale === 'zh' ? 'zh' : 'en';
 const dir = _dir(lang);
+
+// Records for the ⌘K command palette. Fetched on every layout render (not cached) — the
+// underlying content-collection reads are already memoized by Astro, and this is a handful of
+// arrays, not a database query.
+const [experiences, projects, skills, posts] = await Promise.all([
+  getWorkExperience({ lang }),
+  getProjects({ lang }),
+  getSkills({ lang }),
+  getCollection('blog'),
+]);
+
+const paletteRecords: Searchable[] = [
+  ...experiences.map((experience) => ({
+    id: `experience/${experience.id}`,
+    kind: 'experience' as const,
+    title: `${experience.position} · ${experience.organization.name}`,
+    keywords: experience.technologies,
+    href: '/resume',
+  })),
+  ...projects.map((project) => ({
+    id: `project/${project.id}`,
+    kind: 'project' as const,
+    title: project.name,
+    keywords: project.technologies,
+    href: `/portfolio/${project.id.split('/').pop()}`,
+  })),
+  ...skills.map((skill) => ({
+    id: `skill/${skill.id}`,
+    kind: 'skill' as const,
+    title: skill.name,
+    keywords: skill.tags,
+    href: '/#skills',
+  })),
+  ...posts.map((post) => ({
+    id: `post/${post.id}`,
+    kind: 'post' as const,
+    title: post.data.title,
+    keywords: post.data.tags,
+    href: `/blog/${post.id}`,
+  })),
+];
 ---
 
 <!doctype html>
@@ -46,5 +95,7 @@ const dir = _dir(lang);
       // case-study views) → /api/event → GA4. No cookies, no consent banner.
       import '../scripts/conversion-tracking';
     </script>
+    <!-- client:idle: keyboard-triggered (⌘K), so it needn't hydrate before the page is interactive. -->
+    <CommandPalette records={paletteRecords} lang={lang} client:idle />
   </body>
 </html>

--- a/apps/personal-website/src/mcp/catalog.test.ts
+++ b/apps/personal-website/src/mcp/catalog.test.ts
@@ -60,4 +60,84 @@ describe('toToolDescriptors', () => {
         .sort(),
     ).toEqual(PROFILE_TOOLS.map((t) => t.name).sort());
   });
+
+  // The palette/WebMCP path feeds `execute` arguments an on-device model produced from
+  // `inputSchema` as a `responseConstraint` — a model can accept a response schema and still
+  // not honour it (this is E0's premise). `execute` must reject before the bad value ever
+  // reaches `run`/the data layer, unlike the MCP path, which the SDK's own zod-compat layer
+  // already validates.
+  it('rejects a model-produced argument that violates params, before reaching run', async () => {
+    const descriptors = toToolDescriptors();
+    const summary = descriptors.find((d) => d.name === 'get_profile_summary');
+    await expect(summary?.execute({ lang: 'fr' })).rejects.toThrow();
+  });
+});
+
+describe('summarise', () => {
+  const find = (name: string) => {
+    const tool = PROFILE_TOOLS.find((t) => t.name === name);
+    if (!tool) throw new Error(`no such tool: ${name}`);
+    return tool;
+  };
+
+  it('get_profile_summary', () => {
+    const tool = find('get_profile_summary');
+    const result = { experienceCount: 5, projectCount: 4 };
+    expect(tool.summarise(result as never, { lang: 'en' } as never)).toBe(
+      '5 roles and 4 projects on record.',
+    );
+  });
+
+  it('get_work_experience, filtered by technology', () => {
+    const tool = find('get_work_experience');
+    const result = [{ id: 'en/1' }, { id: 'en/2' }];
+    expect(
+      tool.summarise(result as never, { technology: 'react' } as never),
+    ).toBe('react appears in 2 roles.');
+  });
+
+  it('get_education', () => {
+    const tool = find('get_education');
+    const result = [{ id: 'en/1' }];
+    expect(tool.summarise(result as never, {} as never)).toBe(
+      '1 qualification on record.',
+    );
+  });
+
+  it('get_projects, filtered by technology', () => {
+    const tool = find('get_projects');
+    const result = [{ id: 'en/1' }, { id: 'en/2' }, { id: 'en/3' }];
+    expect(
+      tool.summarise(result as never, { technology: 'vue' } as never),
+    ).toBe('vue appears in 3 projects.');
+  });
+
+  it('get_skills', () => {
+    const tool = find('get_skills');
+    const result = [{ id: '1' }, { id: '2' }, { id: '3' }, { id: '4' }];
+    expect(tool.summarise(result as never, {} as never)).toBe(
+      '4 skills listed.',
+    );
+  });
+
+  it('search_by_technology, with matches', () => {
+    const tool = find('search_by_technology');
+    const result = {
+      experiences: [{ id: 'en/1' }, { id: 'en/2' }],
+      projects: [{ id: 'en/1' }],
+    };
+    expect(tool.summarise(result as never, { query: 'react' } as never)).toBe(
+      'react appears in 2 roles and 1 project.',
+    );
+  });
+
+  // search_by_technology's zero-match branch — a separate code path from the matches case
+  // above, not just a boundary value of it.
+  it('search_by_technology, with no matches', () => {
+    const tool = find('search_by_technology');
+    const result = { experiences: [], projects: [] };
+    expect(tool.summarise(result as never, { query: 'cobol' } as never)).toBe(
+      'No records mention cobol.',
+    );
+  });
 });

--- a/apps/personal-website/src/mcp/catalog.test.ts
+++ b/apps/personal-website/src/mcp/catalog.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment node
+//
+// This file (via handler.ts -> profile.ts) statically imports the `astro:content` virtual
+// module, which Astro's content-collection Vite plugin refuses to resolve in a "client" Vite
+// environment (jsdom/happy-dom) — see https://github.com/withastro/astro/issues/14895. The
+// project default is jsdom (src/utils/ai/ needs sessionStorage); this file overrides to node,
+// which Astro treats as server-side, so astro:content resolves.
+import { describe, expect, it } from 'vitest';
+
+import { MCP_TOOLS } from './handler';
+
+/**
+ * Characterisation, not specification: this records what the live server at
+ * rainforest.tools/mcp advertises TODAY, so the catalog refactor in Tasks 2–3 is provably
+ * behaviour-preserving. A remote MCP client breaking is invisible from the site itself, so
+ * "it still looks fine" is not evidence.
+ *
+ * If a change to this list is intended, update it deliberately — do not "fix" it to make a
+ * refactor pass.
+ */
+describe('MCP tool surface (characterisation)', () => {
+  it('advertises exactly these tools', () => {
+    expect(MCP_TOOLS.map((t) => t.name).sort()).toEqual([
+      'get_case_study',
+      'get_education',
+      'get_profile_summary',
+      'get_projects',
+      'get_skills',
+      'get_work_experience',
+      'search_by_technology',
+    ]);
+  });
+
+  it('keeps get_case_study, which comes from the portfolio library, not profile.ts', () => {
+    expect(MCP_TOOLS.find((t) => t.name === 'get_case_study')).toBeDefined();
+  });
+
+  it('gives every tool a non-empty description', () => {
+    for (const tool of MCP_TOOLS) {
+      expect(tool.description.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/personal-website/src/mcp/catalog.test.ts
+++ b/apps/personal-website/src/mcp/catalog.test.ts
@@ -7,6 +7,7 @@
 // which Astro treats as server-side, so astro:content resolves.
 import { describe, expect, it } from 'vitest';
 
+import { PROFILE_TOOLS, toToolDescriptors } from './catalog';
 import { MCP_TOOLS } from './handler';
 
 /**
@@ -39,5 +40,24 @@ describe('MCP tool surface (characterisation)', () => {
     for (const tool of MCP_TOOLS) {
       expect(tool.description.length).toBeGreaterThan(0);
     }
+  });
+});
+
+describe('toToolDescriptors', () => {
+  it('derives JSON Schema from the Zod params', () => {
+    const descriptors = toToolDescriptors();
+    const search = descriptors.find((d) => d.name === 'search_by_technology');
+    expect(search?.inputSchema).toMatchObject({
+      type: 'object',
+      properties: { query: { type: 'string' } },
+    });
+  });
+
+  it('exposes every catalog tool', () => {
+    expect(
+      toToolDescriptors()
+        .map((d) => d.name)
+        .sort(),
+    ).toEqual(PROFILE_TOOLS.map((t) => t.name).sort());
   });
 });

--- a/apps/personal-website/src/mcp/catalog.ts
+++ b/apps/personal-website/src/mcp/catalog.ts
@@ -45,82 +45,111 @@ const count = (value: unknown): number =>
 const plural = (n: number, one: string, many: string) =>
   `${n} ${n === 1 ? one : many}`;
 
+/**
+ * Ties `run`'s argument shape and `summarise`'s `result` type to `params`, per call site.
+ *
+ * Without this, `params`, `run`, and `summarise` below are three independently-typed object
+ * properties with no relationship enforced between them — `ProfileTool.run` is erased to
+ * `(args: Record<string, never>) => Promise<unknown>`, so renaming a `params` key while leaving
+ * `run`'s destructuring untouched compiles cleanly. The tool then advertises and validates the
+ * new key, the handler destructures the old one and gets `undefined`, and it fails silently
+ * (e.g. an unrecognised filter is just ignored, returning unfiltered results) — no type error,
+ * no runtime error, nothing to catch it in review. `S`/`R` here are inferred fresh per
+ * `defineTool(...)` call from `params` and `run`'s actual return value, so `run`'s parameter and
+ * `summarise`'s `result` are checked against that call's own `params`/`run`, not the erased
+ * common shape. The `as unknown as ProfileTool` on return is what erases back to that common
+ * shape so heterogeneous entries can still collect into one `ProfileTool[]`.
+ */
+function defineTool<S extends z.ZodRawShape, R>(tool: {
+  name: string;
+  description: string;
+  params: S;
+  run: (args: z.infer<z.ZodObject<S>>) => Promise<R>;
+  summarise: (result: R, args: z.infer<z.ZodObject<S>>) => string | null;
+}): ProfileTool {
+  return tool as unknown as ProfileTool;
+}
+
 export const PROFILE_TOOLS: ProfileTool[] = [
-  {
+  defineTool({
     name: 'get_profile_summary',
     description: 'Professional profile overview: counts and top technologies',
     params: { lang: langSchema },
     run: ({ lang }) => getProfileSummary({ lang }),
-    summarise: (result: { experienceCount: number; projectCount: number }) =>
+    summarise: (result) =>
       `${plural(result.experienceCount, 'role', 'roles')} and ${plural(result.projectCount, 'project', 'projects')} on record.`,
-  },
-  {
+  }),
+  defineTool({
     name: 'get_work_experience',
     description: 'Work history, optionally filtered by technology',
     params: { technology: technologySchema, lang: langSchema },
     run: ({ technology, lang }) => getWorkExperience({ technology, lang }),
-    summarise: (result: unknown[], { technology }) =>
+    summarise: (result, { technology }) =>
       technology
         ? `${technology} appears in ${plural(count(result), 'role', 'roles')}.`
         : `${plural(count(result), 'role', 'roles')} on record.`,
-  },
-  {
+  }),
+  defineTool({
     name: 'get_education',
     description: 'Academic background',
     params: { lang: langSchema },
     run: ({ lang }) => getEducation({ lang }),
-    summarise: (result: unknown[]) =>
+    summarise: (result) =>
       `${plural(count(result), 'qualification', 'qualifications')} on record.`,
-  },
-  {
+  }),
+  defineTool({
     name: 'get_projects',
     description: 'Portfolio projects, optionally filtered by technology',
     params: { technology: technologySchema, lang: langSchema },
     run: ({ technology, lang }) => getProjects({ technology, lang }),
-    summarise: (result: unknown[], { technology }) =>
+    summarise: (result, { technology }) =>
       technology
         ? `${technology} appears in ${plural(count(result), 'project', 'projects')}.`
         : `${plural(count(result), 'project', 'projects')} on record.`,
-  },
-  {
+  }),
+  defineTool({
     name: 'get_skills',
     description: 'Technical skills inventory',
     params: { lang: langSchema },
     run: ({ lang }) => getSkills({ lang }),
-    summarise: (result: unknown[]) =>
+    summarise: (result) =>
       `${plural(count(result), 'skill', 'skills')} listed.`,
-  },
-  {
+  }),
+  defineTool({
     name: 'search_by_technology',
     description:
       'Substring-match a technology name across all experiences and projects',
     params: { query: z.string(), lang: langSchema },
     run: ({ query, lang }) => searchByTechnology(query, { lang }),
-    summarise: (
-      result: { experiences: unknown[]; projects: unknown[] },
-      { query },
-    ) => {
+    summarise: (result, { query }) => {
       const total = count(result.experiences) + count(result.projects);
       return total === 0
         ? `No records mention ${query}.`
         : `${query} appears in ${plural(count(result.experiences), 'role', 'roles')} and ${plural(count(result.projects), 'project', 'projects')}.`;
     },
-  },
+  }),
 ];
 
 /**
  * Adapter for the palette and WebMCP: JSON Schema instead of Zod, plain data instead of an
  * MCP envelope. `inputSchema` is the same shape `selectTool()` passes as `responseConstraint`
  * and the same shape WebMCP's `registerTool()` expects.
+ *
+ * `execute` parses `input` against `params` before calling `run`. The MCP path doesn't need
+ * this — `server.registerTool` already validates through the SDK's own zod-compat layer — but
+ * this path feeds arguments a browser's on-device model produced from `inputSchema` as a
+ * `responseConstraint`, and a model can accept a response schema and still not honour it.
+ * Without this parse, a malformed arg reaches `run` (and the data layer) as `undefined` or the
+ * wrong type instead of being rejected here.
  */
 export function toToolDescriptors(): ToolDescriptor[] {
-  return PROFILE_TOOLS.map((tool) => ({
-    name: tool.name,
-    description: tool.description,
-    inputSchema: z.toJSONSchema(z.object(tool.params)) as Record<
-      string,
-      unknown
-    >,
-    execute: tool.run as ToolDescriptor['execute'],
-  }));
+  return PROFILE_TOOLS.map((tool) => {
+    const schema = z.object(tool.params);
+    return {
+      name: tool.name,
+      description: tool.description,
+      inputSchema: z.toJSONSchema(schema) as Record<string, unknown>,
+      execute: async (input) => tool.run(schema.parse(input) as never),
+    };
+  });
 }

--- a/apps/personal-website/src/mcp/catalog.ts
+++ b/apps/personal-website/src/mcp/catalog.ts
@@ -1,0 +1,126 @@
+import {
+  getEducation,
+  getProfileSummary,
+  getProjects,
+  getSkills,
+  getWorkExperience,
+  searchByTechnology,
+} from '@rainforest-dev/personal-data';
+import type { SkillTag } from '@types';
+import type { ToolDescriptor } from '@utils/ai';
+import { tags } from '@utils/constants';
+// zod@3.25 ships the v4 implementation under this subpath, with `z.toJSONSchema` available
+// (unlike the classic v3 namespace at the package root). Building every schema here from this
+// one import — rather than v3's `z` for `params` and v4's for JSON Schema — is what lets one
+// Zod definition feed both `server.registerTool` (the MCP SDK's zod-compat layer accepts v4
+// schemas directly) and `toToolDescriptors` below without a second, incompatible schema tree:
+// v3- and v4-built schema instances have different internal shapes and mixing them throws at
+// `toJSONSchema()` time (`Cannot read properties of undefined (reading 'def')`).
+import { z } from 'zod/v4';
+
+const langSchema = z.enum(['en', 'zh']).optional();
+const technologySchema = z
+  .enum(tags.skills as unknown as [SkillTag, ...SkillTag[]])
+  .optional();
+
+/**
+ * One tool, defined once.
+ *
+ * `run` returns plain data — no MCP envelope, no formatting — so every consumer can shape it
+ * for itself. `summarise` is what lets the palette show a sentence without a model writing one:
+ * it composes from `run`'s actual result, so the strip cannot state something untrue.
+ */
+export interface ProfileTool {
+  name: string;
+  description: string;
+  /** Zod raw shape, which is what the MCP SDK's registerTool expects. */
+  params: z.ZodRawShape;
+  run: (args: Record<string, never>) => Promise<unknown>;
+  /** One line for the answer strip, or null when there is nothing worth saying. */
+  summarise: (result: never, args: Record<string, never>) => string | null;
+}
+
+const count = (value: unknown): number =>
+  Array.isArray(value) ? value.length : 0;
+const plural = (n: number, one: string, many: string) =>
+  `${n} ${n === 1 ? one : many}`;
+
+export const PROFILE_TOOLS: ProfileTool[] = [
+  {
+    name: 'get_profile_summary',
+    description: 'Professional profile overview: counts and top technologies',
+    params: { lang: langSchema },
+    run: ({ lang }) => getProfileSummary({ lang }),
+    summarise: (result: { experienceCount: number; projectCount: number }) =>
+      `${plural(result.experienceCount, 'role', 'roles')} and ${plural(result.projectCount, 'project', 'projects')} on record.`,
+  },
+  {
+    name: 'get_work_experience',
+    description: 'Work history, optionally filtered by technology',
+    params: { technology: technologySchema, lang: langSchema },
+    run: ({ technology, lang }) => getWorkExperience({ technology, lang }),
+    summarise: (result: unknown[], { technology }) =>
+      technology
+        ? `${technology} appears in ${plural(count(result), 'role', 'roles')}.`
+        : `${plural(count(result), 'role', 'roles')} on record.`,
+  },
+  {
+    name: 'get_education',
+    description: 'Academic background',
+    params: { lang: langSchema },
+    run: ({ lang }) => getEducation({ lang }),
+    summarise: (result: unknown[]) =>
+      `${plural(count(result), 'qualification', 'qualifications')} on record.`,
+  },
+  {
+    name: 'get_projects',
+    description: 'Portfolio projects, optionally filtered by technology',
+    params: { technology: technologySchema, lang: langSchema },
+    run: ({ technology, lang }) => getProjects({ technology, lang }),
+    summarise: (result: unknown[], { technology }) =>
+      technology
+        ? `${technology} appears in ${plural(count(result), 'project', 'projects')}.`
+        : `${plural(count(result), 'project', 'projects')} on record.`,
+  },
+  {
+    name: 'get_skills',
+    description: 'Technical skills inventory',
+    params: { lang: langSchema },
+    run: ({ lang }) => getSkills({ lang }),
+    summarise: (result: unknown[]) =>
+      `${plural(count(result), 'skill', 'skills')} listed.`,
+  },
+  {
+    name: 'search_by_technology',
+    description:
+      'Substring-match a technology name across all experiences and projects',
+    params: { query: z.string(), lang: langSchema },
+    run: ({ query, lang }) => searchByTechnology(query, { lang }),
+    summarise: (
+      result: { experiences: unknown[]; projects: unknown[] },
+      { query },
+    ) => {
+      const total = count(result.experiences) + count(result.projects);
+      return total === 0
+        ? `No records mention ${query}.`
+        : `${query} appears in ${plural(count(result.experiences), 'role', 'roles')} and ${plural(count(result.projects), 'project', 'projects')}.`;
+    },
+  },
+];
+
+/**
+ * Adapter for the palette and WebMCP: JSON Schema instead of Zod, plain data instead of an
+ * MCP envelope. `inputSchema` is the same shape `selectTool()` passes as `responseConstraint`
+ * and the same shape WebMCP's `registerTool()` expects.
+ */
+export function toToolDescriptors(): ToolDescriptor[] {
+  return PROFILE_TOOLS.map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    inputSchema: z.toJSONSchema(z.object(tool.params)) as Record<
+      string,
+      unknown
+    >,
+    execute: tool.run as ToolDescriptor['execute'],
+  }));
+}

--- a/apps/personal-website/src/mcp/profile.ts
+++ b/apps/personal-website/src/mcp/profile.ts
@@ -1,56 +1,21 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
 import {
-  getEducation,
   getExperienceById,
-  getProfileSummary,
   getProjectById,
-  getProjects,
-  getSkills,
-  getWorkExperience,
-  searchByTechnology,
 } from '@rainforest-dev/personal-data';
 import { hasCaseStudy } from '@rainforest-dev/personal-portfolio/content';
-import type { SkillTag } from '@types';
-import { info, tags } from '@utils/constants';
+import { info } from '@utils/constants';
 import { getEntry } from 'astro:content';
-import { z } from 'zod';
 
-const langSchema = z.enum(['en', 'zh']).optional();
-// Derived from the same tags.skills vocabulary the content schemas use (content.config.ts),
-// rather than a plain z.string() — this makes the parsed value a real SkillTag, not just a
-// string, so the tool handlers below no longer need an `as any` cast to call getWorkExperience/
-// getProjects (which require SkillTag, not string).
-const technologySchema = z
-  .enum(tags.skills as unknown as [SkillTag, ...SkillTag[]])
-  .optional();
+import { PROFILE_TOOLS } from './catalog';
 
-// Single source of truth for each tool's name/description — server.registerTool below reads
-// from these instead of repeating the strings, and llms.txt.ts imports MCP_TOOLS (composed in
-// handler.ts from PROFILE_MCP_TOOLS + PORTFOLIO_MCP_TOOLS) to describe this server's capabilities
-// without maintaining a second, hand-written copy of the same list that could silently drift out
-// of sync if a tool were renamed/added/removed here.
-export const PROFILE_MCP_TOOLS = [
-  {
-    name: 'get_profile_summary',
-    description: 'Professional profile overview: counts and top technologies',
-  },
-  {
-    name: 'get_work_experience',
-    description: 'Work history, optionally filtered by technology',
-  },
-  { name: 'get_education', description: 'Academic background' },
-  {
-    name: 'get_projects',
-    description: 'Portfolio projects, optionally filtered by technology',
-  },
-  { name: 'get_skills', description: 'Technical skills inventory' },
-  {
-    name: 'search_by_technology',
-    description:
-      'Substring-match a technology name across all experiences and projects',
-  },
-] as const;
+// Derived, not repeated. This list previously duplicated every name and description by hand
+// alongside the registrations below; llms.txt.ts reads it via handler.ts's composed MCP_TOOLS.
+export const PROFILE_MCP_TOOLS = PROFILE_TOOLS.map(({ name, description }) => ({
+  name,
+  description,
+})) as ReadonlyArray<{ name: string; description: string }>;
 
 // Same rationale as PROFILE_MCP_TOOLS, for the resource URI templates registered below. `{+id}`
 // (RFC 6570 reserved expansion), not `{id}` — our ids contain slashes (e.g. `en/6`), and
@@ -65,14 +30,6 @@ export const PROFILE_MCP_RESOURCES = [
   { uriTemplate: 'profile://skill/{+id}', title: 'Skill' },
 ] as const;
 
-const [
-  profileSummaryTool,
-  workExperienceTool,
-  educationTool,
-  projectsTool,
-  skillsTool,
-  searchTool,
-] = PROFILE_MCP_TOOLS;
 const [experienceResource, projectResource, skillResource] =
   PROFILE_MCP_RESOURCES;
 
@@ -83,92 +40,18 @@ const [experienceResource, projectResource, skillResource] =
  * which only resolves inside the Astro runtime.
  */
 export function registerProfileMcp(server: McpServer): void {
-  server.registerTool(
-    profileSummaryTool.name,
-    {
-      description: profileSummaryTool.description,
-      inputSchema: { lang: langSchema },
-    },
-    async ({ lang }) => ({
-      content: [
-        {
-          type: 'text',
-          text: JSON.stringify(await getProfileSummary({ lang })),
-        },
-      ],
-    }),
-  );
-
-  server.registerTool(
-    workExperienceTool.name,
-    {
-      description: workExperienceTool.description,
-      inputSchema: { technology: technologySchema, lang: langSchema },
-    },
-    async ({ technology, lang }) => ({
-      content: [
-        {
-          type: 'text',
-          text: JSON.stringify(await getWorkExperience({ technology, lang })),
-        },
-      ],
-    }),
-  );
-
-  server.registerTool(
-    educationTool.name,
-    {
-      description: educationTool.description,
-      inputSchema: { lang: langSchema },
-    },
-    async ({ lang }) => ({
-      content: [
-        { type: 'text', text: JSON.stringify(await getEducation({ lang })) },
-      ],
-    }),
-  );
-
-  server.registerTool(
-    projectsTool.name,
-    {
-      description: projectsTool.description,
-      inputSchema: { technology: technologySchema, lang: langSchema },
-    },
-    async ({ technology, lang }) => ({
-      content: [
-        {
-          type: 'text',
-          text: JSON.stringify(await getProjects({ technology, lang })),
-        },
-      ],
-    }),
-  );
-
-  server.registerTool(
-    skillsTool.name,
-    { description: skillsTool.description, inputSchema: { lang: langSchema } },
-    async ({ lang }) => ({
-      content: [
-        { type: 'text', text: JSON.stringify(await getSkills({ lang })) },
-      ],
-    }),
-  );
-
-  server.registerTool(
-    searchTool.name,
-    {
-      description: searchTool.description,
-      inputSchema: { query: z.string(), lang: langSchema },
-    },
-    async ({ query, lang }) => ({
-      content: [
-        {
-          type: 'text',
-          text: JSON.stringify(await searchByTechnology(query, { lang })),
-        },
-      ],
-    }),
-  );
+  for (const tool of PROFILE_TOOLS) {
+    server.registerTool(
+      tool.name,
+      { description: tool.description, inputSchema: tool.params },
+      // The envelope is the MCP surface's concern, not the catalog's — `run` returns plain data.
+      async (args) => ({
+        content: [
+          { type: 'text', text: JSON.stringify(await tool.run(args as never)) },
+        ],
+      }),
+    );
+  }
 
   // experience/project resources return the same *resolved* shape as the tools above
   // (resolved organization, merged technologies) — not a raw content-collection entry.

--- a/apps/personal-website/src/mcp/profile.ts
+++ b/apps/personal-website/src/mcp/profile.ts
@@ -15,7 +15,7 @@ import { PROFILE_TOOLS } from './catalog';
 export const PROFILE_MCP_TOOLS = PROFILE_TOOLS.map(({ name, description }) => ({
   name,
   description,
-})) as ReadonlyArray<{ name: string; description: string }>;
+}));
 
 // Same rationale as PROFILE_MCP_TOOLS, for the resource URI templates registered below. `{+id}`
 // (RFC 6570 reserved expansion), not `{id}` — our ids contain slashes (e.g. `en/6`), and

--- a/apps/personal-website/src/utils/ai/index.ts
+++ b/apps/personal-website/src/utils/ai/index.ts
@@ -5,6 +5,7 @@ export {
   enableModel,
   selectTool,
 } from './language-model';
+export { PROBE_TIMEOUT_MS, withProbeTimeout } from './probe';
 export type { SummarizeFailure, SummarizeOptions } from './summarizer';
 export {
   destroySummarizer,

--- a/apps/personal-website/src/utils/ai/index.ts
+++ b/apps/personal-website/src/utils/ai/index.ts
@@ -13,6 +13,14 @@ export {
   SUMMARIZE_TIMEOUT_MS,
   SummarizeError,
 } from './summarizer';
+export type { LanguagePair, TranslateFailure } from './translator';
+export {
+  destroyTranslator,
+  detectTranslatorCapability,
+  TRANSLATE_TIMEOUT_MS,
+  translateChunks,
+  TranslateError,
+} from './translator';
 export type { AiState, ToolDescriptor } from './types';
 export { useLanguageModel } from './use-language-model';
 export { useSummarizer } from './use-summarizer';

--- a/apps/personal-website/src/utils/ai/index.ts
+++ b/apps/personal-website/src/utils/ai/index.ts
@@ -5,7 +5,16 @@ export {
   enableModel,
   selectTool,
 } from './language-model';
+export type { SummarizeFailure, SummarizeOptions } from './summarizer';
+export {
+  destroySummarizer,
+  detectSummarizerCapability,
+  summarize,
+  SUMMARIZE_TIMEOUT_MS,
+  SummarizeError,
+} from './summarizer';
 export type { AiState, ToolDescriptor } from './types';
 export { useLanguageModel } from './use-language-model';
+export { useSummarizer } from './use-summarizer';
 export type { AgentToolRegistration } from './webmcp';
 export { registerAgentTools } from './webmcp';

--- a/apps/personal-website/src/utils/ai/language-model.test.ts
+++ b/apps/personal-website/src/utils/ai/language-model.test.ts
@@ -188,9 +188,14 @@ describe('selectTool', () => {
     expect(sessionStorage.getItem('rf:ai:constraint-probe:v1')).toBeNull();
   });
 
-  it('throws when called before enableModel', async () => {
-    stubLanguageModel('available');
-    await expect(selectTool('q', SCHEMA)).rejects.toThrow(/enableModel/);
+  // Replaces a test that asserted the opposite ("throws when called before enableModel"). That
+  // contract was the defect, not a guarantee: `ready` is reached whenever the weights are already
+  // on disk, but the Enable control — enableModel()'s only caller — renders solely for
+  // `downloadable`. So every visitor who already had the model got an Ask row that threw here,
+  // was swallowed by the caller's catch, and left the answer strip blank with no error anywhere.
+  it('opens a session on demand when none exists', async () => {
+    stubSession(async () => '{"tool":"get_skills"}');
+    expect(await selectTool('q', SCHEMA)).toEqual({ tool: 'get_skills' });
   });
 
   it('does not degrade when the caller aborts mid-flight', async () => {

--- a/apps/personal-website/src/utils/ai/language-model.test.ts
+++ b/apps/personal-website/src/utils/ai/language-model.test.ts
@@ -346,8 +346,15 @@ describe('selectTool with an already-aborted signal', () => {
       selectTool('q', SCHEMA, { signal: controller.signal }),
     ).rejects.toThrow();
 
-    // Subscribing alone would miss this: the abort event already fired.
-    expect(promptStarted).toBe(true);
+    // The contract this pins is "reject promptly, without waiting out RUN_TIMEOUT_MS", and the
+    // rejection above is that contract. `prompt` is deliberately NOT started: an already-aborted
+    // caller has given up, so there is no inference worth beginning, and not starting it is the
+    // one behaviour that does not depend on the platform rejecting a pre-aborted signal.
+    //
+    // This assertion previously read `toBe(true)` — it documented an implementation that handed
+    // the aborted signal to `prompt` and relied on it to reject. Opening the session became
+    // awaitable, which made that route hang against any implementation that only subscribes.
+    expect(promptStarted).toBe(false);
     expect(sessionStorage.getItem('rf:ai:constraint-probe:v1')).toBeNull();
   });
 });

--- a/apps/personal-website/src/utils/ai/language-model.ts
+++ b/apps/personal-website/src/utils/ai/language-model.ts
@@ -91,9 +91,32 @@ export async function enableModel(
   })) as unknown as Session;
 }
 
+/**
+ * The live session, opening one first if there isn't one.
+ *
+ * Returns it rather than relying on the module-level `session` staying narrowed: an `await`
+ * between the null check and the use invalidates TypeScript's narrowing, and silencing that with
+ * `!` would assert something this function is better off actually proving.
+ *
+ * Opening on demand is what makes the `ready` path work at all. `ready` is reached only when
+ * availability is already `available`, meaning the weights are on disk and `create()` neither
+ * downloads nor needs a user gesture — the gesture requirement documented on `enableModel` is
+ * about the `downloadable` path, which still goes through the explicit control.
+ */
+async function ensureSession(): Promise<Session> {
+  if (!session) await enableModel();
+  if (!session) throw new Error('Could not open a language model session');
+  return session;
+}
+
 /** Wall-clock bound on a single run. The abort is what the platform honours — we ask it to
- *  stop rather than assuming we can interrupt inference ourselves. */
-export const RUN_TIMEOUT_MS = 20_000;
+ *  stop rather than assuming we can interrupt inference ourselves.
+ *
+ *  30s, not 20s: measured against Chrome 150's on-device model, successful constrained runs are
+ *  bimodal — roughly 0.6–2.4s or 20–21s, with nothing in between. A 20s bound sat directly on top
+ *  of the slow mode, so a run that was going to succeed got aborted a second short often enough to
+ *  make asking look broken. This is a ceiling for a hung call, not a latency target. */
+export const RUN_TIMEOUT_MS = 30_000;
 
 let hasSucceededOnce = false;
 
@@ -121,17 +144,6 @@ export async function selectTool<T>(
   schema: Record<string, unknown>,
   opts: { signal?: AbortSignal } = {},
 ): Promise<T> {
-  // Open a session on demand rather than requiring enableModel() first. `ready` is reached only
-  // when availability is already `available` (detectCapability), which means the weights are on
-  // disk and `create()` neither downloads nor needs a user gesture — the constraint enableModel's
-  // doc comment describes applies to the `downloadable` path, not this one.
-  //
-  // Without this, the AI path was dead on exactly the machines it was built for: a visitor whose
-  // model is already downloaded gets `ready`, so the palette offers the Ask row, but the Enable
-  // control that used to be the only caller of enableModel() renders solely for `downloadable`.
-  // Asking threw here, ask()'s catch swallowed it, and the strip stayed blank forever.
-  if (!session) await enableModel();
-
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), RUN_TIMEOUT_MS);
   const onCallerAbort = () => controller.abort();
@@ -139,6 +151,9 @@ export async function selectTool<T>(
   // An `abort` listener never fires on a signal that is ALREADY aborted — the event fires once,
   // when abort() is called. Subscribing alone would let a pre-aborted caller signal run the full
   // RUN_TIMEOUT_MS as if nothing were wrong, so check the current state first.
+  //
+  // This is wired up BEFORE opening the session, and the timeout covers that too: the whole
+  // operation is what the caller asked to bound, not just the inference part of it.
   if (opts.signal?.aborted) {
     controller.abort();
   } else {
@@ -146,7 +161,15 @@ export async function selectTool<T>(
   }
 
   try {
-    const raw = await session.prompt(query, {
+    const active = await ensureSession();
+    // Opening a session is itself awaitable, so the caller can abort while it is in flight. Do
+    // not hand an already-aborted signal to `prompt()` and hope: its `abort` event has already
+    // fired and fires only once, so an implementation that merely subscribes would hang until
+    // the timeout — the same one-shot-event trap guarded above, reachable a level up.
+    if (controller.signal.aborted) {
+      throw new DOMException('aborted', 'AbortError');
+    }
+    const raw = await active.prompt(query, {
       responseConstraint: schema,
       signal: controller.signal,
     });

--- a/apps/personal-website/src/utils/ai/language-model.ts
+++ b/apps/personal-website/src/utils/ai/language-model.ts
@@ -121,8 +121,16 @@ export async function selectTool<T>(
   schema: Record<string, unknown>,
   opts: { signal?: AbortSignal } = {},
 ): Promise<T> {
-  if (!session)
-    throw new Error('enableModel() must be called before selectTool()');
+  // Open a session on demand rather than requiring enableModel() first. `ready` is reached only
+  // when availability is already `available` (detectCapability), which means the weights are on
+  // disk and `create()` neither downloads nor needs a user gesture — the constraint enableModel's
+  // doc comment describes applies to the `downloadable` path, not this one.
+  //
+  // Without this, the AI path was dead on exactly the machines it was built for: a visitor whose
+  // model is already downloaded gets `ready`, so the palette offers the Ask row, but the Enable
+  // control that used to be the only caller of enableModel() renders solely for `downloadable`.
+  // Asking threw here, ask()'s catch swallowed it, and the strip stayed blank forever.
+  if (!session) await enableModel();
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), RUN_TIMEOUT_MS);

--- a/apps/personal-website/src/utils/ai/language-model.ts
+++ b/apps/personal-website/src/utils/ai/language-model.ts
@@ -1,3 +1,4 @@
+import { withProbeTimeout } from './probe';
 import type { AiState } from './types';
 
 /**
@@ -34,7 +35,11 @@ export async function detectCapability(): Promise<AiState> {
   if (typeof LanguageModel === 'undefined') return { kind: 'unsupported' };
   if (hasProbeFailure()) return { kind: 'unsupported' };
 
-  const availability = await LanguageModel.availability();
+  // A hung probe is treated as a no — see ./probe.
+  const availability = await withProbeTimeout(
+    LanguageModel.availability(),
+    'unavailable',
+  );
   switch (availability) {
     case 'unavailable':
       return { kind: 'unavailable' };

--- a/apps/personal-website/src/utils/ai/language-model.ts
+++ b/apps/personal-website/src/utils/ai/language-model.ts
@@ -112,10 +112,12 @@ async function ensureSession(): Promise<Session> {
 /** Wall-clock bound on a single run. The abort is what the platform honours — we ask it to
  *  stop rather than assuming we can interrupt inference ourselves.
  *
- *  30s, not 20s: measured against Chrome 150's on-device model, successful constrained runs are
- *  bimodal — roughly 0.6–2.4s or 20–21s, with nothing in between. A 20s bound sat directly on top
- *  of the slow mode, so a run that was going to succeed got aborted a second short often enough to
- *  make asking look broken. This is a ceiling for a hung call, not a latency target. */
+ *  A ceiling for a call that has hung, deliberately far above any healthy run. Typical constrained
+ *  runs against Chrome 150 land near a second; the 20–40s runs that originally forced this value up
+ *  from 20s turned out to be self-inflicted — an unconstrained string field in the caller's schema
+ *  invited the model to write an essay into it. Callers own their schemas, so this stays generous
+ *  rather than tight: a bound that trips on a slow-but-working run is worse than one that lets a
+ *  genuinely hung call sit a few extra seconds. */
 export const RUN_TIMEOUT_MS = 30_000;
 
 let hasSucceededOnce = false;

--- a/apps/personal-website/src/utils/ai/probe.ts
+++ b/apps/personal-website/src/utils/ai/probe.ts
@@ -1,0 +1,35 @@
+/**
+ * A capability probe must answer, or be treated as a no.
+ *
+ * `availability()` is documented as a quick lookup and usually returns in under a millisecond —
+ * but it is not guaranteed to settle. Measured 2026-07-29 in Chromium 150:
+ * `Translator.availability({sourceLanguage:'en', targetLanguage:'zh-Hant'})` never resolved, while
+ * `LanguageModel.availability()` and `Summarizer.availability()` both answered in 0ms in the same
+ * page. A probe that hangs is worse than one that fails, because nothing downstream can tell the
+ * difference between "still checking" and "will never answer":
+ *
+ * - a component gating its own render on the result stays invisible forever, with no error
+ * - a `Promise.all` over several probes is held hostage by the slowest
+ *
+ * Both were real. The support table hung on the third probe, and TranslateButton — which awaits the
+ * same detector in `onMounted` — would have rendered nothing at all, silently.
+ */
+export const PROBE_TIMEOUT_MS = 5_000;
+
+/**
+ * Resolves to `fallback` if `probe` has not settled within {@link PROBE_TIMEOUT_MS}.
+ *
+ * The losing probe is abandoned rather than cancelled — `availability()` takes no signal — so it
+ * may still settle later into nothing. That is acceptable for a lookup with no side effects.
+ */
+export function withProbeTimeout<T>(
+  probe: Promise<T>,
+  fallback: T,
+): Promise<T> {
+  return Promise.race([
+    probe,
+    new Promise<T>((resolve) => {
+      setTimeout(() => resolve(fallback), PROBE_TIMEOUT_MS);
+    }),
+  ]);
+}

--- a/apps/personal-website/src/utils/ai/summarizer.test.ts
+++ b/apps/personal-website/src/utils/ai/summarizer.test.ts
@@ -4,6 +4,7 @@ import {
   __resetForTests,
   destroySummarizer,
   detectSummarizerCapability,
+  DOWNLOAD_TIMEOUT_MS,
   summarize,
   SUMMARIZE_TIMEOUT_MS,
   SummarizeError,
@@ -198,6 +199,63 @@ describe('summarize', () => {
       reason: 'timeout',
     });
     await vi.advanceTimersByTimeAsync(SUMMARIZE_TIMEOUT_MS);
+    await assertion;
+  });
+
+  // Regression, from Edge 150 with an empty model cache: the download was still at 74% when a
+  // single shared 60s timer fired, so a run that was working reported "took too long". Opening
+  // the session gets its own, far larger budget.
+  it('does not kill a slow download with the inference budget', async () => {
+    vi.useFakeTimers();
+    Object.defineProperty(globalThis, 'Summarizer', {
+      configurable: true,
+      writable: true,
+      value: {
+        availability: vi.fn(async () => 'downloadable'),
+        // A download that takes well over the inference budget but finishes fine.
+        create: vi.fn(
+          () =>
+            new Promise((resolve) => {
+              setTimeout(
+                () =>
+                  resolve({
+                    summarize: async () => 'a summary',
+                    destroy: vi.fn(),
+                  }),
+                SUMMARIZE_TIMEOUT_MS * 3,
+              );
+            }),
+        ),
+      },
+    });
+
+    const pending = summarize('text');
+    await vi.advanceTimersByTimeAsync(SUMMARIZE_TIMEOUT_MS * 3 + 10);
+    await expect(pending).resolves.toBe('a summary');
+  });
+
+  it('still bounds a download that never finishes, at DOWNLOAD_TIMEOUT_MS', async () => {
+    vi.useFakeTimers();
+    Object.defineProperty(globalThis, 'Summarizer', {
+      configurable: true,
+      writable: true,
+      value: {
+        availability: vi.fn(async () => 'downloadable'),
+        // Never settles and ignores the controller — create() takes no signal, which is
+        // exactly the case rejectOnAbort exists to bound.
+        create: vi.fn(
+          () =>
+            new Promise<never>(() => {
+              /* intentionally never settles */
+            }),
+        ),
+      },
+    });
+    const pending = summarize('text');
+    const assertion = expect(pending).rejects.toMatchObject({
+      reason: 'timeout',
+    });
+    await vi.advanceTimersByTimeAsync(DOWNLOAD_TIMEOUT_MS + 10);
     await assertion;
   });
 

--- a/apps/personal-website/src/utils/ai/summarizer.test.ts
+++ b/apps/personal-website/src/utils/ai/summarizer.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  __resetForTests,
+  destroySummarizer,
+  detectSummarizerCapability,
+  summarize,
+  SUMMARIZE_TIMEOUT_MS,
+  SummarizeError,
+} from './summarizer';
+
+type Availability =
+  | 'unavailable'
+  | 'downloadable'
+  | 'downloading'
+  | 'available';
+
+/** Install a stub `Summarizer` global. Pass `null` to remove it entirely. */
+function stubSummarizer(
+  availability: Availability | null,
+  summarizeImpl?: (input: string, opts?: unknown) => Promise<string>,
+  destroy = vi.fn(),
+) {
+  if (availability === null) {
+    Reflect.deleteProperty(globalThis, 'Summarizer');
+    return { destroy };
+  }
+  Object.defineProperty(globalThis, 'Summarizer', {
+    configurable: true,
+    writable: true,
+    value: {
+      availability: vi.fn(async () => availability),
+      create: vi.fn(async () => ({
+        summarize: summarizeImpl ?? (async () => 'a summary'),
+        destroy,
+      })),
+    },
+  });
+  return { destroy };
+}
+
+afterEach(() => {
+  stubSummarizer(null);
+  __resetForTests();
+  vi.useRealTimers();
+});
+
+describe('detectSummarizerCapability', () => {
+  it('reports unsupported when the global is absent', async () => {
+    stubSummarizer(null);
+    expect(await detectSummarizerCapability()).toEqual({ kind: 'unsupported' });
+  });
+
+  it('maps availability() onto the shared state union', async () => {
+    stubSummarizer('unavailable');
+    expect(await detectSummarizerCapability()).toEqual({ kind: 'unavailable' });
+    stubSummarizer('downloadable');
+    expect(await detectSummarizerCapability()).toEqual({
+      kind: 'downloadable',
+    });
+    stubSummarizer('downloading');
+    expect(await detectSummarizerCapability()).toEqual({
+      kind: 'downloading',
+      progress: 0,
+    });
+    stubSummarizer('available');
+    expect(await detectSummarizerCapability()).toEqual({ kind: 'ready' });
+  });
+
+  // The platform answers per configuration, so a caller that probes bare and then runs with
+  // options could be told "ready" about a config it never asked about.
+  it('passes the caller options through to availability()', async () => {
+    stubSummarizer('available');
+    const opts = {
+      type: 'key-points',
+      format: 'markdown',
+      length: 'short',
+    } as const;
+    await detectSummarizerCapability(opts);
+    expect(
+      (
+        globalThis as unknown as {
+          Summarizer: { availability: ReturnType<typeof vi.fn> };
+        }
+      ).Summarizer.availability,
+    ).toHaveBeenCalledWith(opts);
+  });
+});
+
+describe('summarize', () => {
+  it('returns the summary text', async () => {
+    stubSummarizer('available', async () => 'key points here');
+    expect(await summarize('a long article')).toBe('key points here');
+  });
+
+  it('opens a session on demand, with no separate enable step', async () => {
+    stubSummarizer('available');
+    await summarize('text');
+    const { Summarizer } = globalThis as unknown as {
+      Summarizer: { create: ReturnType<typeof vi.fn> };
+    };
+    expect(Summarizer.create).toHaveBeenCalledTimes(1);
+  });
+
+  // Sessions are configuration-bound: reusing one across configs would silently answer in the
+  // previous shape (ask for a headline, receive key-points).
+  it('reuses the session for one config and rebuilds it for another', async () => {
+    const { destroy } = stubSummarizer('available');
+    const { Summarizer } = globalThis as unknown as {
+      Summarizer: { create: ReturnType<typeof vi.fn> };
+    };
+
+    await summarize('a', { type: 'key-points' });
+    await summarize('b', { type: 'key-points' });
+    expect(Summarizer.create).toHaveBeenCalledTimes(1);
+
+    await summarize('c', { type: 'headline' });
+    expect(Summarizer.create).toHaveBeenCalledTimes(2);
+    // The superseded session is released rather than stranded holding the model.
+    expect(destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('classifies an oversized input as too-long, not a generic failure', async () => {
+    stubSummarizer('available', async () => {
+      throw new DOMException('input too large', 'QuotaExceededError');
+    });
+    await expect(summarize('war and peace')).rejects.toMatchObject({
+      name: 'SummarizeError',
+      reason: 'too-long',
+    });
+  });
+
+  // The platform refuses to start a model download outside a user gesture. Distinct from a
+  // generic failure because it is the one case a reader can act on by clicking again.
+  it('classifies a missing user gesture as needs-gesture', async () => {
+    Object.defineProperty(globalThis, 'Summarizer', {
+      configurable: true,
+      writable: true,
+      value: {
+        availability: vi.fn(async () => 'downloadable'),
+        create: vi.fn(async () => {
+          throw new DOMException(
+            'Requires a user gesture when availability is "downloadable".',
+            'NotAllowedError',
+          );
+        }),
+      },
+    });
+    await expect(summarize('text')).rejects.toMatchObject({
+      reason: 'needs-gesture',
+    });
+  });
+
+  it('classifies anything else as failed', async () => {
+    stubSummarizer('available', async () => {
+      throw new Error('kErrorUnknown');
+    });
+    await expect(summarize('text')).rejects.toMatchObject({
+      reason: 'failed',
+    });
+  });
+
+  it('classifies a caller abort as timeout', async () => {
+    stubSummarizer(
+      'available',
+      (_input, opts) =>
+        new Promise<string>((_resolve, reject) => {
+          const { signal } = opts as { signal: AbortSignal };
+          if (signal.aborted) {
+            reject(new DOMException('aborted', 'AbortError'));
+            return;
+          }
+          signal.addEventListener('abort', () =>
+            reject(new DOMException('aborted', 'AbortError')),
+          );
+        }),
+    );
+    const controller = new AbortController();
+    const pending = summarize('text', {}, { signal: controller.signal });
+    controller.abort();
+    await expect(pending).rejects.toMatchObject({ reason: 'timeout' });
+  });
+
+  it('aborts a hung run at SUMMARIZE_TIMEOUT_MS rather than hanging forever', async () => {
+    vi.useFakeTimers();
+    stubSummarizer(
+      'available',
+      (_input, opts) =>
+        new Promise<string>((_resolve, reject) => {
+          (opts as { signal: AbortSignal }).signal.addEventListener(
+            'abort',
+            () => reject(new DOMException('timed out', 'AbortError')),
+          );
+        }),
+    );
+    const pending = summarize('text');
+    const assertion = expect(pending).rejects.toMatchObject({
+      reason: 'timeout',
+    });
+    await vi.advanceTimersByTimeAsync(SUMMARIZE_TIMEOUT_MS);
+    await assertion;
+  });
+
+  it('reports download progress while the model is fetched', async () => {
+    const events: number[] = [];
+    Object.defineProperty(globalThis, 'Summarizer', {
+      configurable: true,
+      writable: true,
+      value: {
+        availability: vi.fn(async () => 'downloadable'),
+        create: vi.fn(async (opts: { monitor: (m: EventTarget) => void }) => {
+          const monitor = new EventTarget();
+          opts.monitor(monitor);
+          const event = new Event('downloadprogress') as Event & {
+            loaded: number;
+            total: number;
+          };
+          event.loaded = 5;
+          event.total = 10;
+          monitor.dispatchEvent(event);
+          return { summarize: async () => 'done', destroy: vi.fn() };
+        }),
+      },
+    });
+
+    await summarize('text', {}, { onProgress: (p) => events.push(p) });
+
+    expect(events).toEqual([0.5]);
+  });
+
+  it('throws SummarizeError, so callers can switch on reason without instanceof gymnastics', async () => {
+    stubSummarizer('available', async () => {
+      throw new Error('boom');
+    });
+    await expect(summarize('text')).rejects.toBeInstanceOf(SummarizeError);
+  });
+});
+
+describe('destroySummarizer', () => {
+  it('releases the session so the next call opens a fresh one', async () => {
+    const { destroy } = stubSummarizer('available');
+    const { Summarizer } = globalThis as unknown as {
+      Summarizer: { create: ReturnType<typeof vi.fn> };
+    };
+
+    await summarize('a');
+    destroySummarizer();
+    expect(destroy).toHaveBeenCalledTimes(1);
+
+    await summarize('b');
+    expect(Summarizer.create).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/personal-website/src/utils/ai/summarizer.ts
+++ b/apps/personal-website/src/utils/ai/summarizer.ts
@@ -1,3 +1,4 @@
+import { withProbeTimeout } from './probe';
 import type { AiState } from './types';
 
 /**
@@ -42,7 +43,11 @@ export async function detectSummarizerCapability(
 ): Promise<AiState> {
   if (typeof Summarizer === 'undefined') return { kind: 'unsupported' };
 
-  const availability = await Summarizer.availability(options);
+  // A hung probe is treated as a no — see ./probe for the case that made this necessary.
+  const availability = await withProbeTimeout(
+    Summarizer.availability(options),
+    'unavailable',
+  );
   switch (availability) {
     case 'unavailable':
       return { kind: 'unavailable' };

--- a/apps/personal-website/src/utils/ai/summarizer.ts
+++ b/apps/personal-website/src/utils/ai/summarizer.ts
@@ -1,0 +1,189 @@
+import type { AiState } from './types';
+
+/**
+ * The Summarizer API, wrapped the same way `language-model.ts` wraps the Prompt API — same state
+ * union, same lazy-session rule, same "a failure is reported, never swallowed" stance.
+ *
+ * Why a second module rather than a generalized one: the two APIs share a capability *vocabulary*
+ * (`availability()` returning unavailable/downloadable/downloading/available) but nothing else.
+ * Summarizer takes configured sessions and plain text; the Prompt API takes a schema and returns
+ * constrained JSON. Folding them together would mean a wrapper whose options are a union of two
+ * disjoint shapes, so they stay separate and share only `AiState`.
+ *
+ * Worth knowing: Summarizer ships in browsers where the Prompt API does not. Measured 2026-07-29 —
+ * Edge 150 has Summarizer and Translator but no `LanguageModel` at all. A feature built on this
+ * reaches strictly more people than one built on the palette's `selectTool`.
+ */
+
+/** Mirrors the platform's option bag; narrowed to what this site actually uses. */
+export interface SummarizeOptions {
+  type?: 'key-points' | 'tldr' | 'teaser' | 'headline';
+  format?: 'markdown' | 'plain-text';
+  length?: 'short' | 'medium' | 'long';
+}
+
+type SummarizerSession = {
+  summarize: (input: string, opts?: unknown) => Promise<string>;
+  destroy: () => void;
+};
+
+declare const Summarizer: {
+  availability: (opts?: SummarizeOptions) => Promise<string>;
+  create: (opts?: Record<string, unknown>) => Promise<SummarizerSession>;
+};
+
+/**
+ * Availability for a *specific* configuration. The platform answers per option bag — a config it
+ * cannot serve reports `unavailable` even when another one is `available` — so callers must probe
+ * with the same options they intend to run with, which is why this takes them.
+ */
+export async function detectSummarizerCapability(
+  options: SummarizeOptions = {},
+): Promise<AiState> {
+  if (typeof Summarizer === 'undefined') return { kind: 'unsupported' };
+
+  const availability = await Summarizer.availability(options);
+  switch (availability) {
+    case 'unavailable':
+      return { kind: 'unavailable' };
+    case 'downloadable':
+      return { kind: 'downloadable' };
+    case 'downloading':
+      return { kind: 'downloading', progress: 0 };
+    default:
+      return { kind: 'ready' };
+  }
+}
+
+let session: SummarizerSession | null = null;
+let sessionKey = '';
+
+/** Test-only: clear module state between cases. */
+export function __resetForTests(): void {
+  session = null;
+  sessionKey = '';
+}
+
+const keyOf = (options: SummarizeOptions) =>
+  `${options.type ?? ''}|${options.format ?? ''}|${options.length ?? ''}`;
+
+/**
+ * Opens a session for `options`, reusing the live one when the configuration matches.
+ *
+ * Sessions are configuration-bound: asking for a headline through a session created for key-points
+ * returns key-points. Keying the cache on the options — rather than holding one session like the
+ * Prompt API wrapper does — is what lets a page offer more than one summary shape without silently
+ * serving the wrong one.
+ */
+async function ensureSession(
+  options: SummarizeOptions,
+  onProgress?: (progress: number) => void,
+): Promise<SummarizerSession> {
+  const key = keyOf(options);
+  if (session && sessionKey === key) return session;
+
+  session?.destroy();
+  session = await Summarizer.create({
+    ...options,
+    monitor(monitor: EventTarget) {
+      monitor.addEventListener('downloadprogress', (event) => {
+        const { loaded, total } = event as Event & {
+          loaded: number;
+          total: number;
+        };
+        onProgress?.(total > 0 ? loaded / total : 0);
+      });
+    },
+  });
+  sessionKey = key;
+  return session;
+}
+
+/**
+ * Wall-clock ceiling for one summarization, generous because the input is a whole article rather
+ * than a sentence. As with the Prompt API wrapper this bounds a hung call; it is not a target.
+ */
+export const SUMMARIZE_TIMEOUT_MS = 60_000;
+
+/**
+ * Distinguishes what the reader should be told. `unsupported` never reaches here — the UI hides.
+ *
+ * `needs-gesture` is its own case because it is the only one the reader can act on: the platform
+ * refuses `create()` outside a user gesture whenever the model still has to be downloaded
+ * (`NotAllowedError: Requires a user gesture when availability is "downloading" or "downloadable"`).
+ * A real click satisfies it; anything that reaches `summarize()` on a timer, from a lifecycle hook,
+ * or after an await that spent the activation does not.
+ */
+export type SummarizeFailure =
+  | 'timeout'
+  | 'too-long'
+  | 'needs-gesture'
+  | 'failed';
+
+export class SummarizeError extends Error {
+  constructor(
+    readonly reason: SummarizeFailure,
+    cause?: unknown,
+  ) {
+    super(`summarize failed: ${reason}`, { cause });
+    this.name = 'SummarizeError';
+  }
+}
+
+/**
+ * Summarizes `text`, throwing a `SummarizeError` whose `reason` the UI can render.
+ *
+ * Every failure is classified rather than collapsed into one silent nothing. That is a direct
+ * lesson from the command palette: a bare catch there made three unrelated defects — a missing
+ * session, a rejected argument, and a timeout — indistinguishable from "nothing to say", and two
+ * of them survived review because of it.
+ */
+export async function summarize(
+  text: string,
+  options: SummarizeOptions = {},
+  hooks: { signal?: AbortSignal; onProgress?: (progress: number) => void } = {},
+): Promise<string> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), SUMMARIZE_TIMEOUT_MS);
+  const onCallerAbort = () => controller.abort();
+
+  // Wired before opening the session, and the timeout covers session creation too: a first run
+  // includes a model download, which is the part most likely to hang.
+  if (hooks.signal?.aborted) controller.abort();
+  else hooks.signal?.addEventListener('abort', onCallerAbort, { once: true });
+
+  try {
+    const active = await ensureSession(options, hooks.onProgress);
+    // Opening the session is awaitable, so the caller may have aborted meanwhile. Throw rather
+    // than hand `summarize()` a spent signal — its `abort` event has already fired and fires only
+    // once, so an implementation that merely subscribes would hang until the timeout.
+    if (controller.signal.aborted) {
+      throw new DOMException('aborted', 'AbortError');
+    }
+    return await active.summarize(text, { signal: controller.signal });
+  } catch (cause) {
+    if (cause instanceof DOMException && cause.name === 'AbortError') {
+      throw new SummarizeError('timeout', cause);
+    }
+    // The platform rejects oversized input with QuotaExceededError. It is worth its own message:
+    // unlike a generic failure, retrying the same article cannot help.
+    if (cause instanceof DOMException && cause.name === 'QuotaExceededError') {
+      throw new SummarizeError('too-long', cause);
+    }
+    // Opposite of the above: retrying is exactly what helps, provided the retry is a real click.
+    if (cause instanceof DOMException && cause.name === 'NotAllowedError') {
+      throw new SummarizeError('needs-gesture', cause);
+    }
+    throw new SummarizeError('failed', cause);
+  } finally {
+    clearTimeout(timer);
+    hooks.signal?.removeEventListener('abort', onCallerAbort);
+  }
+}
+
+/** Releases the live session. Callers that own the page should do this on teardown. */
+export function destroySummarizer(): void {
+  session?.destroy();
+  session = null;
+  sessionKey = '';
+}

--- a/apps/personal-website/src/utils/ai/summarizer.ts
+++ b/apps/personal-website/src/utils/ai/summarizer.ts
@@ -100,10 +100,40 @@ async function ensureSession(
 }
 
 /**
- * Wall-clock ceiling for one summarization, generous because the input is a whole article rather
- * than a sentence. As with the Prompt API wrapper this bounds a hung call; it is not a target.
+ * Rejects when `signal` aborts, so a phase that cannot take a signal can still be bounded.
+ *
+ * `create()` accepts no AbortSignal: a download that never progresses ignores the controller
+ * entirely, and awaiting it directly would hang past every timeout with the UI stuck busy. Racing
+ * the creation against this turns the timer into something that actually fires. The losing
+ * creation promise is left to settle on its own — it may still cache a session, which a later
+ * call is free to reuse.
+ */
+function rejectOnAbort(signal: AbortSignal): Promise<never> {
+  return new Promise((_resolve, reject) => {
+    const fail = () => reject(new DOMException('aborted', 'AbortError'));
+    if (signal.aborted) fail();
+    else signal.addEventListener('abort', fail, { once: true });
+  });
+}
+
+/**
+ * Ceiling for the inference itself, once a session exists. Generous because the input is a whole
+ * article rather than a sentence, but it bounds a hung call — it is not a latency target.
  */
 export const SUMMARIZE_TIMEOUT_MS = 60_000;
+
+/**
+ * Separate, far larger ceiling for opening the session, because a first run downloads a model of
+ * a few hundred megabytes over the user's connection.
+ *
+ * These were one timer until Edge 150 proved it wrong: with nothing cached, the download was still
+ * at 74% when the 60s inference budget expired, so a run that was working reported "took too long".
+ * The original reasoning — that the download is the part most likely to hang, so it should be
+ * inside the bound — had it backwards. The download is the part most likely to be slow and fine.
+ * Chrome could never surface this, since its model was already on disk and session creation was
+ * instant.
+ */
+export const DOWNLOAD_TIMEOUT_MS = 600_000;
 
 /**
  * Distinguishes what the reader should be told. `unsupported` never reaches here — the UI hides.
@@ -144,16 +174,21 @@ export async function summarize(
   hooks: { signal?: AbortSignal; onProgress?: (progress: number) => void } = {},
 ): Promise<string> {
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), SUMMARIZE_TIMEOUT_MS);
+  // Two phases, two budgets: the download gets DOWNLOAD_TIMEOUT_MS, then the timer is re-armed at
+  // the tighter SUMMARIZE_TIMEOUT_MS for the inference. A caller abort still applies throughout.
+  let timer = setTimeout(() => controller.abort(), DOWNLOAD_TIMEOUT_MS);
   const onCallerAbort = () => controller.abort();
 
-  // Wired before opening the session, and the timeout covers session creation too: a first run
-  // includes a model download, which is the part most likely to hang.
   if (hooks.signal?.aborted) controller.abort();
   else hooks.signal?.addEventListener('abort', onCallerAbort, { once: true });
 
   try {
-    const active = await ensureSession(options, hooks.onProgress);
+    const active = await Promise.race([
+      ensureSession(options, hooks.onProgress),
+      rejectOnAbort(controller.signal),
+    ]);
+    clearTimeout(timer);
+    timer = setTimeout(() => controller.abort(), SUMMARIZE_TIMEOUT_MS);
     // Opening the session is awaitable, so the caller may have aborted meanwhile. Throw rather
     // than hand `summarize()` a spent signal — its `abort` event has already fired and fires only
     // once, so an implementation that merely subscribes would hang until the timeout.

--- a/apps/personal-website/src/utils/ai/translator.test.ts
+++ b/apps/personal-website/src/utils/ai/translator.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  __resetForTests,
+  destroyTranslator,
+  detectTranslatorCapability,
+  TRANSLATE_TIMEOUT_MS,
+  translateChunks,
+  TranslateError,
+} from './translator';
+
+const EN_ZH = { sourceLanguage: 'en', targetLanguage: 'zh-Hant' };
+
+function stubTranslator(
+  availability:
+    | 'unavailable'
+    | 'downloadable'
+    | 'downloading'
+    | 'available'
+    | null,
+  translateImpl?: (input: string, opts?: unknown) => Promise<string>,
+  destroy = vi.fn(),
+) {
+  if (availability === null) {
+    Reflect.deleteProperty(globalThis, 'Translator');
+    return { destroy };
+  }
+  Object.defineProperty(globalThis, 'Translator', {
+    configurable: true,
+    writable: true,
+    value: {
+      availability: vi.fn(async () => availability),
+      create: vi.fn(async () => ({
+        translate: translateImpl ?? (async (input: string) => `[zh]${input}`),
+        destroy,
+      })),
+    },
+  });
+  return { destroy };
+}
+
+afterEach(() => {
+  stubTranslator(null);
+  __resetForTests();
+  vi.useRealTimers();
+});
+
+describe('detectTranslatorCapability', () => {
+  it('reports unsupported when the global is absent', async () => {
+    stubTranslator(null);
+    expect(await detectTranslatorCapability(EN_ZH)).toEqual({
+      kind: 'unsupported',
+    });
+  });
+
+  it('maps availability() onto the shared state union', async () => {
+    stubTranslator('downloadable');
+    expect(await detectTranslatorCapability(EN_ZH)).toEqual({
+      kind: 'downloadable',
+    });
+    stubTranslator('available');
+    expect(await detectTranslatorCapability(EN_ZH)).toEqual({ kind: 'ready' });
+  });
+
+  it('asks about the specific pair — models are per pair, not global', async () => {
+    stubTranslator('available');
+    await detectTranslatorCapability(EN_ZH);
+    expect(
+      (
+        globalThis as unknown as {
+          Translator: { availability: ReturnType<typeof vi.fn> };
+        }
+      ).Translator.availability,
+    ).toHaveBeenCalledWith(EN_ZH);
+  });
+});
+
+describe('translateChunks', () => {
+  it('returns one result per chunk, in order', async () => {
+    stubTranslator('available');
+    expect(await translateChunks(['one', 'two', 'three'], EN_ZH)).toEqual([
+      '[zh]one',
+      '[zh]two',
+      '[zh]three',
+    ]);
+  });
+
+  // The caller puts each result back where it came from, so a dropped or reordered chunk would
+  // silently scramble the page.
+  it('preserves count even when a chunk translates to the same text', async () => {
+    stubTranslator('available', async (input) => input);
+    const chunks = ['a', 'b', 'c', 'd'];
+    expect(await translateChunks(chunks, EN_ZH)).toHaveLength(chunks.length);
+  });
+
+  it('emits each chunk as it lands, so the page can update progressively', async () => {
+    stubTranslator('available');
+    const seen: Array<[number, string]> = [];
+    await translateChunks(['one', 'two'], EN_ZH, {
+      onChunk: (i, text) => seen.push([i, text]),
+    });
+    expect(seen).toEqual([
+      [0, '[zh]one'],
+      [1, '[zh]two'],
+    ]);
+  });
+
+  it('reuses one session for the pair rather than one per chunk', async () => {
+    stubTranslator('available');
+    await translateChunks(['a', 'b', 'c'], EN_ZH);
+    expect(
+      (
+        globalThis as unknown as {
+          Translator: { create: ReturnType<typeof vi.fn> };
+        }
+      ).Translator.create,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it('rebuilds the session when the pair changes', async () => {
+    const { destroy } = stubTranslator('available');
+    const { Translator } = globalThis as unknown as {
+      Translator: { create: ReturnType<typeof vi.fn> };
+    };
+    await translateChunks(['a'], EN_ZH);
+    await translateChunks(['b'], {
+      sourceLanguage: 'zh-Hant',
+      targetLanguage: 'en',
+    });
+    expect(Translator.create).toHaveBeenCalledTimes(2);
+    expect(destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('classifies a missing user gesture as needs-gesture', async () => {
+    Object.defineProperty(globalThis, 'Translator', {
+      configurable: true,
+      writable: true,
+      value: {
+        availability: vi.fn(async () => 'downloadable'),
+        create: vi.fn(async () => {
+          throw new DOMException('needs a gesture', 'NotAllowedError');
+        }),
+      },
+    });
+    await expect(translateChunks(['a'], EN_ZH)).rejects.toMatchObject({
+      reason: 'needs-gesture',
+    });
+  });
+
+  it('classifies anything unrecognised as failed', async () => {
+    stubTranslator('available', async () => {
+      throw new Error('kErrorUnknown');
+    });
+    await expect(translateChunks(['a'], EN_ZH)).rejects.toBeInstanceOf(
+      TranslateError,
+    );
+    await expect(translateChunks(['a'], EN_ZH)).rejects.toMatchObject({
+      reason: 'failed',
+    });
+  });
+
+  it('stops partway through when the caller aborts, rather than finishing the batch', async () => {
+    const controller = new AbortController();
+    let calls = 0;
+    stubTranslator('available', async (input) => {
+      calls += 1;
+      if (calls === 2) controller.abort();
+      return `[zh]${input}`;
+    });
+    await expect(
+      translateChunks(['a', 'b', 'c', 'd'], EN_ZH, {
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ reason: 'timeout' });
+    // Aborted after the second chunk resolved; the third and fourth were never attempted.
+    expect(calls).toBe(2);
+  });
+
+  it('aborts a hung batch at TRANSLATE_TIMEOUT_MS', async () => {
+    vi.useFakeTimers();
+    stubTranslator(
+      'available',
+      (_input, opts) =>
+        new Promise<string>((_resolve, reject) => {
+          (opts as { signal: AbortSignal }).signal.addEventListener(
+            'abort',
+            () => reject(new DOMException('timed out', 'AbortError')),
+          );
+        }),
+    );
+    const pending = translateChunks(['a'], EN_ZH);
+    const assertion = expect(pending).rejects.toMatchObject({
+      reason: 'timeout',
+    });
+    await vi.advanceTimersByTimeAsync(TRANSLATE_TIMEOUT_MS);
+    await assertion;
+  });
+});
+
+describe('destroyTranslator', () => {
+  it('releases the session', async () => {
+    const { destroy } = stubTranslator('available');
+    await translateChunks(['a'], EN_ZH);
+    destroyTranslator();
+    expect(destroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/personal-website/src/utils/ai/translator.test.ts
+++ b/apps/personal-website/src/utils/ai/translator.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { PROBE_TIMEOUT_MS } from './probe';
 import {
   __resetForTests,
   destroyTranslator,
@@ -60,6 +61,30 @@ describe('detectTranslatorCapability', () => {
     });
     stubTranslator('available');
     expect(await detectTranslatorCapability(EN_ZH)).toEqual({ kind: 'ready' });
+  });
+
+  // Regression, measured in Chromium 150: this exact call never resolved, while the other two
+  // APIs' probes answered in 0ms on the same page. A component gating its render on the result
+  // would have stayed invisible forever, with nothing logged.
+  it('treats a probe that never settles as unavailable rather than hanging', async () => {
+    vi.useFakeTimers();
+    Object.defineProperty(globalThis, 'Translator', {
+      configurable: true,
+      writable: true,
+      value: {
+        availability: vi.fn(
+          () =>
+            new Promise<string>(() => {
+              /* never settles, as observed */
+            }),
+        ),
+        create: vi.fn(),
+      },
+    });
+
+    const pending = detectTranslatorCapability(EN_ZH);
+    await vi.advanceTimersByTimeAsync(PROBE_TIMEOUT_MS + 10);
+    expect(await pending).toEqual({ kind: 'unavailable' });
   });
 
   it('asks about the specific pair — models are per pair, not global', async () => {

--- a/apps/personal-website/src/utils/ai/translator.ts
+++ b/apps/personal-website/src/utils/ai/translator.ts
@@ -84,10 +84,30 @@ async function ensureSession(
 }
 
 /**
- * Ceiling for one batch. Higher than the summarizer's because a page's worth of paragraphs is
- * translated through a single session, and the first call also pays for the model download.
+ * Rejects when `signal` aborts, so a phase that cannot take a signal can still be bounded.
+ *
+ * `create()` accepts no AbortSignal: a download that never progresses ignores the controller
+ * entirely, and awaiting it directly would hang past every timeout with the UI stuck busy. Racing
+ * the creation against this turns the timer into something that actually fires. The losing
+ * creation promise is left to settle on its own — it may still cache a session, which a later
+ * call is free to reuse.
+ */
+function rejectOnAbort(signal: AbortSignal): Promise<never> {
+  return new Promise((_resolve, reject) => {
+    const fail = () => reject(new DOMException('aborted', 'AbortError'));
+    if (signal.aborted) fail();
+    else signal.addEventListener('abort', fail, { once: true });
+  });
+}
+
+/**
+ * Ceiling for the batch itself, once a session exists. Higher than the summarizer's because a
+ * page's worth of paragraphs goes through one session.
  */
 export const TRANSLATE_TIMEOUT_MS = 120_000;
+
+/** Separate ceiling for opening the session — see DOWNLOAD_TIMEOUT_MS in ./summarizer. */
+export const DOWNLOAD_TIMEOUT_MS = 600_000;
 
 /** Same vocabulary as the summarizer, so the two features can share failure copy. */
 export type TranslateFailure =
@@ -137,14 +157,21 @@ export async function translateChunks(
   } = {},
 ): Promise<string[]> {
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), TRANSLATE_TIMEOUT_MS);
+  // Download budget first, then re-armed at the batch budget — see ./summarizer for why these are
+  // separate. Edge 150 with an empty cache is what proved one shared timer wrong.
+  let timer = setTimeout(() => controller.abort(), DOWNLOAD_TIMEOUT_MS);
   const onCallerAbort = () => controller.abort();
 
   if (hooks.signal?.aborted) controller.abort();
   else hooks.signal?.addEventListener('abort', onCallerAbort, { once: true });
 
   try {
-    const active = await ensureSession(pair, hooks.onProgress);
+    const active = await Promise.race([
+      ensureSession(pair, hooks.onProgress),
+      rejectOnAbort(controller.signal),
+    ]);
+    clearTimeout(timer);
+    timer = setTimeout(() => controller.abort(), TRANSLATE_TIMEOUT_MS);
     if (controller.signal.aborted) {
       throw new DOMException('aborted', 'AbortError');
     }

--- a/apps/personal-website/src/utils/ai/translator.ts
+++ b/apps/personal-website/src/utils/ai/translator.ts
@@ -1,0 +1,179 @@
+import type { AiState } from './types';
+
+/**
+ * The Translator API, wrapped like `summarizer.ts` — same `AiState`, same lazy session, same
+ * "classify the failure, never swallow it" stance.
+ *
+ * The difference that shapes this module: Translator models are per **language pair**, not one
+ * model with options. `availability()` answers about a pair, `create()` binds to a pair, and a
+ * session for en→zh-Hant cannot translate zh-Hant→en. So the session cache is keyed by pair, and
+ * every entry point takes one.
+ *
+ * Like Summarizer, this ships where the Prompt API does not — measured 2026-07-29, Edge 150 has
+ * Translator and no `LanguageModel`.
+ */
+
+export interface LanguagePair {
+  sourceLanguage: string;
+  targetLanguage: string;
+}
+
+type TranslatorSession = {
+  translate: (input: string, opts?: unknown) => Promise<string>;
+  destroy: () => void;
+};
+
+declare const Translator: {
+  availability: (pair: LanguagePair) => Promise<string>;
+  create: (opts: Record<string, unknown>) => Promise<TranslatorSession>;
+};
+
+/** Availability for one pair. A pair the platform cannot serve reports `unavailable`. */
+export async function detectTranslatorCapability(
+  pair: LanguagePair,
+): Promise<AiState> {
+  if (typeof Translator === 'undefined') return { kind: 'unsupported' };
+
+  const availability = await Translator.availability(pair);
+  switch (availability) {
+    case 'unavailable':
+      return { kind: 'unavailable' };
+    case 'downloadable':
+      return { kind: 'downloadable' };
+    case 'downloading':
+      return { kind: 'downloading', progress: 0 };
+    default:
+      return { kind: 'ready' };
+  }
+}
+
+let session: TranslatorSession | null = null;
+let sessionKey = '';
+
+/** Test-only: clear module state between cases. */
+export function __resetForTests(): void {
+  session = null;
+  sessionKey = '';
+}
+
+const keyOf = (pair: LanguagePair) =>
+  `${pair.sourceLanguage}->${pair.targetLanguage}`;
+
+async function ensureSession(
+  pair: LanguagePair,
+  onProgress?: (progress: number) => void,
+): Promise<TranslatorSession> {
+  const key = keyOf(pair);
+  if (session && sessionKey === key) return session;
+
+  session?.destroy();
+  session = await Translator.create({
+    ...pair,
+    monitor(monitor: EventTarget) {
+      monitor.addEventListener('downloadprogress', (event) => {
+        const { loaded, total } = event as Event & {
+          loaded: number;
+          total: number;
+        };
+        onProgress?.(total > 0 ? loaded / total : 0);
+      });
+    },
+  });
+  sessionKey = key;
+  return session;
+}
+
+/**
+ * Ceiling for one batch. Higher than the summarizer's because a page's worth of paragraphs is
+ * translated through a single session, and the first call also pays for the model download.
+ */
+export const TRANSLATE_TIMEOUT_MS = 120_000;
+
+/** Same vocabulary as the summarizer, so the two features can share failure copy. */
+export type TranslateFailure =
+  | 'timeout'
+  | 'too-long'
+  | 'needs-gesture'
+  | 'failed';
+
+export class TranslateError extends Error {
+  constructor(
+    readonly reason: TranslateFailure,
+    cause?: unknown,
+  ) {
+    super(`translate failed: ${reason}`, { cause });
+    this.name = 'TranslateError';
+  }
+}
+
+function classify(cause: unknown): TranslateFailure {
+  if (cause instanceof DOMException) {
+    if (cause.name === 'AbortError') return 'timeout';
+    if (cause.name === 'QuotaExceededError') return 'too-long';
+    // The platform refuses to start a pair's download outside a user gesture.
+    if (cause.name === 'NotAllowedError') return 'needs-gesture';
+  }
+  return 'failed';
+}
+
+/**
+ * Translates `chunks` through one session, preserving order and count.
+ *
+ * Takes an array rather than a string because the caller is translating a page: each chunk is one
+ * paragraph, and it needs them back one-to-one to put them where they came from. Joining them into
+ * a single string and splitting the result would depend on the model preserving the separator,
+ * which is not something to rely on.
+ *
+ * Sequential, not `Promise.all`: the session is a single resource, and firing a page's worth of
+ * paragraphs at it concurrently produced no speedup worth the risk of overlapping calls.
+ */
+export async function translateChunks(
+  chunks: readonly string[],
+  pair: LanguagePair,
+  hooks: {
+    signal?: AbortSignal;
+    onProgress?: (progress: number) => void;
+    onChunk?: (index: number, text: string) => void;
+  } = {},
+): Promise<string[]> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TRANSLATE_TIMEOUT_MS);
+  const onCallerAbort = () => controller.abort();
+
+  if (hooks.signal?.aborted) controller.abort();
+  else hooks.signal?.addEventListener('abort', onCallerAbort, { once: true });
+
+  try {
+    const active = await ensureSession(pair, hooks.onProgress);
+    if (controller.signal.aborted) {
+      throw new DOMException('aborted', 'AbortError');
+    }
+
+    const results: string[] = [];
+    for (const [index, chunk] of chunks.entries()) {
+      if (controller.signal.aborted) {
+        throw new DOMException('aborted', 'AbortError');
+      }
+      const translated = await active.translate(chunk, {
+        signal: controller.signal,
+      });
+      results.push(translated);
+      // Emitted per chunk so the caller can swap paragraphs in as they land, rather than leaving
+      // the reader on an unchanged page for the whole batch.
+      hooks.onChunk?.(index, translated);
+    }
+    return results;
+  } catch (cause) {
+    throw new TranslateError(classify(cause), cause);
+  } finally {
+    clearTimeout(timer);
+    hooks.signal?.removeEventListener('abort', onCallerAbort);
+  }
+}
+
+/** Releases the live session. */
+export function destroyTranslator(): void {
+  session?.destroy();
+  session = null;
+  sessionKey = '';
+}

--- a/apps/personal-website/src/utils/ai/translator.ts
+++ b/apps/personal-website/src/utils/ai/translator.ts
@@ -1,3 +1,4 @@
+import { withProbeTimeout } from './probe';
 import type { AiState } from './types';
 
 /**
@@ -34,7 +35,12 @@ export async function detectTranslatorCapability(
 ): Promise<AiState> {
   if (typeof Translator === 'undefined') return { kind: 'unsupported' };
 
-  const availability = await Translator.availability(pair);
+  // A hung probe is treated as a no. This is the exact call measured hanging in Chromium 150;
+  // see ./probe.
+  const availability = await withProbeTimeout(
+    Translator.availability(pair),
+    'unavailable',
+  );
   switch (availability) {
     case 'unavailable':
       return { kind: 'unavailable' };

--- a/apps/personal-website/src/utils/ai/use-summarizer.ts
+++ b/apps/personal-website/src/utils/ai/use-summarizer.ts
@@ -1,0 +1,82 @@
+import { onUnmounted, readonly, ref } from 'vue';
+
+import {
+  destroySummarizer,
+  detectSummarizerCapability,
+  summarize as summarizeCore,
+  SummarizeError,
+  type SummarizeFailure,
+  type SummarizeOptions,
+} from './summarizer';
+import type { AiState } from './types';
+
+/**
+ * Vue adapter over `summarizer.ts`. Reactivity and cleanup only — everything fragile stays in the
+ * core so a non-Vue consumer could reuse it.
+ *
+ * Note what this deliberately does NOT do: convert a failure into `null`. `useLanguageModel` does
+ * exactly that, and it cost real debugging time — a timeout reached the palette as an empty result
+ * with the reason parked in a separate ref, so the branch that should have said "took too long"
+ * was unreachable and silently said "couldn't answer" instead. Here the reason IS the state the
+ * template renders.
+ */
+export function useSummarizer(options: SummarizeOptions = {}) {
+  const state = ref<AiState>({ kind: 'unsupported' });
+  const summary = ref<string | null>(null);
+  const failure = ref<SummarizeFailure | null>(null);
+  const busy = ref(false);
+  const progress = ref(0);
+
+  async function refresh(): Promise<void> {
+    state.value = await detectSummarizerCapability(options);
+  }
+
+  /**
+   * Summarizes `text`. Resolves either way — the outcome is in `summary`/`failure`, so a caller
+   * wiring this to a click handler never needs its own try/catch to keep the UI honest.
+   */
+  async function run(text: string): Promise<void> {
+    if (busy.value) return;
+    busy.value = true;
+    summary.value = null;
+    failure.value = null;
+    progress.value = 0;
+    try {
+      summary.value = await summarizeCore(text, options, {
+        onProgress: (value) => {
+          progress.value = value;
+          // Surfacing the download as its own state keeps a first run from looking like a hang:
+          // the model is hundreds of megabytes and the wait is otherwise unexplained.
+          if (value < 1) state.value = { kind: 'downloading', progress: value };
+        },
+      });
+      state.value = { kind: 'ready' };
+    } catch (cause) {
+      failure.value = cause instanceof SummarizeError ? cause.reason : 'failed';
+      // Re-read rather than assume: a run can fail because the capability changed underneath
+      // (model evicted, browser updated), not only because this attempt went wrong.
+      await refresh();
+    } finally {
+      busy.value = false;
+    }
+  }
+
+  /** Clears the panel without re-probing — for closing the summary and starting over. */
+  function reset(): void {
+    summary.value = null;
+    failure.value = null;
+  }
+
+  onUnmounted(destroySummarizer);
+
+  return {
+    state: readonly(state),
+    summary: readonly(summary),
+    failure: readonly(failure),
+    busy: readonly(busy),
+    progress: readonly(progress),
+    refresh,
+    run,
+    reset,
+  };
+}

--- a/apps/personal-website/src/utils/article-text.test.ts
+++ b/apps/personal-website/src/utils/article-text.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { isSummarizable, MIN_PROSE_CHARS, toProse } from './article-text';
+
+// The motivating case, verbatim in shape: web-ai.mdx is imports, headings and island tags with
+// almost no prose. Fed raw to the real Summarizer it echoed the source back — imports included —
+// as its "summary".
+const WEB_AI_LIKE = `import { Baseline } from '@components/blog';
+import { CheckGPU } from '@components/blog/demo';
+
+## GPU support check
+
+<Baseline featureId="webgpu" />
+
+<CheckGPU client:load />
+
+## Edge AI on Web Platforms
+
+{/* <WebLLM client:load /> */}
+`;
+
+describe('toProse', () => {
+  it('drops ES imports and exports', () => {
+    expect(toProse(WEB_AI_LIKE)).not.toMatch(/import|@components/);
+  });
+
+  it('drops self-closing island tags but keeps paired-tag text', () => {
+    expect(toProse('<CheckGPU client:load />')).toBe('');
+    expect(toProse('<Note>real prose here</Note>')).toBe('real prose here');
+  });
+
+  it('drops MDX expression comments', () => {
+    expect(toProse('{/* <WebLLM client:load /> */}')).toBe('');
+  });
+
+  it('drops fenced code, which is the most token-expensive and least summarizable part', () => {
+    expect(toProse('before\n```ts\nconst x = 1;\n```\nafter')).toBe(
+      'before\n\nafter',
+    );
+  });
+
+  it('keeps heading and emphasis words while dropping their syntax', () => {
+    expect(toProse('## GPU support check')).toBe('GPU support check');
+    expect(toProse('**bold** and `code`')).toBe('bold and code');
+  });
+
+  it('reduces a markdown link to its text', () => {
+    expect(toProse('see [the spec](https://example.com/spec) for more')).toBe(
+      'see the spec for more',
+    );
+  });
+
+  it('strips a frontmatter fence when the body still carries one', () => {
+    expect(toProse('---\ntitle: X\n---\nActual prose.')).toBe('Actual prose.');
+  });
+
+  it('leaves ordinary prose alone', () => {
+    const prose = 'This is a paragraph.\n\nAnd a second one.';
+    expect(toProse(prose)).toBe(prose);
+  });
+});
+
+describe('isSummarizable', () => {
+  it('rejects a post that is mostly imports and island tags', () => {
+    // Not a threshold quibble: this reduces to a couple of headings, and summarizing it
+    // produced an echo of the source rather than a summary.
+    expect(isSummarizable(WEB_AI_LIKE)).toBe(false);
+  });
+
+  it('accepts a post with a real body of prose', () => {
+    expect(isSummarizable('word '.repeat(MIN_PROSE_CHARS))).toBe(true);
+  });
+
+  it('measures prose, not raw length — a long code dump is still not summarizable', () => {
+    const codeHeavy = '```ts\n' + 'const x = 1;\n'.repeat(200) + '```';
+    expect(codeHeavy.length).toBeGreaterThan(MIN_PROSE_CHARS);
+    expect(isSummarizable(codeHeavy)).toBe(false);
+  });
+});

--- a/apps/personal-website/src/utils/article-text.test.ts
+++ b/apps/personal-website/src/utils/article-text.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { isSummarizable, MIN_PROSE_CHARS, toProse } from './article-text';
+import {
+  isSummarizable,
+  MIN_PROSE_CHARS,
+  toBullets,
+  toProse,
+} from './article-text';
 
 // The motivating case, verbatim in shape: web-ai.mdx is imports, headings and island tags with
 // almost no prose. Fed raw to the real Summarizer it echoed the source back — imports included —
@@ -75,5 +80,41 @@ describe('isSummarizable', () => {
     const codeHeavy = '```ts\n' + 'const x = 1;\n'.repeat(200) + '```';
     expect(codeHeavy.length).toBeGreaterThan(MIN_PROSE_CHARS);
     expect(isSummarizable(codeHeavy)).toBe(false);
+  });
+});
+
+describe('toBullets', () => {
+  // Real Chrome output, verbatim, for the weather-forecast post.
+  const REAL = [
+    '* The left and right positions of the indicator are calculated based on the percentage of temperature values.',
+    '* The formulas are: `left = (tempMin - lowerBound) / (upperBound - lowerBound)`.',
+    '* A **color-mix** function in CSS is used to visualize temperature ranges.',
+  ].join('\n');
+
+  it('splits markdown bullets and drops the punctuation the reader should not see', () => {
+    const bullets = toBullets(REAL);
+    expect(bullets).toHaveLength(3);
+    expect(bullets[0]).toMatch(/^The left and right positions/);
+    expect(bullets.join(' ')).not.toMatch(/[*`]/);
+  });
+
+  it('keeps the words inside code spans and bold, only removing the markers', () => {
+    expect(toBullets('* A **color-mix** function')).toEqual([
+      'A color-mix function',
+    ]);
+    expect(toBullets('* uses `color-mix` in CSS')).toEqual([
+      'uses color-mix in CSS',
+    ]);
+  });
+
+  // A tldr-shaped answer is a paragraph, not a list; it must still render.
+  it('passes a non-list summary through as a single entry', () => {
+    expect(toBullets('A single paragraph summary.')).toEqual([
+      'A single paragraph summary.',
+    ]);
+  });
+
+  it('ignores blank lines', () => {
+    expect(toBullets('* one\n\n* two')).toEqual(['one', 'two']);
   });
 });

--- a/apps/personal-website/src/utils/article-text.ts
+++ b/apps/personal-website/src/utils/article-text.ts
@@ -49,3 +49,30 @@ export const MIN_PROSE_CHARS = 600;
 export function isSummarizable(body: string): boolean {
   return toProse(body).length >= MIN_PROSE_CHARS;
 }
+
+/**
+ * Splits a markdown key-points summary into plain-text bullets.
+ *
+ * The model is asked for markdown and returns `* item` lines with `**bold**` and `` `code` ``
+ * inside. Rendering that string raw shows the punctuation to the reader; rendering it as HTML
+ * would hand an unreviewed generator a path into the page. So the structure is parsed here and
+ * each bullet is interpolated as text — the list is ours, only the words are the model's.
+ *
+ * Anything that is not a bullet list survives as a single entry, so a `tldr`-style paragraph
+ * still renders.
+ */
+export function toBullets(summary: string): string[] {
+  const clean = (line: string) =>
+    line
+      .replace(/^\s*[*-]\s+/, '')
+      .replace(/\*\*([^*]+)\*\*/g, '$1')
+      .replace(/`([^`]*)`/g, '$1')
+      .trim();
+
+  const lines = summary
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const bullets = lines.filter((line) => /^\s*[*-]\s+/.test(line));
+  return (bullets.length ? bullets : lines).map(clean).filter(Boolean);
+}

--- a/apps/personal-website/src/utils/article-text.ts
+++ b/apps/personal-website/src/utils/article-text.ts
@@ -1,0 +1,51 @@
+/**
+ * Reduces an MDX post body to the prose a summarizer should actually see.
+ *
+ * Written after watching the real model echo an article's source back verbatim — imports, JSX
+ * tags and all — as its "summary". The posts here are MDX: they carry `import` statements, Astro
+ * island tags, and expression comments that are not prose in any sense, and a summarizer handed
+ * them will faithfully summarize the markup.
+ *
+ * Deliberately not a markdown parser. This runs in the browser on every post, and the goal is to
+ * drop the constructs that mislead a summarizer, not to render anything.
+ */
+export function toProse(body: string): string {
+  return (
+    body
+      // frontmatter, when the body still carries its fence
+      .replace(/^---\n[\s\S]*?\n---\n/, '')
+      // fenced code: the least summarizable, most token-expensive part of a technical post
+      .replace(/```[\s\S]*?```/g, '')
+      // MDX expression comments, e.g. {/* <WebLLM client:load /> */}
+      .replace(/\{\/\*[\s\S]*?\*\/\}/g, '')
+      // ES imports/exports at the top of an MDX file
+      .replace(/^\s*(?:import|export)\s.*$/gm, '')
+      // JSX/Astro island tags, self-closing or paired. Paired first so the inner text survives:
+      // <Note>real prose</Note> should keep "real prose".
+      .replace(/<([A-Z][\w.]*)\b[^>]*>([\s\S]*?)<\/\1>/g, '$2')
+      .replace(/<[A-Z][\w.]*\b[^>]*\/>/g, '')
+      // inline code ticks and heading/emphasis markers: keep the words, drop the syntax
+      .replace(/`([^`]*)`/g, '$1')
+      .replace(/^#{1,6}\s+/gm, '')
+      .replace(/\*\*([^*]+)\*\*/g, '$1')
+      // markdown links -> their text
+      .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+      .replace(/\n{3,}/g, '\n\n')
+      .trim()
+  );
+}
+
+/**
+ * Below this many characters of prose there is nothing worth summarizing, and asking anyway
+ * produces the echo described above. `web-ai.mdx` is the motivating case: almost entirely headings
+ * and live demo components, so it reduces to a few dozen characters.
+ *
+ * Chosen as roughly a long paragraph — short enough to admit a brief post, long enough that a
+ * summary is a genuine reduction rather than a restatement.
+ */
+export const MIN_PROSE_CHARS = 600;
+
+/** Whether a post has enough prose that summarizing it is meaningful. */
+export function isSummarizable(body: string): boolean {
+  return toProse(body).length >= MIN_PROSE_CHARS;
+}

--- a/apps/personal-website/src/utils/search.test.ts
+++ b/apps/personal-website/src/utils/search.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { scoreMatch, type Searchable, searchRecords } from './search';
+
+const RECORDS: Searchable[] = [
+  {
+    id: 'p/opencgt',
+    kind: 'project',
+    title: 'OpenCGT',
+    keywords: ['nextjs', 'auth0'],
+    href: '/portfolio/opencgt',
+  },
+  {
+    id: 'p/dex',
+    kind: 'project',
+    title: 'Hashgreen DEX',
+    keywords: ['nextjs'],
+    href: '/portfolio/hashgreen-dex',
+  },
+  {
+    id: 's/ts',
+    kind: 'skill',
+    title: 'TypeScript',
+    keywords: [],
+    href: '/#skills',
+  },
+];
+
+describe('scoreMatch', () => {
+  it('ranks a title prefix above a mid-word hit', () => {
+    expect(scoreMatch('Hash', 'Hashgreen DEX', [])).toBeGreaterThan(
+      scoreMatch('green', 'Hashgreen DEX', []),
+    );
+  });
+
+  it('scores keyword hits below title hits', () => {
+    expect(scoreMatch('auth0', 'OpenCGT', ['auth0'])).toBeLessThan(
+      scoreMatch('OpenCGT', 'OpenCGT', ['auth0']),
+    );
+  });
+
+  it('is case-insensitive', () => {
+    expect(scoreMatch('typescript', 'TypeScript', [])).toBeGreaterThan(0);
+  });
+
+  it('returns 0 when nothing matches', () => {
+    expect(scoreMatch('rust', 'OpenCGT', ['auth0'])).toBe(0);
+  });
+});
+
+describe('searchRecords', () => {
+  it('returns only matches, best first', () => {
+    const hits = searchRecords('nextjs', RECORDS);
+    expect(hits.map((h) => h.id)).toEqual(['p/opencgt', 'p/dex']);
+  });
+
+  it('returns everything for an empty query, so the palette opens populated', () => {
+    expect(searchRecords('', RECORDS)).toHaveLength(RECORDS.length);
+  });
+
+  it('is stable for equal scores', () => {
+    const once = searchRecords('nextjs', RECORDS).map((h) => h.id);
+    const twice = searchRecords('nextjs', RECORDS).map((h) => h.id);
+    expect(once).toEqual(twice);
+  });
+});

--- a/apps/personal-website/src/utils/search.ts
+++ b/apps/personal-website/src/utils/search.ts
@@ -1,0 +1,50 @@
+export interface Searchable {
+  id: string;
+  kind: 'experience' | 'project' | 'skill' | 'post';
+  title: string;
+  keywords: string[];
+  href: string;
+}
+
+/**
+ * Scored substring matching, deliberately not a fuzzy-search library. The whole corpus is a few
+ * hundred rows — roughly seven roles, four projects, fifteen skills and a handful of posts — so
+ * a dependency would cost more than it buys, and this stays synchronous and trivially testable.
+ *
+ * Higher is better; 0 means no match.
+ */
+export function scoreMatch(
+  query: string,
+  title: string,
+  keywords: string[],
+): number {
+  const q = query.trim().toLowerCase();
+  if (!q) return 1;
+
+  const t = title.toLowerCase();
+  if (t === q) return 100;
+  if (t.startsWith(q)) return 75;
+  if (t.includes(q)) return 50;
+  if (keywords.some((k) => k.toLowerCase() === q)) return 30;
+  if (keywords.some((k) => k.toLowerCase().includes(q))) return 15;
+  return 0;
+}
+
+/** Matching records, best first. An empty query returns everything so the palette opens populated. */
+export function searchRecords<T extends Searchable>(
+  query: string,
+  records: T[],
+): T[] {
+  return (
+    records
+      .map((record) => ({
+        record,
+        score: scoreMatch(query, record.title, record.keywords),
+      }))
+      .filter(({ score }) => score > 0)
+      // Array.prototype.sort is stable, so equal scores keep their input order rather than
+      // shuffling between renders.
+      .sort((a, b) => b.score - a.score)
+      .map(({ record }) => record)
+  );
+}

--- a/apps/personal-website/tsconfig.json
+++ b/apps/personal-website/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "extends": ["astro/tsconfigs/strict", "../../tsconfig.base.json"],
   "include": [".astro/types.d.ts", "**/*"],
-  "exclude": ["dist"],
+  // vitest.config.ts: this workspace has multiple installed `vite` majors/hash-variants
+  // (astro@7.1.3's vite@8.0.16 vs. astro-compress's astro@6.4.8 pulling in vite@7.3.5, plus
+  // @types/node-peer-hashed variants of vite@8.0.16 itself), so TS can't portably name
+  // getViteConfig's inferred return type (TS2883) — a dependency-graph issue, not an app bug.
+  // Pure build config, not application code; vitest runs it untyped regardless.
+  "exclude": ["dist", "vitest.config.ts"],
   "compilerOptions": {
     "jsx": "react-jsx",
     "jsxImportSource": "react",

--- a/apps/personal-website/vitest.config.ts
+++ b/apps/personal-website/vitest.config.ts
@@ -1,6 +1,11 @@
-import { defineConfig } from 'vitest/config';
+import { getViteConfig } from 'astro/config';
 
-export default defineConfig({
+// getViteConfig (not plain vitest/config's defineConfig) because src/mcp/profile.ts — pulled
+// in transitively by any test that imports src/mcp/handler.ts — has top-level imports of the
+// `astro:content` virtual module and tsconfig path aliases (`@utils/*`, `@types`). Those only
+// resolve through Astro's own Vite config; plain vitest/config has neither, and fails with
+// "Failed to resolve import" before a single test runs.
+export default getViteConfig({
   test: {
     // jsdom rather than node: the on-device AI capability core (src/utils/ai/) caches a
     // failed capability probe in sessionStorage, which node's environment doesn't provide.
@@ -9,8 +14,8 @@ export default defineConfig({
     // Task 8 (2026-07-07 personal-data-library plan) deleted this app's only local test
     // files (mcp/smoke.test.ts, mcp/profile-data.test.ts) — their replacements now live
     // in libs/personal-data, which apps/personal-website consumes rather than defining
-    // this logic itself. Zero local test files is the expected steady state here, not a
-    // regression, so this shouldn't fail the run.
+    // this logic itself. Zero local test files was the steady state here until this
+    // catalog.test.ts, so passWithNoTests still guards a future regression to that state.
     passWithNoTests: true,
   },
 });

--- a/apps/personal-website/vitest.config.ts
+++ b/apps/personal-website/vitest.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/config" />
 import { getViteConfig } from 'astro/config';
 
 // getViteConfig (not plain vitest/config's defineConfig) because src/mcp/profile.ts — pulled

--- a/docs/superpowers/plans/2026-07-28-command-palette.md
+++ b/docs/superpowers/plans/2026-07-28-command-palette.md
@@ -116,6 +116,27 @@ git commit -m "test(mcp): pin the live tool surface before refactoring the catal
 
 ### Task 2: The catalog
 
+> **Corrected 2026-07-28 during execution.** The code below had two defects, both found by the
+> implementer and confirmed by review:
+>
+> 1. It built `params` with classic `zod` (v3) but converted with `zod/v4`'s `toJSONSchema`. Those
+>    schema instances have incompatible internals and the conversion throws
+>    `Cannot read properties of undefined (reading 'def')`. **Build everything from `zod/v4`.** The
+>    MCP SDK's zod-compat layer accepts v4 schemas and validates them fully — verified live by
+>    rejecting bad arguments with real Zod errors.
+> 2. `run: (args: Record<string, never>)` severs the type link between a tool's `params` and its
+>    `run`. Proven: renaming a `params` key without touching `run` compiles with **0 errors**, and
+>    the tool then validates one name while the handler reads another, silently returning
+>    unfiltered results. Use a generic `defineTool` factory that infers the shape per entry.
+>
+> A third gap, harmless here but not later: `toToolDescriptors().execute` calls `run` **without
+> parsing against `params`**. The MCP path is validated by the SDK, but the palette feeds it
+> model-produced arguments — parse before running.
+>
+> Also note: this was the app's first local test importing app code, so `vitest.config.ts` needed
+> switching to `getViteConfig` from `astro/config` before any of it could load. E0's tests only
+> used relative imports, so that path had never been exercised.
+
 **Files:**
 
 - Create: `apps/personal-website/src/mcp/catalog.ts`

--- a/docs/superpowers/plans/2026-07-28-command-palette.md
+++ b/docs/superpowers/plans/2026-07-28-command-palette.md
@@ -1,0 +1,814 @@
+# ⌘K Command Palette (E) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A command palette that is useful to everyone and better with on-device AI — deterministic search always, natural-language querying as an upgrade — while collapsing the duplicated tool catalog behind `rainforest.tools/mcp` into one definition.
+
+**Architecture:** One Zod-first `ProfileTool[]` catalog. Three consumers derive from it: the MCP server (wraps `run` in a content envelope), the palette and WebMCP (JSON Schema via `zod/v4`'s `toJSONSchema`, `execute: run`), and `llms.txt` (name + description). The model only ever _selects_ a tool; the answer strip's sentence comes from `summarise()` over the tool's real result.
+
+**Tech Stack:** TypeScript 6, Vue 3.5, Astro 7, Vitest 4 (jsdom), `zod@3.25.76` (v4 API via the `zod/v4` subpath), `@modelcontextprotocol/sdk`.
+
+**Spec:** [2026-07-28-command-palette-design.md](../specs/2026-07-28-command-palette-design.md)
+
+**Depends on:** E0 (merged, `7a170a7`) — `src/utils/ai/` provides `detectCapability`, `enableModel`, `selectTool`, `acquire`, `registerAgentTools`, `AiCapability.vue`, `useLanguageModel`, and the `ToolDescriptor` type.
+
+---
+
+## Before you start: what is actually live
+
+`src/mcp/profile.ts` serves **production** at `rainforest.tools/mcp`. It registers six tools, every one with the identical handler shape:
+
+```ts
+async (args) => ({
+  content: [{ type: 'text', text: JSON.stringify(await fn(args)) }],
+});
+```
+
+| Tool                   | Params                            |
+| ---------------------- | --------------------------------- |
+| `get_profile_summary`  | `lang`                            |
+| `get_work_experience`  | `technology`, `lang`              |
+| `get_education`        | `lang`                            |
+| `get_projects`         | `technology`, `lang`              |
+| `get_skills`           | `lang`                            |
+| `search_by_technology` | `query` (required string), `lang` |
+
+**A seventh tool exists outside this file.** `handler.ts` composes `registerProfileMcp` with `registerPortfolioMcp` from `@rainforest-dev/personal-portfolio/mcp`, which contributes `get_case_study`. That library is deliberately decoupled (no `astro:content` dependency) and already has its own single-source `PORTFOLIO_MCP_TOOLS`. **Leave it alone.** But pin it in the characterisation test, because a refactor that silently drops it would look fine on the site.
+
+## File Structure
+
+| File                                                            | Responsibility                                                          |
+| --------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `apps/personal-website/src/mcp/catalog.ts`                      | **New.** The single `ProfileTool[]` definition + `toToolDescriptors()`. |
+| `apps/personal-website/src/mcp/catalog.test.ts`                 | **New.** Characterisation + derivation tests.                           |
+| `apps/personal-website/src/mcp/profile.ts`                      | **Modified.** Becomes a thin adapter over the catalog.                  |
+| `apps/personal-website/src/utils/search.ts`                     | **New.** Pure, synchronous scored matcher. No AI import.                |
+| `apps/personal-website/src/utils/search.test.ts`                | **New.**                                                                |
+| `apps/personal-website/src/components/shell/CommandPalette.vue` | **New.** The palette.                                                   |
+| `apps/personal-website/src/layouts/index.astro`                 | **Modified.** Mounts the palette.                                       |
+
+---
+
+### Task 1: Characterisation tests — pin the live MCP surface BEFORE touching it
+
+Nothing in this task changes behaviour. Its whole purpose is to make the next two tasks provably safe.
+
+**Files:**
+
+- Create: `apps/personal-website/src/mcp/catalog.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+```typescript
+import { describe, expect, it } from 'vitest';
+
+import { MCP_TOOLS } from './handler';
+
+/**
+ * Characterisation, not specification: this records what the live server at
+ * rainforest.tools/mcp advertises TODAY, so the catalog refactor in Tasks 2–3 is provably
+ * behaviour-preserving. A remote MCP client breaking is invisible from the site itself, so
+ * "it still looks fine" is not evidence.
+ *
+ * If a change to this list is intended, update it deliberately — do not "fix" it to make a
+ * refactor pass.
+ */
+describe('MCP tool surface (characterisation)', () => {
+  it('advertises exactly these tools', () => {
+    expect(MCP_TOOLS.map((t) => t.name).sort()).toEqual([
+      'get_case_study',
+      'get_education',
+      'get_profile_summary',
+      'get_projects',
+      'get_skills',
+      'get_work_experience',
+      'search_by_technology',
+    ]);
+  });
+
+  it('keeps get_case_study, which comes from the portfolio library, not profile.ts', () => {
+    // The refactor only touches profile.ts. If this disappears, the composition in
+    // handler.ts was broken rather than the catalog.
+    expect(MCP_TOOLS.find((t) => t.name === 'get_case_study')).toBeDefined();
+  });
+
+  it('gives every tool a non-empty description', () => {
+    for (const tool of MCP_TOOLS) {
+      expect(tool.description.length).toBeGreaterThan(0);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run it — it must PASS immediately**
+
+Run: `pnpm nx test personal-website --skip-nx-cache`
+Expected: PASS. This is the one task in the plan whose test passes on first write — it describes existing behaviour. **If it fails, stop and report**: the surface is not what this plan assumed and Task 2 is unsafe.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/personal-website/src/mcp/catalog.test.ts
+git commit -m "test(mcp): pin the live tool surface before refactoring the catalog"
+```
+
+---
+
+### Task 2: The catalog
+
+**Files:**
+
+- Create: `apps/personal-website/src/mcp/catalog.ts`
+
+- [ ] **Step 1: Write the catalog**
+
+```typescript
+import {
+  getEducation,
+  getProfileSummary,
+  getProjects,
+  getSkills,
+  getWorkExperience,
+  searchByTechnology,
+} from '@rainforest-dev/personal-data';
+import type { ToolDescriptor } from '@utils/ai';
+import { tags } from '@utils/constants';
+import type { SkillTag } from '@types';
+import { z } from 'zod';
+// zod@3.25 ships the v4 implementation under this subpath. `z.toJSONSchema` does not exist on
+// the v3 namespace, and this is what lets one Zod definition also feed responseConstraint and
+// WebMCP without adding a dependency.
+import { z as z4 } from 'zod/v4';
+
+const langSchema = z.enum(['en', 'zh']).optional();
+const technologySchema = z
+  .enum(tags.skills as unknown as [SkillTag, ...SkillTag[]])
+  .optional();
+
+/**
+ * One tool, defined once.
+ *
+ * `run` returns plain data — no MCP envelope, no formatting — so every consumer can shape it
+ * for itself. `summarise` is what lets the palette show a sentence without a model writing one:
+ * it composes from `run`'s actual result, so the strip cannot state something untrue.
+ */
+export interface ProfileTool {
+  name: string;
+  description: string;
+  /** Zod raw shape, which is what the MCP SDK's registerTool expects. */
+  params: z.ZodRawShape;
+  run: (args: Record<string, never>) => Promise<unknown>;
+  /** One line for the answer strip, or null when there is nothing worth saying. */
+  summarise: (result: never, args: Record<string, never>) => string | null;
+}
+
+const count = (value: unknown): number =>
+  Array.isArray(value) ? value.length : 0;
+const plural = (n: number, one: string, many: string) =>
+  `${n} ${n === 1 ? one : many}`;
+
+export const PROFILE_TOOLS: ProfileTool[] = [
+  {
+    name: 'get_profile_summary',
+    description: 'Professional profile overview: counts and top technologies',
+    params: { lang: langSchema },
+    run: ({ lang }) => getProfileSummary({ lang }),
+    summarise: (result: { experienceCount: number; projectCount: number }) =>
+      `${plural(result.experienceCount, 'role', 'roles')} and ${plural(result.projectCount, 'project', 'projects')} on record.`,
+  },
+  {
+    name: 'get_work_experience',
+    description: 'Work history, optionally filtered by technology',
+    params: { technology: technologySchema, lang: langSchema },
+    run: ({ technology, lang }) => getWorkExperience({ technology, lang }),
+    summarise: (result: unknown[], { technology }) =>
+      technology
+        ? `${technology} appears in ${plural(count(result), 'role', 'roles')}.`
+        : `${plural(count(result), 'role', 'roles')} on record.`,
+  },
+  {
+    name: 'get_education',
+    description: 'Academic background',
+    params: { lang: langSchema },
+    run: ({ lang }) => getEducation({ lang }),
+    summarise: (result: unknown[]) =>
+      `${plural(count(result), 'qualification', 'qualifications')} on record.`,
+  },
+  {
+    name: 'get_projects',
+    description: 'Portfolio projects, optionally filtered by technology',
+    params: { technology: technologySchema, lang: langSchema },
+    run: ({ technology, lang }) => getProjects({ technology, lang }),
+    summarise: (result: unknown[], { technology }) =>
+      technology
+        ? `${technology} appears in ${plural(count(result), 'project', 'projects')}.`
+        : `${plural(count(result), 'project', 'projects')} on record.`,
+  },
+  {
+    name: 'get_skills',
+    description: 'Technical skills inventory',
+    params: { lang: langSchema },
+    run: ({ lang }) => getSkills({ lang }),
+    summarise: (result: unknown[]) =>
+      `${plural(count(result), 'skill', 'skills')} listed.`,
+  },
+  {
+    name: 'search_by_technology',
+    description:
+      'Substring-match a technology name across all experiences and projects',
+    params: { query: z.string(), lang: langSchema },
+    run: ({ query, lang }) => searchByTechnology(query, { lang }),
+    summarise: (
+      result: { experiences: unknown[]; projects: unknown[] },
+      { query },
+    ) => {
+      const total = count(result.experiences) + count(result.projects);
+      return total === 0
+        ? `No records mention ${query}.`
+        : `${query} appears in ${plural(count(result.experiences), 'role', 'roles')} and ${plural(count(result.projects), 'project', 'projects')}.`;
+    },
+  },
+];
+
+/**
+ * Adapter for the palette and WebMCP: JSON Schema instead of Zod, plain data instead of an
+ * MCP envelope. `inputSchema` is the same shape `selectTool()` passes as `responseConstraint`
+ * and the same shape WebMCP's `registerTool()` expects.
+ */
+export function toToolDescriptors(): ToolDescriptor[] {
+  return PROFILE_TOOLS.map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    inputSchema: z4.toJSONSchema(z4.object(tool.params as never)) as Record<
+      string,
+      unknown
+    >,
+    execute: tool.run as ToolDescriptor['execute'],
+  }));
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `pnpm nx build personal-website --skip-nx-cache`
+Expected: `0 errors`. Always pass `--skip-nx-cache` — a cache hit reports success without re-running, which has already masked a real failure in this project.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/personal-website/src/mcp/catalog.ts
+git commit -m "feat(mcp): single Zod-first tool catalog with palette adapter"
+```
+
+---
+
+### Task 3: `profile.ts` becomes an adapter
+
+The risky task. Task 1's test is the safety net.
+
+**Files:**
+
+- Modify: `apps/personal-website/src/mcp/profile.ts`
+
+- [ ] **Step 1: Replace the six `server.registerTool` calls with one loop**
+
+Delete the six individual registrations and the now-unused `profileSummaryTool`/`workExperienceTool`/`educationTool`/`projectsTool`/`skillsTool`/`searchTool` consts, and derive `PROFILE_MCP_TOOLS` from the catalog:
+
+```typescript
+import { PROFILE_TOOLS } from './catalog';
+
+// Derived, not repeated. This list previously duplicated every name and description by hand
+// alongside the registrations below; llms.txt.ts reads it via handler.ts's composed MCP_TOOLS.
+export const PROFILE_MCP_TOOLS = PROFILE_TOOLS.map(({ name, description }) => ({
+  name,
+  description,
+})) as ReadonlyArray<{ name: string; description: string }>;
+```
+
+and inside `registerProfileMcp`, replace the six blocks with:
+
+```typescript
+for (const tool of PROFILE_TOOLS) {
+  server.registerTool(
+    tool.name,
+    { description: tool.description, inputSchema: tool.params },
+    // The envelope is the MCP surface's concern, not the catalog's — `run` returns plain data.
+    async (args) => ({
+      content: [
+        { type: 'text', text: JSON.stringify(await tool.run(args as never)) },
+      ],
+    }),
+  );
+}
+```
+
+Leave the resource registrations (`profile://experience/{+id}` etc.) exactly as they are — this task is tools only.
+
+- [ ] **Step 2: Run the characterisation test — it must STILL pass**
+
+Run: `pnpm nx test personal-website --skip-nx-cache`
+Expected: PASS, including Task 1's three tests unchanged. **If the tool-surface test fails, the refactor changed the public surface — revert rather than editing the test.**
+
+- [ ] **Step 3: Verify the endpoint still answers**
+
+```bash
+pnpm nx dev personal-website
+```
+
+Then in another shell:
+
+```bash
+curl -s -X POST http://localhost:4321/mcp -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | head -c 600
+```
+
+Expected: a JSON-RPC result listing all seven tools, `get_case_study` among them. Stop the dev server afterwards.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/personal-website/src/mcp/profile.ts
+git commit -m "refactor(mcp): register tools from the shared catalog"
+```
+
+---
+
+### Task 4: Deterministic search
+
+**Files:**
+
+- Create: `apps/personal-website/src/utils/search.ts`
+- Create: `apps/personal-website/src/utils/search.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+import { describe, expect, it } from 'vitest';
+
+import { scoreMatch, type Searchable } from './search';
+import { searchRecords } from './search';
+
+const RECORDS: Searchable[] = [
+  {
+    id: 'p/opencgt',
+    kind: 'project',
+    title: 'OpenCGT',
+    keywords: ['nextjs', 'auth0'],
+    href: '/portfolio/opencgt',
+  },
+  {
+    id: 'p/dex',
+    kind: 'project',
+    title: 'Hashgreen DEX',
+    keywords: ['nextjs'],
+    href: '/portfolio/hashgreen-dex',
+  },
+  {
+    id: 's/ts',
+    kind: 'skill',
+    title: 'TypeScript',
+    keywords: [],
+    href: '/#skills',
+  },
+];
+
+describe('scoreMatch', () => {
+  it('ranks a title prefix above a mid-word hit', () => {
+    expect(scoreMatch('Hash', 'Hashgreen DEX', [])).toBeGreaterThan(
+      scoreMatch('green', 'Hashgreen DEX', []),
+    );
+  });
+
+  it('scores keyword hits below title hits', () => {
+    expect(scoreMatch('auth0', 'OpenCGT', ['auth0'])).toBeLessThan(
+      scoreMatch('OpenCGT', 'OpenCGT', ['auth0']),
+    );
+  });
+
+  it('is case-insensitive', () => {
+    expect(scoreMatch('typescript', 'TypeScript', [])).toBeGreaterThan(0);
+  });
+
+  it('returns 0 when nothing matches', () => {
+    expect(scoreMatch('rust', 'OpenCGT', ['auth0'])).toBe(0);
+  });
+});
+
+describe('searchRecords', () => {
+  it('returns only matches, best first', () => {
+    const hits = searchRecords('nextjs', RECORDS);
+    expect(hits.map((h) => h.id)).toEqual(['p/opencgt', 'p/dex']);
+  });
+
+  it('returns everything for an empty query, so the palette opens populated', () => {
+    expect(searchRecords('', RECORDS)).toHaveLength(RECORDS.length);
+  });
+
+  it('is stable for equal scores', () => {
+    const once = searchRecords('nextjs', RECORDS).map((h) => h.id);
+    const twice = searchRecords('nextjs', RECORDS).map((h) => h.id);
+    expect(once).toEqual(twice);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm nx test personal-website --skip-nx-cache`
+Expected: FAIL — cannot resolve `./search`.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+export interface Searchable {
+  id: string;
+  kind: 'experience' | 'project' | 'skill' | 'post';
+  title: string;
+  keywords: string[];
+  href: string;
+}
+
+/**
+ * Scored substring matching, deliberately not a fuzzy-search library. The whole corpus is a few
+ * hundred rows — roughly seven roles, four projects, fifteen skills and a handful of posts — so
+ * a dependency would cost more than it buys, and this stays synchronous and trivially testable.
+ *
+ * Higher is better; 0 means no match.
+ */
+export function scoreMatch(
+  query: string,
+  title: string,
+  keywords: string[],
+): number {
+  const q = query.trim().toLowerCase();
+  if (!q) return 1;
+
+  const t = title.toLowerCase();
+  if (t === q) return 100;
+  if (t.startsWith(q)) return 75;
+  if (t.includes(q)) return 50;
+  if (keywords.some((k) => k.toLowerCase() === q)) return 30;
+  if (keywords.some((k) => k.toLowerCase().includes(q))) return 15;
+  return 0;
+}
+
+/** Matching records, best first. An empty query returns everything so the palette opens populated. */
+export function searchRecords<T extends Searchable>(
+  query: string,
+  records: T[],
+): T[] {
+  return (
+    records
+      .map((record) => ({
+        record,
+        score: scoreMatch(query, record.title, record.keywords),
+      }))
+      .filter(({ score }) => score > 0)
+      // Array.prototype.sort is stable, so equal scores keep their input order rather than
+      // shuffling between renders.
+      .sort((a, b) => b.score - a.score)
+      .map(({ record }) => record)
+  );
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm nx test personal-website --skip-nx-cache`
+Expected: PASS.
+
+- [ ] **Step 5: Lint, format, commit**
+
+```bash
+pnpm nx lint personal-website --fix
+pnpm prettier --write apps/personal-website/src/utils/search.ts apps/personal-website/src/utils/search.test.ts
+git add apps/personal-website/src/utils/search.ts apps/personal-website/src/utils/search.test.ts
+git commit -m "feat(search): scored matcher for the command palette"
+```
+
+Formatting is now a CI gate (`format:check`), and lint does not catch it — `eslint-config-prettier` disables the stylistic rules. Run Prettier on every file you touch, in every task from here on.
+
+---
+
+### Task 5: The palette, search only
+
+No AI yet. Prove the palette works for everyone before layering anything on it.
+
+**Files:**
+
+- Create: `apps/personal-website/src/components/shell/CommandPalette.vue`
+
+- [ ] **Step 1: Write the component**
+
+```vue
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from 'vue';
+
+import { searchRecords, type Searchable } from '@utils/search';
+
+const props = defineProps<{ records: Searchable[] }>();
+
+const open = ref(false);
+const query = ref('');
+const selected = ref(0);
+
+const results = computed(() => searchRecords(query.value, props.records));
+
+/**
+ * Rows, not modes. Row 0 will become an "Ask" row once AI is wired in Task 6; keeping the
+ * activation rule as "activate the selected row" means Enter never changes meaning — only the
+ * contents of the list do.
+ */
+const rows = computed(() => results.value);
+
+function onKeydown(event: KeyboardEvent) {
+  if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+    event.preventDefault();
+    open.value = !open.value;
+    return;
+  }
+  if (!open.value) return;
+
+  if (event.key === 'Escape') {
+    open.value = false;
+  } else if (event.key === 'ArrowDown') {
+    event.preventDefault();
+    selected.value = Math.min(selected.value + 1, rows.value.length - 1);
+  } else if (event.key === 'ArrowUp') {
+    event.preventDefault();
+    selected.value = Math.max(selected.value - 1, 0);
+  } else if (event.key === 'Enter') {
+    event.preventDefault();
+    activate(selected.value);
+  }
+}
+
+function activate(index: number) {
+  const row = rows.value[index];
+  if (row) window.location.href = row.href;
+}
+
+onMounted(() => window.addEventListener('keydown', onKeydown));
+onUnmounted(() => window.removeEventListener('keydown', onKeydown));
+</script>
+
+<template>
+  <div
+    v-if="open"
+    class="fixed inset-0 z-50 flex items-start justify-center bg-black/40 pt-24"
+  >
+    <div
+      class="bg-card w-full max-w-xl rounded-lg border shadow-lg"
+      role="dialog"
+      aria-modal="true"
+    >
+      <input
+        v-model="query"
+        class="w-full border-b bg-transparent px-4 py-3 outline-none"
+        placeholder="Search experience, projects, skills…"
+        aria-label="Search"
+        autofocus
+        @input="selected = 0"
+      />
+      <ul class="max-h-80 overflow-y-auto py-1" role="listbox">
+        <li
+          v-for="(row, index) in rows"
+          :key="row.id"
+          :aria-selected="index === selected"
+          role="option"
+          class="cursor-pointer px-4 py-2"
+          :class="index === selected ? 'bg-muted' : ''"
+          @click="activate(index)"
+          @mouseenter="selected = index"
+        >
+          <span class="text-muted-foreground mr-2 text-xs uppercase">{{
+            row.kind
+          }}</span>
+          {{ row.title }}
+        </li>
+        <li v-if="rows.length === 0" class="text-muted-foreground px-4 py-2">
+          No matches
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `pnpm nx build personal-website --skip-nx-cache`
+Expected: `0 errors`.
+
+- [ ] **Step 3: Format and commit**
+
+```bash
+pnpm prettier --write apps/personal-website/src/components/shell/CommandPalette.vue
+git add apps/personal-website/src/components/shell/CommandPalette.vue
+git commit -m "feat(palette): ⌘K search over profile records"
+```
+
+---
+
+### Task 6: Mount it, and verify in a real browser
+
+**Files:**
+
+- Modify: `apps/personal-website/src/layouts/index.astro`
+
+- [ ] **Step 1: Build the record list and mount**
+
+In the layout's frontmatter, assemble `Searchable[]` from `getWorkExperience`, `getProjects`, `getSkills` and the blog collection for the current locale, then render:
+
+```astro
+<CommandPalette client:idle records={records} />
+```
+
+`client:idle` rather than `client:load`: the palette is keyboard-triggered, so it does not need to hydrate before the page is interactive.
+
+- [ ] **Step 2: Verify in the browser — not just the build**
+
+```bash
+pnpm nx dev personal-website
+```
+
+Check all of these by hand:
+
+- `⌘K` opens; `Escape` closes
+- Typing filters; `↑↓` moves the highlight; `↵` navigates to the highlighted record
+- The page has no console errors
+- It works on `/zh` as well as `/`
+
+- [ ] **Step 3: Format and commit**
+
+```bash
+pnpm prettier --write apps/personal-website/src/layouts/index.astro
+git add apps/personal-website/src/layouts/index.astro
+git commit -m "feat(palette): mount ⌘K in the site layout"
+```
+
+---
+
+### Task 7: The AI upgrade
+
+Only now does the model appear. Everything above must already work without it.
+
+**Files:**
+
+- Modify: `apps/personal-website/src/components/shell/CommandPalette.vue`
+
+- [ ] **Step 1: Add the ask row and the answer strip**
+
+Add to the script block:
+
+```typescript
+import { useLanguageModel } from '@utils/ai';
+import { PROFILE_TOOLS, toToolDescriptors } from '@mcp/catalog';
+
+const props = defineProps<{ records: Searchable[]; lang: 'en' | 'zh' }>();
+
+const { state, enable, selectTool } = useLanguageModel();
+const answer = ref<string | null>(null);
+const asking = ref(false);
+
+// No answer strip in zh: E0 pins model output to English because non-English replies are
+// unreliable, and English prose above Chinese records reads as a bug rather than a decision.
+const canAsk = computed(
+  () => props.lang === 'en' && state.value.kind === 'ready',
+);
+
+/** Row 0 is the ask row when asking is possible; otherwise the list is results alone. */
+const rows = computed(() =>
+  canAsk.value && query.value.trim()
+    ? [
+        {
+          id: '__ask__',
+          kind: 'ask' as const,
+          title: `Ask: "${query.value}"`,
+          keywords: [],
+          href: '',
+        },
+        ...results.value,
+      ]
+    : results.value,
+);
+
+const SELECTION_SCHEMA = {
+  type: 'object',
+  required: ['tool'],
+  additionalProperties: false,
+  properties: {
+    tool: { type: 'string', enum: PROFILE_TOOLS.map((t) => t.name) },
+    technology: { type: 'string' },
+    query: { type: 'string' },
+  },
+};
+
+async function ask() {
+  asking.value = true;
+  answer.value = null;
+  try {
+    const choice = await selectTool<{
+      tool: string;
+      technology?: string;
+      query?: string;
+    }>(query.value, SELECTION_SCHEMA);
+    if (!choice) return; // selectTool already degraded state; the list still works
+    const tool = PROFILE_TOOLS.find((t) => t.name === choice.tool);
+    if (!tool) return;
+    const args = {
+      technology: choice.technology,
+      query: choice.query,
+      lang: props.lang,
+    };
+    const result = await tool.run(args as never);
+    // The sentence comes from the real result, never from the model.
+    answer.value = tool.summarise(result as never, args as never);
+  } finally {
+    asking.value = false;
+  }
+}
+```
+
+and change `activate` so the ask row asks:
+
+```typescript
+function activate(index: number) {
+  const row = rows.value[index];
+  if (!row) return;
+  if (row.id === '__ask__') void ask();
+  else window.location.href = row.href;
+}
+```
+
+In the template, render the strip above the list when `answer` is set, and an enable button when `state.kind === 'downloadable'` — a real click, which is what the gesture requirement needs.
+
+**Never use `v-html` for `answer`.** It is derived from your own data today, but the rule is that model-adjacent output is rendered as text.
+
+- [ ] **Step 2: Verify in the browser**
+
+Run `pnpm nx dev personal-website`, then check:
+
+- With no model: typing still filters, `↵` opens the top result, no ask row appears
+- On `/zh`: no ask row even when the model is ready
+- With the model enabled: `↵` on a fresh query fills the strip; the records below it match the claim
+
+- [ ] **Step 3: Full gates, format, commit**
+
+```bash
+pnpm nx test personal-website --skip-nx-cache
+pnpm nx build personal-website --skip-nx-cache
+pnpm nx lint personal-website
+pnpm format:check
+pnpm prettier --write apps/personal-website/src/components/shell/CommandPalette.vue
+git add apps/personal-website/src/components/shell/CommandPalette.vue
+git commit -m "feat(palette): on-device AI selects a tool; the strip is templated"
+```
+
+---
+
+### Task 8: Register the catalog with WebMCP
+
+One line, and it completes "one catalog, three surfaces".
+
+**Files:**
+
+- Modify: `apps/personal-website/src/components/shell/CommandPalette.vue`
+
+- [ ] **Step 1: Register on mount, dispose on unmount**
+
+```typescript
+import { registerAgentTools } from '@utils/ai';
+
+// No-ops in every shipping browser today — document.modelContext exists in none of them
+// (verified 2026-07-28: Chrome 150, Edge 150, Chromium 148). Wired now because the descriptors
+// already exist and the dispose handle makes it leak-free.
+const registration = registerAgentTools(toToolDescriptors());
+onUnmounted(registration.dispose);
+```
+
+- [ ] **Step 2: Verify nothing regressed**
+
+Run: `pnpm nx test personal-website --skip-nx-cache` and `pnpm nx build personal-website --skip-nx-cache`
+Expected: all pass. In the browser, confirm the palette still opens — a mistake here would throw on mount.
+
+- [ ] **Step 3: Format and commit**
+
+```bash
+pnpm prettier --write apps/personal-website/src/components/shell/CommandPalette.vue
+git add apps/personal-website/src/components/shell/CommandPalette.vue
+git commit -m "feat(palette): expose the tool catalog to agents via WebMCP"
+```
+
+---
+
+## Definition of done
+
+- Task 1's characterisation test still passes **unmodified** — the refactor preserved the live MCP surface, including `get_case_study` from the portfolio library.
+- `pnpm nx test`, `nx build`, `nx lint` and `pnpm format:check` all clean.
+- ⌘K works with no model at all, in both locales.
+- With the model enabled in `en`, `↵` on a query fills the strip from real records.
+- No `v-html` anywhere near model-adjacent output.
+
+## Next
+
+**D** — the blog demos and the recorded fallback, which can only be captured once this works.

--- a/docs/superpowers/plans/2026-07-28-personal-data-browser-safe.md
+++ b/docs/superpowers/plans/2026-07-28-personal-data-browser-safe.md
@@ -1,0 +1,140 @@
+# Make `personal-data` Browser-Safe — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Let `@rainforest-dev/personal-data` run in a browser, by parsing frontmatter at build time instead of at runtime.
+
+**Why now:** The ⌘K palette (E) executes catalog tools client-side. Every tool goes through `loader.ts`, which calls `gray-matter` at runtime — and `gray-matter` requires Node's `Buffer`. Result: **every ask throws `ReferenceError: Buffer is not defined` in every browser.** The palette degrades cleanly (its `try/catch` keeps search working) but the AI path can never return an answer.
+
+**Second problem, same root cause:** `import.meta.glob(..., { query: '?raw' })` inlines raw **markdown** into the bundle, and the browser then needs a YAML parser to read it. The palette chunk is currently **364 KB** — larger than the Vue runtime. `libs/personal-data/vite.config.ts` already warns that the `index` entry "inline[s] the entire content dataset"; this is that warning coming true.
+
+Parsing at build time fixes both: no `Buffer`, no YAML parser shipped, and JSON instead of markdown in the bundle.
+
+---
+
+## Approach
+
+Replace the runtime `matter(raw)` call with a **Vite-time transform**, so `import.meta.glob` yields already-parsed `{ data, content }` objects.
+
+Chosen over a codegen step that writes a generated file: `personal-data` is already Vite-built and `import.meta.glob` is already a Vite construct, so a transform adds no new coupling — whereas a generated artifact can go stale in dev between editing a markdown file and rebuilding. Vitest and Astro dev both run through Vite, so a transform stays correct in every context.
+
+`gray-matter` moves from a runtime dependency to a **build-time only** one. It still does the parsing; it just does it once, during the build, in Node — where `Buffer` exists.
+
+**If the transform approach turns out not to work** — e.g. `import.meta.glob`'s eager output can't be reshaped from a plugin in this Vite version — **stop and report BLOCKED** rather than forcing it. The fallback is a codegen step, and that is a different plan.
+
+---
+
+## Task 1: Pin current behaviour
+
+Nothing changes yet. `loader.ts` is consumed by the MCP server, `llms.txt`, Astro SSR and now the palette; a parsing change that alters output would break all four silently.
+
+**Files:** modify `libs/personal-data/src/loader.test.ts`
+
+- [ ] **Step 1: Add characterisation tests**
+
+Assert the _exact_ parsed shape for one entry of each collection kind — a markdown one with array frontmatter (`experiences/en/7.md` has `technologies` as an array and `startAt` as a date-like string) and the JSON collection (`organizations`). Assert `id`, every `data` field, and that `body` is the markdown **after** the frontmatter fence, with no leading blank line.
+
+Include one entry whose frontmatter contains a **quoted date string** (`startAt: '2025-05'`) and assert it survives as whatever type it is today — do not "improve" it. A transform that silently starts producing `Date` objects where strings were expected would break `z.coerce.date()` consumers in a way tests must catch.
+
+- [ ] **Step 2: Run — must PASS immediately**
+
+`pnpm nx test personal-data --skip-nx-cache`
+
+This describes existing behaviour, so it passes on first write. **If it fails, stop and report** — the current shape isn't what this plan assumes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add libs/personal-data/src/loader.test.ts
+git commit -m "test(personal-data): pin parsed entry shapes before moving parsing to build time"
+```
+
+---
+
+## Task 2: The build-time transform
+
+**Files:** modify `libs/personal-data/vite.config.ts`, `libs/personal-data/src/loader.ts`
+
+- [ ] **Step 1: Add the transform plugin**
+
+In `vite.config.ts`, add a plugin that handles `.md` files imported with a dedicated query (e.g. `?frontmatter`), parsing with `gray-matter` at transform time and emitting a module whose default export is `{ data, content }`.
+
+Comment it with _why_: parsing must happen in Node at build time because `gray-matter` needs `Buffer`, which browsers lack — and because shipping parsed JSON is smaller than shipping markdown plus a parser.
+
+- [ ] **Step 2: Point the loader at it**
+
+Change the markdown globs in `loader.ts` from `query: '?raw', import: 'default'` to the new query, and delete the runtime `matter()` call and its import. The JSON collection (`organizations`) is unaffected — it never used `gray-matter`.
+
+- [ ] **Step 3: Move `gray-matter` to devDependencies**
+
+In `libs/personal-data/package.json`. It is now build-time only. Run `pnpm install`.
+
+- [ ] **Step 4: Verify**
+
+```bash
+pnpm nx test personal-data --skip-nx-cache
+pnpm nx build personal-data --skip-nx-cache
+```
+
+Task 1's characterisation tests must **still pass unmodified**. If any fails, the transform changed the parsed shape — fix the transform, do not edit the test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libs/personal-data
+git commit -m "perf(personal-data): parse frontmatter at build time so the loader runs in a browser"
+```
+
+---
+
+## Task 3: Prove it in a browser, and measure
+
+**Files:** none — this is verification.
+
+- [ ] **Step 1: Confirm the `Buffer` error is gone**
+
+```bash
+pnpm nx build personal-website --skip-nx-cache
+pnpm nx dev personal-website
+```
+
+In the browser, open ⌘K and trigger an ask with the model enabled — or, if you'd rather not pull a multi-hundred-megabyte model, stub `LanguageModel.create` so `selectTool` returns a valid `{ tool: 'get_skills' }` and confirm the answer strip fills with a real sentence.
+
+**Report exactly what you did and what you saw.** "Should work now" is not a result.
+
+- [ ] **Step 2: Measure the bundle**
+
+Before and after, record the size of the palette chunk:
+
+```bash
+ls -S apps/personal-website/dist/client/_astro/*.js | head -3 | xargs -I{} sh -c 'echo "$(du -h {} | cut -f1)  $(basename {})"'
+```
+
+It was **364 KB** for `CommandPalette.*.js`. Report the new figure. If it did not shrink, say so — the whole dataset may still be inlined for a different reason, and that is worth knowing rather than assuming.
+
+- [ ] **Step 3: Full gates across the workspace**
+
+Both the MCP path and the site consume this library, so check widely:
+
+```bash
+pnpm nx run-many -t test --all
+pnpm nx run-many -t build --all
+pnpm nx lint personal-website
+pnpm format:check
+```
+
+Also re-verify the live MCP endpoint still returns all seven tools with correct payloads, since `loader.ts` is what feeds them:
+
+```bash
+curl -s -X POST http://localhost:4321/mcp -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_skills","arguments":{}}}' | head -c 400
+```
+
+- [ ] **Step 4: Commit any fixes, then report**
+
+## Definition of done
+
+- Task 1's characterisation tests pass unmodified.
+- An ask in a real browser fills the answer strip with a sentence built from real records.
+- The palette chunk is measurably smaller, with the figure reported.
+- Every project's tests and builds pass; the MCP endpoint still serves all seven tools.
+- `gray-matter` is a devDependency.

--- a/docs/superpowers/specs/2026-07-28-command-palette-design.md
+++ b/docs/superpowers/specs/2026-07-28-command-palette-design.md
@@ -1,0 +1,136 @@
+# ⌘K Command Palette (E) — Design Spec
+
+- **Date:** 2026-07-28
+- **Branch:** `claude/command-palette`, stacked on `claude/ai-capability-primitive` (E0, PR #257)
+- **Status:** Design approved in brainstorming; pending written-spec review → implementation plan.
+- **Chain:** step **E** of [2026-07-27-browser-ai-chain-design.md](./2026-07-27-browser-ai-chain-design.md). A is merged (#255); E0 is PR #257.
+
+## 1. Goal
+
+A command palette on rainforest.tools that is **useful to everyone and better with on-device AI**.
+Deterministic search always works; the Prompt API is an upgrade that adds natural-language
+querying, never a prerequisite.
+
+It is also the first real consumer of E0, and the place where the tool catalog behind
+`rainforest.tools/mcp` stops being duplicated.
+
+### Decisions locked in brainstorming
+
+1. **Answer strip above the results.** A short answer sits above the actual records it came from,
+   so a claim and its evidence are visible together.
+2. **One Zod-first catalog, two adapters.** `zod@3.25.76` ships the v4 implementation under the
+   `zod/v4` subpath, and `z.toJSONSchema()` works there — verified — so Zod → JSON Schema needs no
+   new dependency. The reverse direction would need a library and is lossy.
+3. **No answer strip in `zh`.** E0 pins output to English because non-English replies are
+   unreliable on current on-device models. Rather than show English prose above Chinese records,
+   `zh` gets search only.
+4. **`↵` activates the selected row.** Typing never triggers inference.
+5. **The strip is templated from real results.** The model selects a tool; it does not write prose.
+
+## 2. Behaviour
+
+`⌘K` / `Ctrl+K` opens from anywhere. Typing runs deterministic search over
+`@rainforest-dev/personal-data` — experiences, projects, skills, blog posts. That path never
+touches the model.
+
+The row list differs by capability; **the keyboard rule does not**. `↑↓` moves, `↵` activates.
+
+| Condition                             | Row 0             | Remaining rows |
+| ------------------------------------- | ----------------- | -------------- |
+| AI ready, locale `en`                 | `Ask: "<query>"`  | search results |
+| AI absent / unavailable / locale `zh` | top search result | search results |
+
+So `↵` on a fresh query asks when asking is possible and opens the top hit when it is not, without
+`↵` ever meaning two things in the same list. This is the reason to model it as _rows_ rather than
+as modal Enter behaviour: one rule, different rows.
+
+Activating the ask row runs **one** `selectTool()` call, executes the chosen tool locally against
+bundled data, and renders the strip. Nothing is streamed and no second call is made.
+
+**Enabling the model.** The download must start from a real user gesture or the platform throws
+`NotAllowedError`. The enable control therefore lives in `AiCapability`'s `downloadable` slot as a
+button — it cannot be triggered by opening the palette or by typing.
+
+## 3. The catalog
+
+The substantive part. Today `src/mcp/profile.ts` registers each tool inline with Zod params and an
+MCP content envelope, and `PROFILE_MCP_TOOLS` separately repeats every name and description for
+`llms.txt`. The palette would be a third copy.
+
+New `src/mcp/catalog.ts`, one definition per tool:
+
+```ts
+export interface ProfileTool<
+  TArgs = Record<string, unknown>,
+  TResult = unknown,
+> {
+  name: string;
+  description: string;
+  /** Zod raw shape — what the MCP SDK's registerTool expects. */
+  params: ZodRawShape;
+  /** Plain data. No MCP envelope, no formatting. */
+  run: (args: TArgs) => Promise<TResult>;
+  /**
+   * One line for the answer strip, composed from `run`'s actual result.
+   * Returns null when there is nothing worth saying. No model involved.
+   */
+  summarise: (result: TResult, args: TArgs) => string | null;
+}
+```
+
+Three surfaces derive from it, none hand-maintained:
+
+| Consumer                         | Derivation                                                                                                                               |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `registerProfileMcp(server)`     | wraps `run()` in `{ content: [{ type: 'text', text: JSON.stringify(...) }] }`                                                            |
+| `toToolDescriptors()`            | `inputSchema` via `z.toJSONSchema(z.object(params))` from `zod/v4`; `execute: run`. Feeds both `selectTool()` and `registerAgentTools()` |
+| `PROFILE_MCP_TOOLS` (`llms.txt`) | name + description, derived rather than repeated                                                                                         |
+
+`summarise` is E's addition and the reason the strip can be truthful. It lives **with** the tool,
+so a new tool cannot ship without deciding how it reads.
+
+## 4. The answer strip
+
+The model's only job is choosing a tool and its arguments, under `responseConstraint`. The
+sentence comes from `summarise(result, args)` — composed from records that exist.
+
+This makes a wrong answer structurally impossible in a way review cannot guarantee: there is no
+generated text about the author's career anywhere on the page. It also keeps the interaction to
+one call, which is the only pattern the on-device model handles reliably.
+
+If `summarise` returns `null`, the strip is omitted and results render alone.
+
+## 5. Search
+
+Hand-rolled matcher in `src/utils/search.ts`. No fuzzy-search dependency: the entire corpus is
+roughly seven experiences, four projects, fifteen skills and a handful of posts — small enough
+that a scored substring/prefix match over a few hundred rows is both sufficient and instant.
+
+Search is pure, synchronous and independently testable, with no dependency on `src/utils/ai/`.
+
+## 6. Files
+
+- **New:** `src/mcp/catalog.ts`, `src/utils/search.ts`, `src/components/shell/CommandPalette.vue`
+- **Modified:** `src/mcp/profile.ts` (becomes a thin adapter), `src/pages/llms.txt.ts` and
+  `llms-full.txt.ts` (derive the tool list), the site layout (mount the palette)
+
+## 7. Risk: this refactors live, shipped code
+
+`src/mcp/profile.ts` currently serves `rainforest.tools/mcp` in production. Extracting the catalog
+must preserve tool names, descriptions, argument shapes and output payloads exactly, or remote MCP
+clients break **silently** — nothing on the site would look wrong.
+
+**Mitigation, and it is a hard requirement of the plan:** write characterisation tests that pin the
+current MCP tool list and each tool's output shape _before_ touching `profile.ts`, so the refactor
+is provably behaviour-preserving rather than merely believed to be.
+
+## 8. Out of scope
+
+- Generated prose, streaming, multi-step or retry logic — excluded by E0's measured limits.
+- A `zh` answer strip. Revisit only if on-device Chinese output becomes reliable.
+- Server-model fallback.
+- Search ranking sophistication beyond scored matching; the corpus does not justify it.
+
+## 9. Next step
+
+Implementation plan for E, beginning with the characterisation tests from §7.

--- a/libs/personal-data/package.json
+++ b/libs/personal-data/package.json
@@ -29,11 +29,11 @@
   },
   "dependencies": {
     "fast-glob": "^3.3.3",
-    "gray-matter": "^4.0.3",
     "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/node": "catalog:",
+    "gray-matter": "^4.0.3",
     "vite-plugin-dts": "^4.5.4"
   }
 }

--- a/libs/personal-data/src/loader.test.ts
+++ b/libs/personal-data/src/loader.test.ts
@@ -33,6 +33,72 @@ describe('loader', () => {
     expect(missing).toBeUndefined();
   });
 
+  // Characterisation tests: pin the exact shape `getEntry`/`getCollection` produce TODAY,
+  // before frontmatter parsing moves from runtime (gray-matter in loader.ts) to build time (a
+  // Vite transform). They must keep passing, unmodified, after that move — if one breaks, the
+  // transform changed the parsed shape and the transform is what's wrong, not the test.
+  describe('characterisation: parsed entry shapes', () => {
+    it('parses a markdown entry with array frontmatter to the exact current shape (experiences/en/7.md)', async () => {
+      const entry = await getEntry('experiences', 'en/7');
+      expect(entry).toBeDefined();
+      expect(entry?.id).toBe('en/7');
+      expect(entry?.data).toEqual({
+        type: 'job',
+        employment: 'full-time',
+        language: 'en',
+        organization: 'en/angible',
+        position: 'Senior Frontend Engineer',
+        // Pinned as-is: experienceSchema's `startAt` is `z.coerce.date()`, so the quoted YAML
+        // string '2025-05' is already a `Date` by the time it reaches `entry.data` today. Do
+        // not "improve" this to a string — a build-time transform that starts handing zod a
+        // native Date instead of a string would coerce identically here, but a consumer
+        // relying on z.coerce.date() elsewhere could silently start seeing different results
+        // if the transform's serialization step (e.g. JSON.stringify) mangles a Date.
+        startAt: new Date('2025-05'),
+        technologies: [
+          'nextjs',
+          'typescript',
+          'auth0',
+          'nx',
+          'playwright',
+          'fastapi',
+          'docker',
+          'terraform',
+        ],
+        projects: [],
+      });
+      expect(entry?.data.startAt).toBeInstanceOf(Date);
+      expect(entry?.data.endAt).toBeUndefined();
+      // Body is the markdown after the frontmatter fence, with no leading/trailing blank line
+      // (matter()'s `content` starts with a leading "\n" right after the closing `---`; the
+      // loader trims it) but internal line breaks within the paragraph are preserved as-is.
+      expect(entry?.body).toBe(
+        'Lead frontend development across two retail product lines in an edge-AI monorepo. Migrated\n' +
+          'end-to-end authentication to a managed identity provider, retiring a large in-house auth layer, and\n' +
+          'delivered the role-based permission matrix that governs access across the dashboard. Established the\n' +
+          "project's end-to-end test foundation from scratch and moved its container delivery pipeline onto\n" +
+          'managed Kubernetes.',
+      );
+      expect(entry?.body.startsWith('\n')).toBe(false);
+      expect(entry?.body.endsWith('\n')).toBe(false);
+    });
+
+    it('parses a JSON-collection entry to the exact current shape (organizations/en/codegreen.json)', async () => {
+      // organizations never went through gray-matter (JSON_COLLECTIONS branch in parseEntry) —
+      // pinned here too so the same test file covers both parse strategies loader.ts branches
+      // on, and a transform that only touches the markdown path can't silently regress this one.
+      const entry = await getEntry('organizations', 'en/codegreen');
+      expect(entry).toBeDefined();
+      expect(entry?.id).toBe('en/codegreen');
+      expect(entry?.data).toEqual({
+        name: 'CodeGreen',
+        language: 'en',
+        link: 'https://www.codegreen.org',
+      });
+      expect(entry?.body).toBe('');
+    });
+  });
+
   describe('validation errors', () => {
     // parseEntry is tested directly against fabricated content rather than by writing
     // a real file to disk: the collections' file lists are now resolved once, at

--- a/libs/personal-data/src/loader.ts
+++ b/libs/personal-data/src/loader.ts
@@ -2,7 +2,9 @@
 // (and the Zod schemas that validate it) can be consumed outside of Astro —
 // e.g. by the personal-data MCP server — without pulling in the Astro runtime.
 // See docs/superpowers/specs/2026-07-07-personal-mcp-split-design.md.
-import { type z, ZodError } from 'zod';
+// `/v4` to match ./schemas.ts — see the comment on its import. The `instanceof ZodError`
+// check below only catches errors thrown by schemas built from the *same* namespace.
+import { type z, ZodError } from 'zod/v4';
 
 import {
   experienceSchema,

--- a/libs/personal-data/src/loader.ts
+++ b/libs/personal-data/src/loader.ts
@@ -2,7 +2,6 @@
 // (and the Zod schemas that validate it) can be consumed outside of Astro —
 // e.g. by the personal-data MCP server — without pulling in the Astro runtime.
 // See docs/superpowers/specs/2026-07-07-personal-mcp-split-design.md.
-import matter from 'gray-matter';
 import { type z, ZodError } from 'zod';
 
 import {
@@ -34,46 +33,68 @@ export interface Entry<Data> {
 
 type CollectionData<C extends CollectionName> = z.infer<(typeof schemas)[C]>;
 
-// Each entry's raw file content is read and inlined by Vite at BUILD time (`eager`,
-// `query: '?raw'`), so the resulting strings live directly in this module's compiled
-// output — unlike a runtime `fs.readFileSync` relative to `import.meta.url`, this
-// doesn't care where the built module ends up on disk. That matters because this
-// library gets consumed two different ways: bundled by its own `vite.config.ts` into
-// `dist/index.js`, and re-bundled by consumers' own bundlers (e.g. Astro's Vite
-// pipeline for the MCP API route), which may relocate the compiled code arbitrarily.
-// A runtime file read also silently returns nothing on Vercel: the data files aren't
-// statically imported anywhere, so Vercel's Node file-tracer (which decides what ships
-// with a deployed serverless function) never includes them — `fg.sync` against a
-// missing directory doesn't throw, it just returns `[]`, which is why the bug
-// presented as empty collections rather than a crash. Inlining the content as literal
-// strings sidesteps file-tracing entirely: there's no file to trace, it's already
-// part of the JS.
+// Each entry's file content is read and inlined by Vite at BUILD time (`eager`), so the
+// resulting values live directly in this module's compiled output — unlike a runtime
+// `fs.readFileSync` relative to `import.meta.url`, this doesn't care where the built module
+// ends up on disk. That matters because this library gets consumed two different ways:
+// bundled by its own `vite.config.ts` into `dist/index.js`, and re-bundled by consumers' own
+// bundlers (e.g. Astro's Vite pipeline for the MCP API route), which may relocate the compiled
+// code arbitrarily. A runtime file read also silently returns nothing on Vercel: the data
+// files aren't statically imported anywhere, so Vercel's Node file-tracer (which decides what
+// ships with a deployed serverless function) never includes them — `fg.sync` against a missing
+// directory doesn't throw, it just returns `[]`, which is why the bug presented as empty
+// collections rather than a crash. Inlining the content as literal values sidesteps
+// file-tracing entirely: there's no file to trace, it's already part of the JS.
 //
 // `import.meta.glob`'s pattern *and options* must be written as literals inline at
 // each call site (Vite statically parses this expression at compile time — a pattern
 // or options object passed in via a shared variable isn't recognized), so this is one
 // call per collection rather than a parameterized helper.
-const rawFilesByCollection: Record<CollectionName, Record<string, string>> = {
+
+// organizations are JSON, not Markdown-with-frontmatter — no gray-matter involved, so these
+// stay raw strings, `JSON.parse`'d per entry in parseEntry below.
+const rawJsonFilesByCollection: Record<
+  'organizations',
+  Record<string, string>
+> = {
   organizations: import.meta.glob('./data/organizations/**/*.json', {
     eager: true,
     query: '?raw',
     import: 'default',
   }) as Record<string, string>,
+};
+
+// A file imported with this raw string as a JS module's default export, produced by the
+// `?frontmatter` Vite plugin (see vite.config.ts): gray-matter's parse of a markdown file's
+// frontmatter fence and body, run in Node at build time rather than at runtime — gray-matter
+// needs Buffer, which browsers don't have. `data` is `unknown` here (not yet schema-validated);
+// parseEntry below runs it through the collection's Zod schema.
+interface ParsedMarkdown {
+  data: unknown;
+  content: string;
+}
+
+type MarkdownCollectionName = Exclude<CollectionName, 'organizations'>;
+
+const parsedMarkdownFilesByCollection: Record<
+  MarkdownCollectionName,
+  Record<string, ParsedMarkdown>
+> = {
   experiences: import.meta.glob('./data/experiences/**/*.md', {
     eager: true,
-    query: '?raw',
+    query: '?frontmatter',
     import: 'default',
-  }) as Record<string, string>,
+  }) as Record<string, ParsedMarkdown>,
   projects: import.meta.glob('./data/projects/**/*.md', {
     eager: true,
-    query: '?raw',
+    query: '?frontmatter',
     import: 'default',
-  }) as Record<string, string>,
+  }) as Record<string, ParsedMarkdown>,
   skills: import.meta.glob('./data/skills/**/*.md', {
     eager: true,
-    query: '?raw',
+    query: '?frontmatter',
     import: 'default',
-  }) as Record<string, string>,
+  }) as Record<string, ParsedMarkdown>,
 };
 
 function idFromPath(collection: CollectionName, filePath: string): string {
@@ -82,17 +103,22 @@ function idFromPath(collection: CollectionName, filePath: string): string {
 }
 
 /**
- * Parses one file's raw content into an `Entry`, wrapping schema-validation failures
+ * Parses one file's content into an `Entry`, wrapping schema-validation failures
  * with the offending file's path/id. Exported (rather than folded into getCollection)
  * so validation-error behavior is testable directly against fabricated content,
- * independent of the eager glob above — that glob is resolved once, at import time,
+ * independent of the eager globs above — those are resolved once, at import time,
  * against whatever files exist on disk at build time, so a test can't inject a bad
- * file into it at runtime the way it could with the old fs-per-call reader.
+ * file into them at runtime the way it could with the old fs-per-call reader.
+ *
+ * `raw` is a JSON string for JSON collections (still parsed here, at runtime — no
+ * gray-matter/Buffer involved) or an already-frontmatter-parsed `{ data, content }` for
+ * Markdown collections (parsed at build time by the `?frontmatter` Vite plugin; see
+ * vite.config.ts and the glob definitions above).
  */
 export function parseEntry<C extends CollectionName>(
   collection: C,
   filePath: string,
-  raw: string,
+  raw: string | ParsedMarkdown,
 ): Entry<CollectionData<C>> {
   const id = idFromPath(collection, filePath);
   const schema = schemas[collection];
@@ -100,11 +126,11 @@ export function parseEntry<C extends CollectionName>(
     if (JSON_COLLECTIONS.has(collection)) {
       return {
         id,
-        data: schema.parse(JSON.parse(raw)) as CollectionData<C>,
+        data: schema.parse(JSON.parse(raw as string)) as CollectionData<C>,
         body: '',
       };
     }
-    const { data, content } = matter(raw);
+    const { data, content } = raw as ParsedMarkdown;
     return {
       id,
       data: schema.parse(data) as CollectionData<C>,
@@ -124,7 +150,11 @@ export async function getCollection<C extends CollectionName>(
   collection: C,
   filter?: (entry: Entry<CollectionData<C>>) => boolean,
 ): Promise<Entry<CollectionData<C>>[]> {
-  const files = rawFilesByCollection[collection];
+  const files: Record<string, string | ParsedMarkdown> = JSON_COLLECTIONS.has(
+    collection,
+  )
+    ? rawJsonFilesByCollection[collection as 'organizations']
+    : parsedMarkdownFilesByCollection[collection as MarkdownCollectionName];
   const entries = Object.entries(files).map(([filePath, raw]) =>
     parseEntry(collection, filePath, raw),
   );

--- a/libs/personal-data/src/schemas.ts
+++ b/libs/personal-data/src/schemas.ts
@@ -6,7 +6,13 @@
 // content.config.ts's own comment for why they weren't consolidated into one reader), so
 // if the content shape changes here, update content.config.ts's schemas to match, and
 // vice versa.
-import { z } from 'zod';
+// The `/v4` subpath, not the package root: zod@3.25 ships BOTH implementations, and the root
+// resolves to the classic v3 one. This library is bundled into the browser alongside
+// apps/personal-website's MCP catalog, which needs v4's `z.toJSONSchema` — importing the root
+// here put two entire copies of Zod in the client chunk. Keep this and ./loader.ts on the same
+// subpath: a v4 error is not `instanceof` v3's `ZodError`, so a split would break loader.ts's
+// error wrapping without failing to compile.
+import { z } from 'zod/v4';
 
 import { employmentTypes, experienceTypes, locales, skillTags } from './vocab';
 

--- a/libs/personal-data/vite.config.ts
+++ b/libs/personal-data/vite.config.ts
@@ -1,11 +1,45 @@
+import * as fs from 'node:fs/promises';
+
+import matter from 'gray-matter';
 import * as path from 'path';
+import type { Plugin } from 'vite';
 import dts from 'vite-plugin-dts';
 import { defineConfig } from 'vitest/config';
+
+// Parses `*.md?frontmatter` imports with gray-matter in Node, at build time, instead of
+// loader.ts calling `matter()` at runtime. gray-matter needs Node's `Buffer`, which browsers
+// don't have, so runtime parsing throws `ReferenceError: Buffer is not defined` — invisible
+// while this library only ran server-side (MCP endpoint, llms.txt, Astro SSR), but fatal now
+// that the ⌘K command palette's on-device "ask" tools run this same loader client-side.
+// Shipping the already-parsed `{ data, content }` as JSON is also strictly smaller than
+// shipping raw markdown *plus* a YAML/frontmatter parser to run it through in the browser.
+//
+// Implemented as a `load` hook (not `transform`) because nothing else claims `.md?frontmatter`
+// — mirrors how Vite's own built-in `?raw` handling works (`vite:asset`'s `load` hook reads the
+// file itself and returns `export default ${JSON.stringify(text)}`; see
+// node_modules/vite/dist/node/chunks/node.js's `assetPlugin`), so there's no upstream loader
+// output to transform, only a file on disk to read and reshape.
+function frontmatterPlugin(): Plugin {
+  return {
+    name: 'personal-data:frontmatter',
+    enforce: 'pre',
+    async load(id) {
+      const [filePath, query] = id.split('?');
+      if (!filePath.endsWith('.md') || !query) return;
+      if (!new URLSearchParams(query).has('frontmatter')) return;
+      this.addWatchFile(filePath);
+      const raw = await fs.readFile(filePath, 'utf-8');
+      const { data, content } = matter(raw);
+      return `export default ${JSON.stringify({ data, content })};`;
+    },
+  };
+}
 
 export default defineConfig({
   root: __dirname,
   cacheDir: '../../node_modules/.vite/libs/personal-data',
   plugins: [
+    frontmatterPlugin(),
     dts({
       entryRoot: 'src',
       tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -503,6 +503,9 @@ importers:
       '@vite-pwa/astro':
         specifier: ^1.2.0
         version: 1.2.0(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@25.6.0)(@vercel/functions@3.7.1(ws@8.21.0))(jiti@2.6.1)(less@4.1.3)(rollup@2.79.2)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vite-plugin-pwa@1.3.0(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0))
+      '@vue/test-utils':
+        specifier: ^2.4.11
+        version: 2.4.11(@vue/compiler-dom@3.5.38)(@vue/server-renderer@3.5.32(vue@3.5.32(typescript@6.0.3)))(vue@3.5.32(typescript@6.0.3))
       '@webgpu/types':
         specifier: ^0.1.69
         version: 0.1.69
@@ -3674,6 +3677,9 @@ packages:
   '@nx/workspace@23.1.0':
     resolution: {integrity: sha512-cobC05wJX7c2bWJ6s3g0IOuu6YLCEPrmpkZdX4xPEtt3GX96BsDnBpqSaqdrKhmhaa16oIERisU3AozmxmV6DA==}
 
+  '@one-ini/wasm@0.1.1':
+    resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
+
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
 
@@ -6545,6 +6551,16 @@ packages:
   '@vue/shared@3.5.38':
     resolution: {integrity: sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug==}
 
+  '@vue/test-utils@2.4.11':
+    resolution: {integrity: sha512-GDqaqZsA6m2E5vNzej0aYiIb6BX8xV9pNSbbbXKOfEYwg7ZNblVX8suyqmUBThq8VIrgAJNxn+z72hVtUeiWHA==}
+    peerDependencies:
+      '@vue/compiler-dom': 3.x
+      '@vue/server-renderer': 3.x
+      vue: 3.x
+    peerDependenciesMeta:
+      '@vue/server-renderer':
+        optional: true
+
   '@vueuse/core@14.2.1':
     resolution: {integrity: sha512-3vwDzV+GDUNpdegRY6kzpLm4Igptq+GA0QkJ3W61Iv27YWwW/ufSlOfgQIpN6FZRMG0mkaz4gglJRtq5SeJyIQ==}
     peerDependencies:
@@ -6670,6 +6686,10 @@ packages:
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
     hasBin: true
+
+  abbrev@2.0.0:
+    resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
@@ -7573,6 +7593,9 @@ packages:
   confbox@0.2.2:
     resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
 
+  config-chain@1.1.13:
+    resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
+
   confusing-browser-globals@1.0.11:
     resolution: {integrity: sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==}
 
@@ -8217,6 +8240,11 @@ packages:
   eciesjs@0.4.18:
     resolution: {integrity: sha512-wG99Zcfcys9fZux7Cft8BAX/YrOJLJSZ3jyYPfhZHqN2E+Ffx+QXBDsv3gubEgPtV6dTzJMSQUwk1H98/t/0wQ==}
     engines: {bun: '>=1', deno: '>=2', node: '>=16'}
+
+  editorconfig@1.0.7:
+    resolution: {integrity: sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -10044,6 +10072,11 @@ packages:
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
 
+  js-beautify@1.15.4:
+    resolution: {integrity: sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   js-cookie@3.0.8:
     resolution: {integrity: sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==}
 
@@ -11122,6 +11155,11 @@ packages:
     resolution: {integrity: sha512-OXdegQq03OmXEjt2hZP33W2YPs/E5BcFQks46+G2gAxs4gHOIVD1u7EqlYLYSKsaIpyKCK9Gbk0ta1/gjRSMRQ==}
     engines: {node: '>=6'}
 
+  nopt@7.2.1:
+    resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    hasBin: true
+
   nopt@8.1.0:
     resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -11982,6 +12020,9 @@ packages:
 
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
+  proto-list@1.2.4:
+    resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -14297,6 +14338,9 @@ packages:
 
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
+  vue-component-type-helpers@3.3.8:
+    resolution: {integrity: sha512-troqCMmQodQDqUqn63NQaFi+CDSclSe7sc8VEBFqf5GFLqmGR2Ph3P2WEC7qwpRVyEWsTi/aAr4vyOe/B1hU3g==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -19630,6 +19674,8 @@ snapshots:
       - '@swc-node/register'
       - '@swc/core'
 
+  '@one-ini/wasm@0.1.1': {}
+
   '@open-draft/deferred-promise@2.2.0': {}
 
   '@open-draft/logger@0.3.0':
@@ -22571,6 +22617,15 @@ snapshots:
 
   '@vue/shared@3.5.38': {}
 
+  '@vue/test-utils@2.4.11(@vue/compiler-dom@3.5.38)(@vue/server-renderer@3.5.32(vue@3.5.32(typescript@6.0.3)))(vue@3.5.32(typescript@6.0.3))':
+    dependencies:
+      '@vue/compiler-dom': 3.5.38
+      js-beautify: 1.15.4
+      vue: 3.5.32(typescript@6.0.3)
+      vue-component-type-helpers: 3.3.8
+    optionalDependencies:
+      '@vue/server-renderer': 3.5.32(vue@3.5.32(typescript@6.0.3))
+
   '@vueuse/core@14.2.1(vue@3.5.32(typescript@6.0.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.21
@@ -22769,6 +22824,8 @@ snapshots:
     dependencies:
       jsonparse: 1.3.1
       through: 2.3.8
+
+  abbrev@2.0.0: {}
 
   abbrev@3.0.1: {}
 
@@ -24080,6 +24137,11 @@ snapshots:
 
   confbox@0.2.2: {}
 
+  config-chain@1.1.13:
+    dependencies:
+      ini: 1.3.8
+      proto-list: 1.2.4
+
   confusing-browser-globals@1.0.11: {}
 
   connect-history-api-fallback@2.0.0:
@@ -24612,6 +24674,13 @@ snapshots:
       '@noble/ciphers': 1.3.0
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
+
+  editorconfig@1.0.7:
+    dependencies:
+      '@one-ini/wasm': 0.1.1
+      commander: 10.0.1
+      minimatch: 9.0.9
+      semver: 7.8.5
 
   ee-first@1.1.1: {}
 
@@ -27093,6 +27162,14 @@ snapshots:
 
   jose@6.2.2: {}
 
+  js-beautify@1.15.4:
+    dependencies:
+      config-chain: 1.1.13
+      editorconfig: 1.0.7
+      glob: 10.5.0
+      js-cookie: 3.0.8
+      nopt: 7.2.1
+
   js-cookie@3.0.8: {}
 
   js-tokens@10.0.0: {}
@@ -28500,6 +28577,10 @@ snapshots:
       sorted-array-functions: 1.3.0
     optional: true
 
+  nopt@7.2.1:
+    dependencies:
+      abbrev: 2.0.0
+
   nopt@8.1.0:
     dependencies:
       abbrev: 3.0.1
@@ -29509,6 +29590,8 @@ snapshots:
       sisteransi: 1.0.5
 
   property-information@7.2.0: {}
+
+  proto-list@1.2.4: {}
 
   proxy-addr@2.0.7:
     dependencies:
@@ -32301,6 +32384,8 @@ snapshots:
   vscode-nls@5.2.0: {}
 
   vscode-uri@3.1.0: {}
+
+  vue-component-type-helpers@3.3.8: {}
 
   vue-demi@0.14.10(vue@3.5.32(typescript@6.0.3)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -570,9 +570,6 @@ importers:
       fast-glob:
         specifier: ^3.3.3
         version: 3.3.3
-      gray-matter:
-        specifier: ^4.0.3
-        version: 4.0.3
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -580,6 +577,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.0
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
       vite-plugin-dts:
         specifier: ^4.5.4
         version: 4.5.4(@types/node@25.6.0)(rollup@4.62.2)(typescript@6.0.3)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.6.1)(less@4.1.3)(sass-embedded@1.100.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))


### PR DESCRIPTION
Workstream **E**. Adds a ⌘K palette to the site: instant fuzzy search over profile records, and — where the browser has an on-device model — an *ask* row that picks a tool, runs it, and states the answer in a sentence. Builds on the capability primitive from #257.

## The idea

The site already exposes a tool surface over MCP at `/mcp` for remote agents. That same surface should serve a human pressing ⌘K, and an in-page agent. This PR makes one Zod definition feed all three:

```
                 ┌─ server.registerTool()   → /mcp        (remote agents)
PROFILE_TOOLS ───┼─ toToolDescriptors()     → ⌘K palette  (on-device model)
  (catalog.ts)   └─ registerAgentTools()    → WebMCP      (in-page agents)
```

Previously the MCP tool definitions lived in `profile.ts` and would have had to be duplicated to reach the palette. `catalog.ts` is now the single source; `profile.ts` registers *from* it.

## Design notes worth reviewing

**Search is not AI.** Typing filters records with a plain scored matcher (`utils/search.ts`) — no model, no latency, works everywhere. The model is opt-in behind a gesture-gated "Enable on-device AI" row, because the download is hundreds of megabytes. A browser without the API loses the ask row and nothing else.

**The model picks the tool; it does not write the answer.** `selectTool()` constrains decoding to `{tool, args}` against the tool's own JSON Schema. The sentence in the answer strip comes from each tool's `summarise()`, composed from `run()`'s actual result. A model that hallucinates cannot make the strip state something untrue — the worst case is the wrong tool running.

**`execute` validates before `run`.** A model can accept a `responseConstraint` and still not honour it. Without a parse at that boundary, a malformed argument reaches the data layer as `undefined` and silently returns unfiltered results. Covered by a test.

**`defineTool` ties `params` to `run`.** `ProfileTool` erases `run` to `(args: Record<string, never>)`, so renaming a `params` key while leaving `run`'s destructuring untouched compiled with zero errors — the tool would advertise the new key and the handler read the old one, failing silently. The generic makes that a type error; verified by mutation (the rename now fails with ts(2339)).

## Two bugs found and fixed along the way

**`gray-matter` needs `Buffer`.** `loader.ts` parsed frontmatter at runtime, which is fine on a server and impossible in a browser — every ask threw `ReferenceError: Buffer is not defined`. Parsing moved to a Vite-time `?frontmatter` transform, so the browser receives parsed objects and no YAML parser. `gray-matter` is now a devDependency.

**Two copies of Zod in the client chunk.** `zod@3.25` ships both implementations — the package root resolves to classic v3, `zod/v4` to the rewrite. `personal-data` imported the root while `catalog.ts` imports `zod/v4` (it needs `z.toJSONSchema`). `personal-data` moved to `zod/v4`. `loader.ts` had to move *with* `schemas.ts`: a v4 error is not `instanceof` v3's `ZodError`, so splitting them would have silently stopped attaching the offending filename to validation failures while still compiling.

### Palette chunk

| | raw | gzip |
|---|---|---|
| before both fixes | 369,089 B | 91,324 B |
| after build-time frontmatter | 139,162 B | 37,637 B |
| after single Zod | **88,095 B** | **26,574 B** |

Net: **−76.1% raw, −70.9% gzip.**

Verified by extracting string literals unique to each Zod implementation: 29 of 31 v3-unique literals were present before, **0 of 31** after.

## Verification

- `pnpm nx run-many -t test --all` — 5 projects, 321 tests
- `pnpm nx run-many -t build --all` — 6 projects
- `pnpm nx run-many -t typecheck --all` — 7 projects
- `pnpm format:check`, lint — 0 errors

Characterisation tests in `loader.test.ts` and `catalog.test.ts` pass **unmodified** — they pin the live tool surface and the exact parsed entry shapes, so the catalog refactor and the parsing move are provably behaviour-preserving.

Live MCP checked against the running server: all 7 tools still advertised, and `tools/call` with a bad argument still rejected with `-32602` and a real Zod error. The v4 tools return v4's error shape and the v3 portfolio tool returns v3's — which is the evidence the SDK routes each schema to its own parser rather than silently accepting.

In the browser: palette opens populated with real parsed records, search filters correctly, no console errors.

## Follow-ups, not in scope

- `libs/personal-portfolio/src/mcp.ts` still imports classic `zod`. It is server-only — none of its markers appear in the client chunk — so it costs nothing there, but the MCP route's server bundle does still carry both copies.
- Data is only ~9.5% of the remaining chunk; the rest is code.

Refs: no-ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)
