### PR TITLE
Keep katex internal to Vite so astro dev boots

### DIFF
--- a/apps/personal-website/astro.config.mjs
+++ b/apps/personal-website/astro.config.mjs
@@ -92,6 +92,17 @@ export default defineConfig({
         config: () => ({ oxc: { jsx: { refresh: false } } }),
       },
     ],
+    resolve: {
+      // `layouts/blog.astro` and `layouts/quick-post.astro` import `katex/dist/katex.min.css`.
+      // Under SSR, Astro externalises bare-specifier imports and hands them to Node, which has no
+      // loader for `.css` and dies with `ERR_UNKNOWN_FILE_EXTENSION` on every page. Keeping katex
+      // internal lets Vite process the stylesheet, which is what it does in the client build.
+      //
+      // Dev-only in effect, and that is the trap: `astro build` succeeded and shipped a correct
+      // fingerprinted stylesheet the whole time `astro dev` was unusable — the same asymmetry the
+      // React Fast Refresh plugin above exists to work around.
+      noExternal: ['katex'],
+    },
   },
   integrations: [
     {


### PR DESCRIPTION
**Regression from #264, currently on main.** `astro dev` fails on every page.

#264 imported `katex/dist/katex.min.css` from the two post layouts. Under SSR, Astro externalises bare-specifier imports and hands them to Node, which has no loader for `.css`:

```
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".css"
  for .../katex@0.16.21/node_modules/katex/dist/katex.min.css
```

Vite's own hint names the fix: add the package to `vite.resolve.noExternal`. That keeps the stylesheet inside Vite, which is already what happens in the client build.

## Why it slipped through

The effect is **dev-only**. `astro build` succeeded and shipped a correct fingerprinted stylesheet the entire time `astro dev` was unusable — so #264's verification, which was thorough against the *built output*, could not have caught it.

This is the second time this exact asymmetry has bitten this config file; the React Fast Refresh workaround a few lines above exists for the same reason. Worth remembering that for this app, a green `astro build` says nothing about `astro dev`.

## Verification

| | |
|---|---|
| `/blog/web-ai` in dev | HTTP 200, zero error markers |
| `/posts` in dev | HTTP 200 |
| stylesheet present in dev | `katex/dist/katex.min.css` alongside `.katex-mathml` |
| `astro build` | still passes |
| `format:check` | passes |

Refs: no-ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)