### PR TITLE
Import KaTeX's stylesheet so equations render once

### DIFF
--- a/apps/personal-website/package.json
+++ b/apps/personal-website/package.json
@@ -43,6 +43,7 @@
     "i18next-resources-to-backend": "^1.2.1",
     "iconify-icon": "^3.0.2",
     "js-cookie": "^3.0.7",
+    "katex": "0.16.21",
     "lit": "catalog:",
     "lodash-es": "^4.17.23",
     "marked": "^17.0.1",

--- a/apps/personal-website/src/layouts/blog.astro
+++ b/apps/personal-website/src/layouts/blog.astro
@@ -1,4 +1,14 @@
 ---
+// KaTeX ships its markup in two layers: a visual `.katex-html` one and a `.katex-mathml` layer for
+// assistive tech. This stylesheet is what visually hides the second — without it the MathML text
+// renders underneath every equation as a garbled duplicate. rehype-katex (astro.config.mjs) emits
+// the markup but pulls in no CSS, so importing it is on us.
+//
+// Bundled rather than fetched from a CDN, which is how ./quick-post.astro used to do it: one less
+// third-party request on a site whose selling point is that things run locally, and it cannot
+// break when a CDN does.
+import 'katex/dist/katex.min.css';
+
 import { Comments } from '@components/blog';
 import { info } from '@utils/constants';
 import { Image } from 'astro:assets';

--- a/apps/personal-website/src/layouts/quick-post.astro
+++ b/apps/personal-website/src/layouts/quick-post.astro
@@ -1,12 +1,10 @@
 ---
-
+// The same bundled KaTeX stylesheet ./blog.astro imports — see the note there for what it fixes.
+//
+// This used to be a jsdelivr <link>, which meant the two layouts that render post content loaded
+// the same stylesheet by two different mechanisms. blog.astro simply never got one, so equations
+// double-rendered there while /posts looked fine. One shared import is what stops that recurring.
+import 'katex/dist/katex.min.css';
 ---
-
-<link
-  rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/katex@0.16.21/dist/katex.min.css"
-  integrity="sha384-zh0CIslj+VczCZtlzBcjt5ppRcsAmDnRem7ESsYwWwg3m/OaJ2l4x7YBZl9Kxxib"
-  crossorigin="anonymous"
-/>
 
 <slot />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,6 +433,9 @@ importers:
       js-cookie:
         specifier: ^3.0.7
         version: 3.0.8
+      katex:
+        specifier: 0.16.21
+        version: 0.16.21
       lit:
         specifier: 'catalog:'
         version: 3.3.2


### PR DESCRIPTION
Math on blog posts rendered twice — the typeset equation, and directly beneath it a garbled duplicate:

> left = upperBound − lowerBoundtempMin − lowerBound

## Cause

`rehype-katex` emits two layers: a visual `.katex-html` one and a `.katex-mathml` one for assistive tech. KaTeX's stylesheet is what visually hides the second. Without it, `.katex-mathml` computed to `position: static; clip: auto`, so its text rendered into the page.

Pre-existing since `f7712dc`, which added math support without any CSS import.

## The part that made it easy to miss

The stylesheet was not missing *everywhere*. `layouts/quick-post.astro` already pulled it from jsdelivr, so `/posts` looked correct while the blog route did not. **Two layouts render post content and only one was wired up.**

Both now share one bundled import, so they can't drift apart again.

## Why bundled rather than the CDN link

- One less third-party request, on a site whose selling point is that things run locally
- No SRI hash to keep in sync with a version number by hand
- Cannot break when a CDN does, or in a restricted network

`katex` becomes an explicit dependency: pnpm's strict layout makes `rehype-katex`'s transitive copy unresolvable from the app, so the import fails without it.

## Verification

Against the built output:

| check | result |
|---|---|
| pages containing KaTeX markup | `posts/index.html`, `blog/en/quick-posts/weather-forecast/index.html` |
| both link the stylesheet | ✅ same fingerprinted `katex.*.css` (deduped) |
| jsdelivr references remaining | 0 |
| KaTeX fonts bundled | ✅ emitted to `_astro/` |

In the browser, on the acceptance page:

```js
getComputedStyle(document.querySelector('.katex-mathml')).position  // "absolute"  (was "static")
getComputedStyle(document.querySelector('.katex-mathml')).clip      // "rect(1px, 1px, 1px, 1px)"
```

All three equations render once, and the duplicate text is gone.

Tests, builds, lint and format:check all pass.

Refs: no-ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)