### PR TITLE
fix(observatory): style rendered markdown tables in the note drawer

### DIFF
--- a/apps/loop-observatory/src/components/TaskDetail.vue
+++ b/apps/loop-observatory/src/components/TaskDetail.vue
@@ -973,6 +973,33 @@ onMounted(() => {
   background: none;
   padding: 0;
 }
+/* Tables. The drawer is narrow, so the table scrolls inside its own wrapper
+   rather than widening the drawer — same reasoning as `pre` above. */
+.note-body :deep(table) {
+  display: block;
+  overflow-x: auto;
+  width: max-content;
+  max-width: 100%;
+  border-collapse: collapse;
+  margin: 0.7em 0;
+  font-size: 0.9em;
+}
+.note-body :deep(th),
+.note-body :deep(td) {
+  border: 1px solid var(--border);
+  padding: 0.35em 0.6em;
+  text-align: left;
+  vertical-align: top;
+}
+.note-body :deep(th) {
+  background: var(--muted);
+  font-weight: 600;
+  color: var(--foreground);
+  white-space: nowrap;
+}
+.note-body :deep(td) {
+  color: var(--foreground);
+}
 .note-body :deep(blockquote) {
   border-left: 3px solid var(--border);
   padding-left: 0.8em;


### PR DESCRIPTION
Follow-up to #270. That PR made the renderer emit `<table>`; this one makes it look like a table.

`.note-body` had no table rules, so the output came out with browser defaults — no borders, no cell padding, columns jammed together.

- Borders and padding drawn from the existing `--border` / `--muted` variables, so it matches the rest of the drawer in both themes.
- The table scrolls inside its own wrapper rather than widening the drawer. Same reasoning already applied to `pre`: the drawer is narrow, and a wide table would otherwise push the footer padding out of view.

Verified against the live Observatory on the mini — the AG-132 note's execution-plan table renders correctly server-side; this adds the styling on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
