### PR TITLE
fix(loop): a turn-limited executor is unfinished, not failed

### DIFF
--- a/tools/loop/README.md
+++ b/tools/loop/README.md
@@ -60,6 +60,24 @@ A label can be _explicitly disabled_, which is distinct from _not loaded_ — a
 disabled job stays disabled across a bootstrap, so a job that appears installed
 and silent is usually this rather than a broken plist.
 
+## Tests
+
+    tools/loop/tests/max-turns-no-fallback.sh
+
+Runs the engine **in this tree** — not whatever is installed — against a
+throwaway `LOOP_HOME`, vault, git repo and fake executors. The real install, its
+registry and its allowlists are never read or written, and the allowlist the test
+creates names a task that exists only inside its sandbox, so it authorises
+nothing. Needs a loopctl venv, borrowed from an install: the venv is a build
+artifact and is not in the repo.
+
+It guards one behaviour that is expensive to get wrong: an executor that
+exhausts its turn budget must **not** be handed on to the next executor.
+Exhausting turns means unfinished, not unable — the next executor would start the
+same task from zero on a budget that just proved insufficient, and if the first
+one had already committed, it would open a second PR for the same fix. Verified
+to fail when that guard is removed.
+
 ## Not in this repo
 
 Four kinds of file live in the install directory but are deliberately absent

--- a/tools/loop/engine/ralph.sh
+++ b/tools/loop/engine/ralph.sh
@@ -97,10 +97,27 @@ except Exception:
     payload = {}
 subtype = str(payload.get("subtype") or "")
 text = payload.get("result") or ""
-line = " ".join(str(text).split())[:180]
+# The fallback belongs to the text, not to the whole line: a stop reason with no
+# result -- exactly what the turn limit produces -- would otherwise print as a
+# bare "[error_max_turns]" and hide the fact that the executor said nothing.
+line = " ".join(str(text).split())[:180] or "(executor returned no result text)"
 prefix = f"[{subtype}] " if subtype and subtype != "success" else ""
-print((prefix + line).strip() or "(executor returned no result text)")' \
+print((prefix + line).strip())' \
     2>/dev/null || echo "(unreadable executor output)"
+}
+
+# The executor's own reason for stopping, as the CLI reports it. Measured
+# 2026-07-29: exhausting --max-turns exits 1 with subtype "error_max_turns",
+# is_error true, and result null -- indistinguishable from a real failure by exit
+# code alone, which is the whole reason this is read separately.
+executor_subtype() {
+  printf '%s' "$1" | "$PYTHON_BIN" -c \
+    'import json, sys
+try:
+    print(json.loads(sys.stdin.read()).get("subtype") or "")
+except Exception:
+    print("")' \
+    2>/dev/null || printf ''
 }
 
 # Two separate gates, both of which stopped this executor dead before 2026-07-29:
@@ -234,10 +251,37 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
     fi
     if [ "$candidate_status" -ne 0 ]; then
       log "executor=$candidate failed (exit=$candidate_status) · $(executor_verdict "$candidate_out")"
-      # A non-zero exit does not mean nothing happened. Hitting the turn limit
-      # exits 1, and on 2026-07-29 it did so one step after the executor had
-      # committed and opened a PR. Handing that task to the next executor would
-      # have it redo committed work and open a second PR for the same fix.
+      # Exhausting the turn budget means unfinished, not unable, so the fallback
+      # chain is the wrong response: the next executor starts the same task from
+      # zero with a budget that just proved insufficient, and if the first one had
+      # already committed it opens a second PR for the same fix. Checked before
+      # the repo-moved guard below, because a run can exhaust its turns without
+      # having committed anything yet and still must not be handed on.
+      if [ "$(executor_subtype "$candidate_out")" = "error_max_turns" ]; then
+        turn_cost=$(printf '%s' "$candidate_out" | "$PYTHON_BIN" -c \
+          'import json, sys; data=sys.stdin.read(); print(json.loads(data).get("total_cost_usd", 0) if data.strip() else 0)' \
+          2>/dev/null || echo 0)
+        SPENT=$("$PYTHON_BIN" -c \
+          'from decimal import Decimal; import sys; print(Decimal(sys.argv[1]) + Decimal(sys.argv[2]))' \
+          "$SPENT" "$turn_cost")
+        log "  turn limit ($MAX_TURNS) reached — not a provider failure, so the task is NOT passed on"
+        log "  spent \$$turn_cost this attempt; ralph does not resume — inspect the branch, then re-run"
+        # The spend happened whether or not the task finished; a ledger that omits
+        # it understates what the task has cost so far.
+        "$LOOPCTL" record-run \
+          --project "$slug" \
+          --task "$task_id" \
+          --executor "$candidate" \
+          --machine "$MACHINE" \
+          --cost "$turn_cost" \
+          --status incomplete \
+          --note "hit the $MAX_TURNS-turn limit; no fallback attempted" >/dev/null 2>&1 || \
+          log "  run ledger unavailable; the spend above is only in this log"
+        exit "$candidate_status"
+      fi
+      # A non-zero exit does not mean nothing happened. On 2026-07-29 an executor
+      # exited 1 one step after committing and opening a PR. Handing that task on
+      # would have it redo committed work and open a second PR for the same fix.
       if [ "$head_before" != "$(git -C "$project_path" rev-parse HEAD 2>/dev/null || echo -)" ]; then
         log "  the repo moved before this failure; not passing the task on -- inspect the branch, then resume"
         exit "$candidate_status"

--- a/tools/loop/tests/max-turns-no-fallback.sh
+++ b/tools/loop/tests/max-turns-no-fallback.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Does ralph hand a turn-limited task to the next executor?
+#
+# Fully isolated: LOOP_HOME, LOOPCTL, CLAUDE_BIN, CODEX_BIN, LOOP_MACHINE and the
+# quota file are all redirected, so the real install, its registry and its
+# allowlists are never read or written. The allowlist created here names a task
+# that exists only inside this sandbox -- it authorises nothing real.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Tests the engine in THIS tree, not whatever happens to be installed -- the point
+# is to gate the code under review. The venv is borrowed from an install, because
+# it is a build artifact and is not in the repo.
+ENGINE=${LOOP_TEST_ENGINE:-"$HERE/../engine"}
+VENV=${LOOP_TEST_VENV:-"$HOME/.claude/loop/.venv"}
+INSTALLED=${LOOP_TEST_INSTALLED:-"$HOME/.claude/loop"}
+
+[ -f "$ENGINE/ralph.sh" ] || { echo "engine not found at $ENGINE"; exit 2; }
+[ -x "$VENV/bin/python" ] || {
+  echo "no loopctl venv at $VENV — install first (tools/loop/install.sh), or set LOOP_TEST_VENV"
+  exit 2
+}
+
+ROOT=$(mktemp -d /tmp/ralph-maxturns-XXXXXX)
+HOME_DIR="$ROOT/loop-home"
+# For an obsidian-base project, tasks_dir resolves against the PROJECT path, so
+# the project and the vault are the same tree -- as they are for the real
+# obsidian-vault entry. It is also a git repo, which the repo-moved guard reads.
+VAULT="$ROOT/vault"
+PROJECT="$VAULT"
+MACHINE=test-host
+TASK_ID=T-99999999999999
+
+pass=0; fail=0
+check() {
+  if [ "$2" = "$3" ]; then pass=$((pass+1)); printf '  PASS  %s\n' "$1"
+  else fail=$((fail+1)); printf '  FAIL  %s\n        got=%s\n        want=%s\n' "$1" "$2" "$3"; fi
+}
+
+# --- sandboxed loop home -----------------------------------------------------
+mkdir -p "$HOME_DIR/greenlight"
+cp "$ENGINE/loopctl" "$ENGINE/ralph.sh" "$ENGINE/contract.md" \
+   "$ENGINE/pyproject.toml" "$HOME_DIR/"
+cp -R "$ENGINE/lib" "$HOME_DIR/lib"
+ln -s "$VENV" "$HOME_DIR/.venv"
+
+# --- the vault, which is also the project tree and a git repo ----------------
+mkdir -p "$VAULT/_system/tasks"
+git -C "$VAULT" init -q
+printf 'seed\n' > "$VAULT/README.md"
+git -C "$VAULT" add -A
+git -C "$VAULT" -c commit.gpgsign=false -c user.email=t@t -c user.name=t commit -qm seed
+cat > "$VAULT/_system/tasks/$TASK_ID.md" <<NOTE
+---
+task_id: "$TASK_ID"
+status: Not started
+priority: P2
+points: 1
+scope: personal
+---
+
+# Sandbox task
+
+Exists only inside this test.
+NOTE
+
+cat > "$HOME_DIR/config.yaml" <<CFG
+defaults:
+  policy: greenlit-only
+  dormant_days: 21
+  budget_usd: 10
+  max_iter: 15
+  vault_path: $VAULT
+
+projects:
+  - slug: sandbox
+    path: $PROJECT
+    source: obsidian-base
+    source_config:
+      tasks_dir: _system/tasks
+      scope: personal
+    greenlight: $HOME_DIR/greenlight/sandbox.md
+    policy: greenlit-only
+    stop_at: pr-ready
+    machines: [$MACHINE]
+CFG
+
+# The bullet names the task's `id`, which for an obsidian-base source is the note
+# path -- not the bare T-… . _greenlight_rank matches on id, metadata.item_id, or
+# title, and item_id only exists for Notion-sourced tasks.
+cat > "$HOME_DIR/greenlight/sandbox.md" <<GL
+# sandbox greenlight
+
+## Cleared
+- _system/tasks/$TASK_ID.md
+GL
+
+# --- fake executors ----------------------------------------------------------
+# claude: behaves exactly as the real CLI does on turn exhaustion (measured
+# 2026-07-29): the max-turns JSON on stdout, exit 1.
+cat > "$ROOT/fake-claude" <<'FAKE'
+#!/usr/bin/env bash
+echo "claude" >> "$RALPH_TEST_CALLS"
+cat <<'JSON'
+{"type":"result","subtype":"error_max_turns","is_error":true,"num_turns":100,"total_cost_usd":1.23,"result":null}
+JSON
+exit 1
+FAKE
+
+# codex: must never run. If it does, it leaves its name in the call log.
+cat > "$ROOT/fake-codex" <<'FAKE'
+#!/usr/bin/env bash
+echo "codex" >> "$RALPH_TEST_CALLS"
+echo '{"type":"result","subtype":"success","result":"codex redid the work"}'
+exit 0
+FAKE
+chmod +x "$ROOT/fake-claude" "$ROOT/fake-codex"
+
+# --- quota gate: force "ok" so it is not what stops the run ------------------
+mkdir -p "$ROOT/quota/_system/usage"
+cat > "$ROOT/quota/_system/usage/quota.$MACHINE.json" <<Q
+{"claude": {"five_hour": {"used_pct": 10}, "weekly_all": {"used_pct": 10}}}
+Q
+
+export LOOP_HOME="$HOME_DIR"
+export LOOPCTL="$HOME_DIR/loopctl"
+export LOOP_CONTRACT="$HOME_DIR/contract.md"
+export LOOP_VAULT_PATH="$VAULT"
+export LOOP_MACHINE="$MACHINE"
+export CLAUDE_BIN="$ROOT/fake-claude"
+export CODEX_BIN="$ROOT/fake-codex"
+export AGY_BIN=/nonexistent/agy
+export LOOP_EXECUTORS=claude,codex,agy
+export LOOP_QUOTA_FILE="$ROOT/quota/_system/usage/quota.$MACHINE.json"
+export RALPH_TEST_CALLS="$ROOT/calls.log"
+export RALPH_MAX_TURNS=100
+: > "$RALPH_TEST_CALLS"
+
+echo "  scan:"
+"$LOOPCTL" scan sandbox >/dev/null 2>&1 || echo "        scan failed"
+candidates=$("$LOOPCTL" next sandbox 2>/dev/null | "$VENV/bin/python" -c 'import json,sys; print(len(json.load(sys.stdin)))' 2>/dev/null || echo 0)
+check "sandbox 有 1 個 greenlit 候選（前置條件）" "$candidates" "1"
+[ "$candidates" = "1" ] || { echo "  前置條件失敗，測試無意義"; echo "  $ROOT"; exit 1; }
+
+echo "  ralph:"
+set +e
+bash "$HOME_DIR/ralph.sh" 1 10 > "$ROOT/ralph.out" 2>&1
+ralph_exit=$?
+set -e
+sed 's/^/        /' "$ROOT/ralph.out"
+
+echo
+calls=$(tr '\n' ' ' < "$RALPH_TEST_CALLS" | sed 's/ *$//')
+check "claude 被呼叫" "$(grep -c '^claude$' "$RALPH_TEST_CALLS" | tr -d ' ')" "1"
+check "codex 沒有被呼叫（核心：不 fallback）" "$(grep -c '^codex$' "$RALPH_TEST_CALLS" | tr -d ' ')" "0"
+check "呼叫序列只有 claude" "$calls" "claude"
+check "ralph exit 1" "$ralph_exit" "1"
+check "log 說明 turn limit" "$(grep -c 'turn limit (100) reached' "$ROOT/ralph.out" | tr -d ' ')" "1"
+check "log 明說不會傳給下一個" "$(grep -c 'NOT passed on' "$ROOT/ralph.out" | tr -d ' ')" "1"
+check "log 記下這次花費" "$(grep -c 'spent \$1.23' "$ROOT/ralph.out" | tr -d ' ')" "1"
+check "log 未出現舊的 fallback 字樣" "$(grep -c 'trying next executor' "$ROOT/ralph.out" | tr -d ' ')" "0"
+check "真環境的 allowlist 未被碰" "$(grep -c "$TASK_ID" "$INSTALLED/greenlight/"*.md 2>/dev/null | grep -vc ':0$' | tr -d ' ')" "0"
+
+# The spend is real whether or not the task finished; a ledger that omits it
+# understates the task's cost. Assert the entry, not just the absence of an error.
+LEDGER="$VAULT/_system/usage/loop-runs.$MACHINE.jsonl"
+ledger_row=$("$VENV/bin/python" - "$LEDGER" <<'PY'
+import json, sys
+from pathlib import Path
+p = Path(sys.argv[1])
+if not p.exists():
+    print("NO_FILE"); raise SystemExit
+rows = [json.loads(l) for l in p.read_text().splitlines() if l.strip()]
+if len(rows) != 1:
+    print(f"ROWS={len(rows)}"); raise SystemExit
+r = rows[0]
+print("{}|{}|{}".format(r.get("status"), r.get("cost_usd") or r.get("cost"), r.get("executor")))
+PY
+)
+check "ledger 有一筆 incomplete 且帶成本" "$ledger_row" "incomplete|1.23|claude"
+
+echo
+echo "  $pass/$((pass+fail))"
+[ "$fail" -eq 0 ] && rm -rf "$ROOT" || echo "  保留現場: $ROOT"
+exit "$fail"


### PR DESCRIPTION
A turn-limited executor was being treated as a failed one, which sent the task down the fallback chain.

## The bug

ralph judged executors by exit code alone. Exhausting `--max-turns` exits **1** — measured, not assumed:

| | |
|---|---|
| exit code | `1` |
| `subtype` | `error_max_turns` |
| `is_error` | `true` |
| `result` | `null` |

That is indistinguishable from a provider failure by exit code, so the task fell through to the next executor.

## Why that is wrong twice over

**It cannot succeed.** The next executor starts the same task from zero, on a budget that just proved insufficient for it.

**It can open a second PR.** On 2026-07-29 an executor fixed a bug, ran the tests, committed, and opened a PR — then hit the turn limit one step short of recording its state. ralph logged `all configured executors failed; stopping without changing the project`, which was false: the project had a new commit and an open PR. With the default `LOOP_EXECUTORS=claude,codex,agy`, the next executor would have redone committed work and opened a second PR for the same fix. It did not only because that run was invoked with a single executor.

## The fix

Read the stop reason, and on `error_max_turns` stop the run without passing the task on.

Checked **before** the existing repo-moved guard, because a run can exhaust its turns before committing anything and still must not be handed on — the repo-moved guard would miss exactly that case.

The attempt's spend goes to the ledger either way (`status: incomplete`). The money was spent whether or not the task finished; a ledger that omits it understates what the task has cost.

Also fixes the verdict line. Its fallback text was attached to the whole string rather than to the result text, so a stop reason with no result — precisely what the turn limit produces — printed as a bare `[error_max_turns]` and hid the fact that the executor said nothing at all.

## Tests

`tools/loop/tests/max-turns-no-fallback.sh` — **the first test of any kind for this engine.**

Runs the engine in this tree (not whatever is installed) against a throwaway `LOOP_HOME`, vault, git repo and fake executors. The real install, its registry and its allowlists are never read or written, and the allowlist it creates names a task that exists only inside the sandbox, so it authorises nothing.

11 assertions, the load-bearing one being that `codex` is never invoked. Verified to fail when the guard is reverted — 7 of the 11 go red, including that one.

```
PASS  claude 被呼叫
PASS  codex 沒有被呼叫（核心：不 fallback）
PASS  ralph exit 1
PASS  log 說明 turn limit
PASS  ledger 有一筆 incomplete 且帶成本
…
11/11
```

## What this does not do

**ralph still does not resume.** Each iteration gets a fresh `--session-id`, and `--resume` is never used, so a turn-limited task is stopped for a human to look at rather than continued. Resuming means persisting the session id per task and deciding when continuing is safe — the code may have moved, the task definition may have changed, or the session may simply be stale. That is a design question, not an oversight, and it is deliberately out of scope here. The log now says so explicitly rather than leaving it to be discovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
