### PR TITLE
feat(loop): surface a resume command when a run hits the turn limit

### DIFF
--- a/tools/loop/README.md
+++ b/tools/loop/README.md
@@ -60,6 +60,31 @@ A label can be _explicitly disabled_, which is distinct from _not loaded_ — a
 disabled job stays disabled across a bootstrap, so a job that appears installed
 and silent is usually this rather than a broken plist.
 
+## When a run runs out of turns
+
+ralph does **not** resume. A turn-limited run stops without passing the task to
+the next executor — exhausting turns means unfinished, not unable, and handing it
+on would restart the same task on a budget that just proved insufficient, or open
+a second PR for work the first executor had already committed.
+
+The session survives with its full context, so it can be picked up by hand. Both
+the log and the task card carry the exact command:
+
+    cd '<project path>' && claude --resume <session id>
+
+Verified against a real turn-limited session: it came back knowing the ticket,
+the fix it had written, the PR it had opened, and that its next call had failed.
+
+The note is written with `loopctl task-note`, not `loopctl set`. `set` requires a
+state, and every state it accepts is an assertion — a run that exhausted its
+turns may have committed, opened a PR, or produced nothing, so any state passed
+would be a guess. `task-note` records the observation and asserts nothing.
+
+Automatic resume is deliberately not implemented. It would need a guard for when
+continuing is unsafe: the branch may have moved under the session, the task
+definition may have changed, or the session may simply be stale — and continuing
+with an outdated understanding can be worse than starting over.
+
 ## Tests
 
     tools/loop/tests/max-turns-no-fallback.sh

--- a/tools/loop/engine/lib/loopctl/scan.py
+++ b/tools/loop/engine/lib/loopctl/scan.py
@@ -338,6 +338,44 @@ def set_task_state(
     return task
 
 
+def set_task_note(slug: str, task_id: str, note: str, *, now_ts: int | None = None) -> dict:
+    """Record an observation against a task without claiming its state changed.
+
+    `set_task_state` cannot be reused for this: it requires a state, and every
+    state it would accept is an assertion. A run that exhausted its turn budget
+    may have committed, opened a PR, or produced nothing at all -- asserting any
+    of those would be a guess, and asserting the state it already had would still
+    risk tripping the stop_at path that retires the greenlight.
+
+    The note reaches Observatory through the same overlay `set_task_state`
+    publishes, so it renders on the task card (TaskDetail's `loopNote`).
+    """
+    document = registry.read_project_state(slug)
+    if not document:
+        raise ValueError(f"project '{slug}' has no scanned registry state")
+    matches = [item for item in document.get("tasks") or [] if _answers_to(item, str(task_id))]
+    if not matches:
+        raise ValueError(f"task '{task_id}' is not present in project '{slug}'")
+    if len(matches) > 1:
+        raise ValueError(
+            f"task '{task_id}' matches {len(matches)} tasks in project '{slug}'; "
+            "use the Notion URL to disambiguate"
+        )
+    task = matches[0]
+    overlay = dict(task.get("overlay") or {})
+    overlay["note"] = note
+    overlay["updated_ts"] = now_ts or _now()
+    task["overlay"] = overlay
+    registry.write_project_state(slug, document)
+    # Best-effort, exactly as in set_task_state: an unavailable vault must not
+    # fail the caller that was only leaving a note.
+    try:
+        publish_task_state(slug, task)
+    except OSError:
+        pass
+    return task
+
+
 def _retire_greenlight_if_terminal(slug: str, task: dict) -> dict | None:
     """Withdraw the task's greenlight once the loop has reached the project's stop_at.
 
@@ -503,6 +541,12 @@ def _build_parser() -> argparse.ArgumentParser:
     set_parser.add_argument("--note")
     set_parser.add_argument("--blocked-reason")
 
+    # Separate from `set` on purpose: this asserts nothing about the task's state.
+    note_parser = sub.add_parser("task-note")
+    note_parser.add_argument("slug")
+    note_parser.add_argument("task")
+    note_parser.add_argument("--note", required=True)
+
     run_parser = sub.add_parser("record-run")
     run_parser.add_argument("--project", required=True)
     run_parser.add_argument("--task", required=True)
@@ -562,6 +606,12 @@ def main(argv=None) -> int:
                 retired = _retire_greenlight_if_terminal(args.slug, task)
             if retired is not None:
                 task["greenlight"] = retired
+            _print_json(task)
+            return 0
+
+        if args.cmd == "task-note":
+            with registry.ProjectLock(args.slug):
+                task = set_task_note(args.slug, args.task, args.note)
             _print_json(task)
             return 0
 

--- a/tools/loop/engine/ralph.sh
+++ b/tools/loop/engine/ralph.sh
@@ -265,7 +265,20 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
           'from decimal import Decimal; import sys; print(Decimal(sys.argv[1]) + Decimal(sys.argv[2]))' \
           "$SPENT" "$turn_cost")
         log "  turn limit ($MAX_TURNS) reached — not a provider failure, so the task is NOT passed on"
-        log "  spent \$$turn_cost this attempt; ralph does not resume — inspect the branch, then re-run"
+        log "  spent \$$turn_cost this attempt"
+        # The session survives with its full context -- what it understood, what it
+        # tried, what it had just done. Print the exact command to pick it up:
+        # reconstructing it later means knowing transcripts are keyed by cwd and
+        # that the session id appears nowhere but this log.
+        resume_hint="cd '$project_path' && claude --resume $sid"
+        log "  ralph does not resume, but this session can be continued by hand:"
+        log "    $resume_hint"
+        # Onto the task card too, so the hint is reachable from Observatory and not
+        # only by whoever reads this log. task-note rather than set: the run's
+        # outcome is unknown, and any state passed would be a guess.
+        "$LOOPCTL" task-note "$slug" "$task_id" \
+          --note "Turn limit ($MAX_TURNS) reached, unfinished. Continue: $resume_hint" \
+          >/dev/null 2>&1 || log "  (task note not written; the hint above is the only copy)"
         # The spend happened whether or not the task finished; a ledger that omits
         # it understates what the task has cost so far.
         "$LOOPCTL" record-run \

--- a/tools/loop/tests/max-turns-no-fallback.sh
+++ b/tools/loop/tests/max-turns-no-fallback.sh
@@ -179,6 +179,38 @@ PY
 )
 check "ledger 有一筆 incomplete 且帶成本" "$ledger_row" "incomplete|1.23|claude"
 
+# The whole point of the turn-limit branch is that the session can be picked up.
+# Assert the command is printed and reaches the task card, not just that we logged
+# something.
+check "log 印出可直接跑的 resume 指令" "$(grep -c "claude --resume" "$ROOT/ralph.out" | tr -d ' ')" "1"
+# Only what ralph owns: a complete, runnable command. Where the CLI keeps the
+# transcript is its own business, and `cd <path> && claude --resume <id>` does not
+# depend on that encoding -- so asserting the file's location would test the CLI,
+# not this branch. That resume restores context was verified separately against a
+# real session.
+check "resume 指令完整（cd + 36 字元 session id）" \
+  "$(grep -cE "cd '.*' && claude --resume [A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}" "$ROOT/ralph.out" | tr -d ' ')" "1"
+# Matched by content, not by key. How the overlay is keyed is the code's business
+# -- for an obsidian-base task it is the note path, for a Notion one the AG- id --
+# and duplicating that rule here would just test the test.
+progress_note=$("$VENV/bin/python" - "$VAULT/_system/usage/tasks-progress.json" <<'PYNOTE'
+import json, sys
+from pathlib import Path
+p = Path(sys.argv[1])
+if not p.exists():
+    print("NO_FILE"); raise SystemExit
+entries = (json.loads(p.read_text()).get("tasks") or {})
+hits = [k for k, v in entries.items() if "claude --resume" in ((v or {}).get("note") or "")]
+if len(hits) == 1:
+    print("HAS_RESUME")
+elif not entries:
+    print("NO_ENTRIES")
+else:
+    print(f"NO_RESUME(keys={list(entries)[:2]})")
+PYNOTE
+)
+check "task note 帶著 resume 指令（Observatory 讀得到）" "$progress_note" "HAS_RESUME"
+
 echo
 echo "  $pass/$((pass+fail))"
 [ "$fail" -eq 0 ] && rm -rf "$ROOT" || echo "  保留現場: $ROOT"


### PR DESCRIPTION
A turn-limited session survives with its full context. Nothing surfaced how to reach it.

## What was missing

`#267` made ralph stop cleanly on `error_max_turns` instead of handing the task to the next executor. But picking the session up again required knowing three things that were nowhere convenient: that the session still exists, that its id appears only in a log line, and that transcripts are keyed by cwd so `--resume` has to run from the right directory.

Verified first that resuming actually works, against the real turn-limited session from 2026-07-29:

> I was running one Loop iteration on AG-290 …, fixing it with an identity-keyed `form.reset` hydration in `StoreForm.tsx` plus 5 regression tests, and the last action I completed was opening draft PR #2469 — my subsequent `loopctl set …` call failed with…

It came back knowing the ticket, the fix it had written, the PR it had opened, and that its next call had failed. The context is intact; only the entry point was hidden.

## The change

ralph now prints the exact command:

```
turn limit (100) reached — not a provider failure, so the task is NOT passed on
spent $1.23 this attempt
ralph does not resume, but this session can be continued by hand:
  cd '/Users/rainforest/Repositories/sdf-wt/ralph-ag290' && claude --resume B09C7670-…
```

…and writes it onto the task card, so it is reachable from Observatory rather than only from whoever reads the log. It lands in the `note` field of the progress overlay, which `TaskDetail.vue` already renders as `loopNote` — no UI change needed.

## Why a new `loopctl task-note` instead of `set`

`set` requires a state, and **every state it accepts is an assertion.** A run that exhausted its turns may have committed, opened a PR, or produced nothing at all — asserting any of those would be a guess.

Passing the state the task already had is not a safe workaround either: if that state happened to be the project's `stop_at`, `set` would retire the greenlight for a task that is not finished.

`task-note` writes the note, publishes the overlay, and asserts nothing about state.

## Tests

Three assertions added to `tools/loop/tests/max-turns-no-fallback.sh` (now 14):

| | |
|---|---|
| log 印出可直接跑的 resume 指令 | the command appears |
| resume 指令完整 | `cd '<path>' && claude --resume <36-char id>` — a complete, runnable line |
| task note 帶著 resume 指令 | it reaches the progress overlay Observatory reads |

Each verified to fail when the behaviour is removed. Breaking the `task-note` call also exercised its fallback path, which correctly logged `task note not written; the hint above is the only copy`.

The overlay assertion matches on **content, not key** — how the overlay is keyed is the code's business (the note path for an obsidian-base task, the `AG-` id for a Notion one), and duplicating that rule in the test would only test the test.

One thing deliberately **not** asserted: where the CLI stores the transcript. `cd <path> && claude --resume <id>` does not depend on that encoding, so asserting the file's location would test the CLI rather than this branch.

## Still not implemented: automatic resume

ralph does not resume itself, and this PR does not change that. Doing so needs a guard for when continuing is unsafe — the branch may have moved under the session, the task definition may have changed, or the session may simply be stale, and continuing with an outdated understanding can be worse than starting over. The README now states this rather than leaving it to be discovered.

## Note on the desktop app

The original question was whether these sessions could be continued in the Claude desktop app. They cannot, and this PR does not attempt it: the two use independent stores — `~/.claude/projects/<cwd>/<uuid>.jsonl` for the CLI (827 on this machine) versus `…/Claude/claude-code-sessions/…/local_<uuid>.json` for the app (226). Writing into the app's store would mean depending on an internal format that an app update can change, with the user's whole session list as the blast radius. A copyable command is the supported path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
