### PR TITLE
feat(loop): resolve a task's preset to a real model and effort at run time

### DIFF
--- a/tools/loop/engine/lib/loopctl/scan.py
+++ b/tools/loop/engine/lib/loopctl/scan.py
@@ -556,6 +556,13 @@ def _build_parser() -> argparse.ArgumentParser:
     run_parser.add_argument("--status", default="completed")
     run_parser.add_argument("--note")
     run_parser.add_argument("--started-ts", type=int)
+    run_parser.add_argument("--model")
+    run_parser.add_argument("--effort")
+    run_parser.add_argument("--tokens-out", type=int)
+    run_parser.add_argument("--quota-5h-before")
+    run_parser.add_argument("--quota-5h-after")
+    run_parser.add_argument("--quota-week-before")
+    run_parser.add_argument("--quota-week-after")
 
     sweep_parser = sub.add_parser("sweep")
     sweep_parser.add_argument("--machine", required=True)
@@ -626,6 +633,13 @@ def main(argv=None) -> int:
                     status=args.status,
                     note=args.note,
                     started_ts=args.started_ts,
+                    model=args.model,
+                    effort=args.effort,
+                    tokens_out=args.tokens_out,
+                    quota_5h_before=args.quota_5h_before,
+                    quota_5h_after=args.quota_5h_after,
+                    quota_week_before=args.quota_week_before,
+                    quota_week_after=args.quota_week_after,
                 )
             )
             return 0

--- a/tools/loop/engine/lib/loopctl/writeback.py
+++ b/tools/loop/engine/lib/loopctl/writeback.py
@@ -188,6 +188,39 @@ def publish_task_state(
     return entry
 
 
+def _pct(value: str | float | None) -> float | None:
+    """A quota percentage, or None for the '?' the sampler emits when unread."""
+    if value is None or value == "" or value == "?":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _quota_block(before_5h, after_5h, before_week, after_week) -> dict | None:
+    """Structured quota movement for one run, or None when nothing was sampled.
+
+    The percentage-point deltas were previously only ever written into the free-text
+    `note`, which made them unusable for anything but reading. They are the only
+    measurement that answers "what did this run actually cost me", so they belong
+    in fields.
+    """
+    five_before, five_after = _pct(before_5h), _pct(after_5h)
+    week_before, week_after = _pct(before_week), _pct(after_week)
+    if all(v is None for v in (five_before, five_after, week_before, week_after)):
+        return None
+    delta = lambda a, b: None if a is None or b is None else round(b - a, 4)
+    return {
+        "five_hour_before": five_before,
+        "five_hour_after": five_after,
+        "five_hour_delta_pp": delta(five_before, five_after),
+        "weekly_before": week_before,
+        "weekly_after": week_after,
+        "weekly_delta_pp": delta(week_before, week_after),
+    }
+
+
 def append_run(
     *,
     project: str,
@@ -199,6 +232,13 @@ def append_run(
     note: str | None = None,
     started_ts: int | None = None,
     ended_ts: int | None = None,
+    model: str | None = None,
+    effort: str | None = None,
+    tokens_out: int | None = None,
+    quota_5h_before: str | float | None = None,
+    quota_5h_after: str | float | None = None,
+    quota_week_before: str | float | None = None,
+    quota_week_after: str | float | None = None,
 ) -> dict:
     """Append one structured iteration/retro record to a machine partition."""
     ended = ended_ts or int(time.time())
@@ -213,6 +253,14 @@ def append_run(
         "cost_usd": float(cost_usd or 0),
         "status": status,
         "note": note,
+        # Which model and effort actually ran. Neither was recorded anywhere
+        # before, so "was xhigh worth it" could not be answered from own data.
+        "model": model,
+        "effort": effort,
+        "tokens_out": tokens_out,
+        "quota": _quota_block(
+            quota_5h_before, quota_5h_after, quota_week_before, quota_week_after
+        ),
     }
     path = usage_path(f"loop-runs.{machine}.jsonl")
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/tools/loop/engine/ralph.sh
+++ b/tools/loop/engine/ralph.sh
@@ -12,6 +12,15 @@ PYTHON_BIN=${LOOP_PYTHON:-"$LOOP_HOME/.venv/bin/python"}
 MACHINE=${LOOP_MACHINE:-${USAGE_MACHINE:-$(hostname -s)}}
 EXECUTORS=${LOOP_EXECUTORS:-claude,codex,agy}
 AGENT_CONFIG=${LOOP_AGENT_CONFIG:-}
+# Resolved per iteration from the agent config's preset for this task. Empty
+# means "say nothing", so each executor falls back to its own default -- the
+# behaviour that existed before presets.
+PLAN_MODEL=""
+PLAN_EFFORT=""
+# The usage tracker lives outside LOOP_HOME and runs on the system interpreter;
+# the loop venv does not carry its dependencies.
+USAGE_RUNTIME=${LOOP_USAGE_RUNTIME:-"$HOME/.local/share/loop-usage-runtime"}
+USAGE_PYTHON=${LOOP_USAGE_PYTHON:-$(command -v python3 2>/dev/null || echo python3)}
 MAX_ITER=${1:-15}
 BUDGET_USD=${2:-10}
 BACKOFF=${RALPH_BACKOFF_SECS:-1800}
@@ -73,9 +82,19 @@ print("{}\t{}\t{}".format(verdict, "" if five is None else five, "" if week is N
 PY
 }
 
+# Force a fresh provider read before sampling. Without this the before/after
+# pair both come from the file the hourly job rewrites, so a run lasting minutes
+# reads the same snapshot twice -- which is why every delta recorded up to
+# 2026-07-30 was ~0pp. Best-effort: an unavailable tracker must not stop a run,
+# it just leaves the delta as approximate as it was before.
+refresh_quota() {
+  [ -d "$USAGE_RUNTIME" ] || return 0
+  (cd "$USAGE_RUNTIME" && "$USAGE_PYTHON" -m scripts.usage.export_quota) \
+    >/dev/null 2>&1 || true
+}
+
 # Percentage-point delta between two quota readings, for the per-iteration
-# estimate. The snapshot refreshes on its own schedule, so this trails reality
-# by up to one refresh interval and is reported as an approximation.
+# estimate.
 pct_delta() {
   [ -n "$1" ] && [ -n "$2" ] || { printf '?'; return; }
   "$PYTHON_BIN" -c \
@@ -128,8 +147,14 @@ except Exception:
 run_claude() {
   local slug="$1" project_path="$2" prompt="$3" sid="$4"
   [ -x "$CLAUDE_BIN" ] || return 127
+  # `${opts[@]+...}` because an empty array under `set -u` is an unbound
+  # expansion on the bash 3.2 that ships with macOS.
+  local opts=()
+  [ -n "$PLAN_MODEL" ] && opts+=(--model "$PLAN_MODEL")
+  [ -n "$PLAN_EFFORT" ] && opts+=(--effort "$PLAN_EFFORT")
   (cd "$project_path" && printf '%s' "$prompt" | LOOP_PROJECT="$slug" LOOP_EXECUTOR=claude \
     LOOP_QUOTA_MODE="${QUOTA_MODE:-ok}" "$CLAUDE_BIN" -p \
+    ${opts[@]+"${opts[@]}"} \
     --permission-mode "${LOOP_CLAUDE_PERMISSION_MODE:-auto}" --add-dir "$LOOP_HOME" \
     --session-id "$sid" --output-format json --max-turns "$MAX_TURNS")
 }
@@ -137,8 +162,14 @@ run_claude() {
 run_codex() {
   local slug="$1" project_path="$2" prompt="$3"
   [ -x "$CODEX_BIN" ] || return 127
+  # Codex has no dedicated effort flag; `-c` sets it and the server validates it
+  # (a bogus level is a 400, so a typo fails loudly rather than being ignored).
+  local opts=()
+  [ -n "$PLAN_MODEL" ] && opts+=(-m "$PLAN_MODEL")
+  [ -n "$PLAN_EFFORT" ] && opts+=(-c "model_reasoning_effort=$PLAN_EFFORT")
   (cd "$project_path" && printf '%s' "$prompt" | LOOP_PROJECT="$slug" LOOP_EXECUTOR=codex \
     LOOP_QUOTA_MODE="${QUOTA_MODE:-ok}" "$CODEX_BIN" exec \
+    ${opts[@]+"${opts[@]}"} \
     --json --ephemeral --sandbox workspace-write -C "$project_path" -)
 }
 
@@ -162,7 +193,17 @@ run_executor() {
 IFS=',' read -r -a executor_list <<< "$EXECUTORS"
 [ "${#executor_list[@]}" -gt 0 ] || { log "no executors configured"; exit 1; }
 
-preferred_executor() {
+# Emits "<provider>\t<model>\t<effort>" for a task, or nothing at all.
+#
+# A task stores only a preset id; the model and effort behind it are resolved
+# here, at run time. That is the point of the indirection -- renaming a model in
+# the config carries every task forward on its next run, and no task note ever
+# pins a model that has since been superseded.
+#
+# Silence is a valid answer, and the safe one: an unreadable config, an unknown
+# preset, or a preset naming an unknown provider all fall through to the
+# executor's own defaults, which is exactly how the loop behaved before presets.
+preferred_plan() {
   local task_id="$1"
   [ -n "$AGENT_CONFIG" ] && [ -f "$AGENT_CONFIG" ] || return 0
   "$PYTHON_BIN" - "$AGENT_CONFIG" "$task_id" <<'PY'
@@ -170,19 +211,25 @@ import json
 import sys
 from pathlib import Path
 
+PROVIDERS = {"claude", "codex", "agy"}
+
 try:
     document = json.loads(Path(sys.argv[1]).read_text())
     task = (document.get("tasks") or {}).get(str(sys.argv[2])) or {}
-    agent = task.get("agent") or document.get("default_agent") or "claude"
-    if agent in {"claude", "codex", "agy"}:
-        print(agent)
-except (OSError, ValueError, TypeError):
+    presets = document.get("presets") or {}
+    name = task.get("preset") or document.get("default_preset")
+    preset = presets.get(name) or {} if name else {}
+    provider = preset.get("provider") or task.get("agent") or document.get("default_agent") or "claude"
+    if provider in PROVIDERS:
+        print("{}\t{}\t{}".format(provider, preset.get("model") or "", preset.get("effort") or ""))
+except (OSError, ValueError, TypeError, AttributeError):
     pass
 PY
 }
 
 log "start · machine=$MACHINE max_iter=$MAX_ITER budget=\$$BUDGET_USD"
 while [ "$iter" -lt "$MAX_ITER" ]; do
+  refresh_quota
   IFS=$'\t' read -r QUOTA_MODE pct5_before pctw_before <<< "$(quota_state)"
   log "quota · 5h=${pct5_before:-?}% weekly=${pctw_before:-?}% · gate=$QUOTA_MODE"
   case "$QUOTA_MODE" in
@@ -213,7 +260,10 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
   next_json=$("$LOOPCTL" next "$slug" 2>/dev/null || printf '[]')
   task_id=$(printf '%s' "$next_json" | "$PYTHON_BIN" -c \
     'import json, sys; rows=json.load(sys.stdin); print(rows[0].get("id", "") if rows else "")' 2>/dev/null || printf '')
-  preferred=$(preferred_executor "$task_id")
+  # Reset every iteration: a task with no preset must not inherit the previous
+  # task's model.
+  preferred=""; PLAN_MODEL=""; PLAN_EFFORT=""
+  IFS=$'\t' read -r preferred PLAN_MODEL PLAN_EFFORT <<< "$(preferred_plan "$task_id")"
   ordered_executors=()
   if [ -n "$preferred" ]; then
     ordered_executors+=("$preferred")
@@ -224,7 +274,7 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
     fi
   done
   if [ -n "$preferred" ]; then
-    log "task=$task_id preferred_executor=$preferred"
+    log "task=$task_id executor=$preferred model=${PLAN_MODEL:-default} effort=${PLAN_EFFORT:-default}"
   fi
 
   prompt=$(printf 'LOOP_PROJECT=%s\n\n' "$slug"; cat "$CONTRACT")
@@ -281,6 +331,9 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
           >/dev/null 2>&1 || log "  (task note not written; the hint above is the only copy)"
         # The spend happened whether or not the task finished; a ledger that omits
         # it understates what the task has cost so far.
+        turn_fields=()
+        [ -n "$PLAN_MODEL" ] && turn_fields+=(--model "$PLAN_MODEL")
+        [ -n "$PLAN_EFFORT" ] && turn_fields+=(--effort "$PLAN_EFFORT")
         "$LOOPCTL" record-run \
           --project "$slug" \
           --task "$task_id" \
@@ -288,6 +341,7 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
           --machine "$MACHINE" \
           --cost "$turn_cost" \
           --status incomplete \
+          ${turn_fields[@]+"${turn_fields[@]}"} \
           --note "hit the $MAX_TURNS-turn limit; no fallback attempted" >/dev/null 2>&1 || \
           log "  run ledger unavailable; the spend above is only in this log"
         exit "$candidate_status"
@@ -332,6 +386,10 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
   SPENT=$("$PYTHON_BIN" -c \
     'from decimal import Decimal; import sys; print(Decimal(sys.argv[1]) + Decimal(sys.argv[2]))' \
     "$SPENT" "$cost")
+  tokens_out=$(printf '%s' "$out" | "$PYTHON_BIN" -c \
+    'import json, sys; data=sys.stdin.read(); print((json.loads(data).get("usage") or {}).get("output_tokens", "") if data.strip() else "")' \
+    2>/dev/null || printf '')
+  refresh_quota
   IFS=$'\t' read -r _ pct5_after pctw_after <<< "$(quota_state)"
   d5=$(pct_delta "$pct5_before" "$pct5_after")
   dw=$(pct_delta "$pctw_before" "$pctw_after")
@@ -350,13 +408,22 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
   fi
   # Observatory/retro mirror is append-only and best-effort. The executor's
   # loopctl set remains the authoritative task-state transition.
+  run_fields=()
+  [ -n "$PLAN_MODEL" ] && run_fields+=(--model "$PLAN_MODEL")
+  [ -n "$PLAN_EFFORT" ] && run_fields+=(--effort "$PLAN_EFFORT")
+  [ -n "$tokens_out" ] && run_fields+=(--tokens-out "$tokens_out")
+  [ -n "$pct5_before" ] && run_fields+=(--quota-5h-before "$pct5_before")
+  [ -n "$pct5_after" ] && run_fields+=(--quota-5h-after "$pct5_after")
+  [ -n "$pctw_before" ] && run_fields+=(--quota-week-before "$pctw_before")
+  [ -n "$pctw_after" ] && run_fields+=(--quota-week-after "$pctw_after")
   "$LOOPCTL" record-run \
     --project "$slug" \
     --task "$task_id" \
     --executor "$provider" \
     --machine "$MACHINE" \
     --cost "$cost" \
-    --note "iteration $iter/$MAX_ITER; exit=$status; quota 5h ${pct5_before:-?}%→${pct5_after:-?}% (~${d5}pp), weekly ${pctw_before:-?}%→${pctw_after:-?}% (~${dw}pp)" >/dev/null 2>&1 || \
+    ${run_fields[@]+"${run_fields[@]}"} \
+    --note "iteration $iter/$MAX_ITER; exit=$status" >/dev/null 2>&1 || \
     log "run ledger unavailable; continuing"
   over_budget=$("$PYTHON_BIN" -c "from decimal import Decimal; import sys; print(int(Decimal(sys.argv[1]) > Decimal(sys.argv[2])))" \
     "${SPENT:-0}" "$BUDGET_USD")

--- a/tools/loop/tests/execution-presets.sh
+++ b/tools/loop/tests/execution-presets.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# Does a task's preset reach the executor as a real model/effort flag, and does
+# the run record keep what ran?
+#
+# The three things this gates, each of which was silently broken or absent:
+#   1. `--model` / `--effort` on claude, `-m` / `-c model_reasoning_effort=` on
+#      codex. Neither executor was ever told which model to use, so a plan card
+#      naming Opus 4.8 while the CLI default was Opus 5 was simply a lie.
+#   2. No agent config, or an unknown preset, must change nothing -- the loop has
+#      to keep working exactly as it did for tasks with no preset.
+#   3. `model`, `effort` and the quota before/after must land in the run record
+#      as fields. They previously existed only inside a free-text note, or (for
+#      effort) nowhere at all, so "was xhigh worth it" was unanswerable.
+#
+# Fully isolated: LOOP_HOME, LOOPCTL, CLAUDE_BIN, CODEX_BIN, LOOP_MACHINE, the
+# quota file and the agent config are all redirected. The allowlist created here
+# names a task that exists only inside this sandbox -- it authorises nothing real.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENGINE=${LOOP_TEST_ENGINE:-"$HERE/../engine"}
+VENV=${LOOP_TEST_VENV:-"$HOME/.claude/loop/.venv"}
+
+[ -f "$ENGINE/ralph.sh" ] || { echo "engine not found at $ENGINE"; exit 2; }
+[ -x "$VENV/bin/python" ] || {
+  echo "no loopctl venv at $VENV — install first (tools/loop/install.sh), or set LOOP_TEST_VENV"
+  exit 2
+}
+
+ROOT=$(mktemp -d /tmp/ralph-presets-XXXXXX)
+HOME_DIR="$ROOT/loop-home"
+VAULT="$ROOT/vault"
+PROJECT="$VAULT"
+MACHINE=test-host
+TASK_ID=T-99999999999999
+TASK_KEY="_system/tasks/$TASK_ID.md"
+
+pass=0; fail=0
+check() {
+  if [ "$2" = "$3" ]; then pass=$((pass+1)); printf '  PASS  %s\n' "$1"
+  else fail=$((fail+1)); printf '  FAIL  %s\n        got=%s\n        want=%s\n' "$1" "$2" "$3"; fi
+}
+contains() {
+  case "$2" in *"$3"*) check "$1" yes yes ;; *) check "$1" "missing: $3" "present in: $2" ;; esac
+}
+excludes() {
+  case "$2" in *"$3"*) check "$1" "present: $3" "absent" ;; *) check "$1" yes yes ;; esac
+}
+
+# --- sandboxed loop home -----------------------------------------------------
+mkdir -p "$HOME_DIR/greenlight"
+cp "$ENGINE/loopctl" "$ENGINE/ralph.sh" "$ENGINE/contract.md" \
+   "$ENGINE/pyproject.toml" "$HOME_DIR/"
+cp -R "$ENGINE/lib" "$HOME_DIR/lib"
+ln -s "$VENV" "$HOME_DIR/.venv"
+
+# --- the vault, which is also the project tree and a git repo ----------------
+mkdir -p "$VAULT/_system/tasks" "$VAULT/_system/usage"
+git -C "$VAULT" init -q
+printf 'seed\n' > "$VAULT/README.md"
+git -C "$VAULT" add -A
+git -C "$VAULT" -c commit.gpgsign=false -c user.email=t@t -c user.name=t commit -qm seed
+cat > "$VAULT/$TASK_KEY" <<NOTE
+---
+task_id: "$TASK_ID"
+status: Not started
+priority: P2
+points: 1
+scope: personal
+---
+
+# Sandbox task
+
+Exists only inside this test.
+NOTE
+
+cat > "$HOME_DIR/config.yaml" <<CFG
+defaults:
+  policy: greenlit-only
+  dormant_days: 21
+  budget_usd: 10
+  max_iter: 15
+  vault_path: $VAULT
+
+projects:
+  - slug: sandbox
+    path: $PROJECT
+    source: obsidian-base
+    source_config:
+      tasks_dir: _system/tasks
+      scope: personal
+    greenlight: $HOME_DIR/greenlight/sandbox.md
+    policy: greenlit-only
+    stop_at: pr-ready
+    machines: [$MACHINE]
+CFG
+
+cat > "$HOME_DIR/greenlight/sandbox.md" <<GL
+# sandbox greenlight
+
+## Cleared
+- $TASK_KEY
+GL
+
+# --- fake executors: record the exact argv they were handed ------------------
+cat > "$ROOT/fake-claude" <<'FAKE'
+#!/usr/bin/env bash
+printf 'claude %s\n' "$*" >> "$RALPH_TEST_CALLS"
+echo '{"type":"result","subtype":"success","total_cost_usd":0.5,"usage":{"output_tokens":4242},"result":"done"}'
+exit 0
+FAKE
+cat > "$ROOT/fake-codex" <<'FAKE'
+#!/usr/bin/env bash
+printf 'codex %s\n' "$*" >> "$RALPH_TEST_CALLS"
+echo '{"type":"result","subtype":"success","result":"done"}'
+exit 0
+FAKE
+chmod +x "$ROOT/fake-claude" "$ROOT/fake-codex"
+
+mkdir -p "$ROOT/quota/_system/usage"
+write_quota() {
+  cat > "$ROOT/quota/_system/usage/quota.$MACHINE.json" <<Q
+{"claude": {"five_hour": {"used_pct": $1}, "weekly_all": {"used_pct": $2}}}
+Q
+}
+write_quota 10 20
+
+export LOOP_HOME="$HOME_DIR"
+export LOOPCTL="$HOME_DIR/loopctl"
+export LOOP_CONTRACT="$HOME_DIR/contract.md"
+export LOOP_VAULT_PATH="$VAULT"
+export VAULT_PATH="$VAULT"
+export LOOP_MACHINE="$MACHINE"
+export CLAUDE_BIN="$ROOT/fake-claude"
+export CODEX_BIN="$ROOT/fake-codex"
+export AGY_BIN=/nonexistent/agy
+export LOOP_EXECUTORS=claude,codex,agy
+export LOOP_QUOTA_FILE="$ROOT/quota/_system/usage/quota.$MACHINE.json"
+export RALPH_TEST_CALLS="$ROOT/calls.log"
+# No usage runtime in the sandbox, so refresh_quota is a no-op and the quota file
+# written above is what both samples read.
+export LOOP_USAGE_RUNTIME="$ROOT/no-such-runtime"
+
+"$LOOPCTL" scan sandbox >/dev/null 2>&1 || echo "  scan failed"
+
+runs_file="$VAULT/_system/usage/loop-runs.$MACHINE.jsonl"
+run_ralph() {
+  : > "$RALPH_TEST_CALLS"
+  rm -f "$runs_file"
+  "$HOME_DIR/ralph.sh" 1 10 >/dev/null 2>&1
+}
+last_run_field() {
+  [ -f "$runs_file" ] || { printf 'NO-RUN-RECORD'; return; }
+  "$VENV/bin/python" - "$runs_file" "$1" <<'PY'
+import json, sys
+rows = [json.loads(l) for l in open(sys.argv[1]) if l.strip()]
+if not rows:
+    print("NO-RUN-RECORD"); raise SystemExit
+value = rows[-1]
+for part in sys.argv[2].split("."):
+    value = (value or {}).get(part) if isinstance(value, dict) else None
+print("" if value is None else value)
+PY
+}
+
+# --- 1. a claude preset reaches the CLI as real flags ------------------------
+echo "  claude preset:"
+cat > "$ROOT/agents.json" <<JSON
+{
+  "default_agent": "claude",
+  "presets": {"deep": {"provider": "claude", "model": "claude-opus-5", "effort": "xhigh"}},
+  "tasks": {"$TASK_KEY": {"preset": "deep"}}
+}
+JSON
+export LOOP_AGENT_CONFIG="$ROOT/agents.json"
+run_ralph
+calls=$(cat "$RALPH_TEST_CALLS")
+contains "claude is told the model" "$calls" -- "--model claude-opus-5"
+contains "claude is told the effort" "$calls" "--effort xhigh"
+check "the run record keeps the model" "$(last_run_field model)" "claude-opus-5"
+check "the run record keeps the effort" "$(last_run_field effort)" "xhigh"
+check "the run record keeps output tokens" "$(last_run_field tokens_out)" "4242"
+
+# --- 2. quota is recorded as fields, with the delta computed -----------------
+echo "  quota fields:"
+check "5h before is a number" "$(last_run_field quota.five_hour_before)" "10.0"
+check "weekly before is a number" "$(last_run_field quota.weekly_before)" "20.0"
+check "5h delta is computed" "$(last_run_field quota.five_hour_delta_pp)" "0.0"
+
+# --- 3. a codex preset uses codex's own flag spelling ------------------------
+echo "  codex preset:"
+cat > "$ROOT/agents.json" <<JSON
+{
+  "default_agent": "claude",
+  "presets": {"trial-terra": {"provider": "codex", "model": "gpt-5.6-terra", "effort": "medium"}},
+  "tasks": {"$TASK_KEY": {"preset": "trial-terra"}}
+}
+JSON
+run_ralph
+calls=$(cat "$RALPH_TEST_CALLS")
+contains "codex ran, not claude" "$calls" "codex "
+contains "codex is told the model" "$calls" "-m gpt-5.6-terra"
+contains "codex effort goes through -c" "$calls" "-c model_reasoning_effort=medium"
+
+# --- 4. no config at all: unchanged behaviour --------------------------------
+# The regression that matters most. A task with no preset must invoke the CLI
+# exactly as before, or every existing task changes behaviour on upgrade.
+echo "  no agent config:"
+unset LOOP_AGENT_CONFIG
+run_ralph
+calls=$(cat "$RALPH_TEST_CALLS")
+contains "claude still runs" "$calls" "claude "
+excludes "no model flag is invented" "$calls" "--model"
+excludes "no effort flag is invented" "$calls" "--effort"
+check "the run record leaves model empty" "$(last_run_field model)" ""
+
+# --- 5. an unknown preset falls back rather than failing ---------------------
+echo "  unknown preset:"
+cat > "$ROOT/agents.json" <<JSON
+{
+  "default_agent": "claude",
+  "presets": {"deep": {"provider": "claude", "model": "claude-opus-5", "effort": "xhigh"}},
+  "tasks": {"$TASK_KEY": {"preset": "no-such-preset"}}
+}
+JSON
+export LOOP_AGENT_CONFIG="$ROOT/agents.json"
+run_ralph
+calls=$(cat "$RALPH_TEST_CALLS")
+contains "claude still runs on an unknown preset" "$calls" "claude "
+excludes "an unknown preset invents no model" "$calls" "--model"
+
+printf '\n  %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ] || exit 1
+rm -rf "$ROOT"


### PR DESCRIPTION
ralph never told either executor which model to use. `run_claude` passed no `--model`, `run_codex` passed no `-m` — so the Observatory's plan card could name `claude-opus-4-8` while the CLI default was Opus 5, and nothing contradicted it. **The card was a label, not a control.**

Pairs with the registry landing in the vault repo (`_system/usage/loop-agents.json`), which both machines already read via `LOOP_AGENT_CONFIG`.

## Preset → model/effort

`preferred_plan` replaces `preferred_executor`, resolving the task's preset into `provider \t model \t effort`. Both executors pass them through:

| executor | flags |
|---|---|
| claude | `--model <m> --effort <e>` |
| codex | `-m <m> -c model_reasoning_effort=<e>` |

Codex has no dedicated effort flag; `-c` sets it and the **server validates** the key — a bogus level returns HTTP 400, so a typo fails loudly rather than being silently ignored. Verified against `codex-cli 0.146.0`.

Resolution happens **at run time**, not at plan-selection time. Renaming a model in the config carries every task forward on its next run without touching a single task note — which is the whole point of the indirection.

### Silence is the safe answer

No agent config, an unknown preset, or a preset naming an unknown provider all fall through to the executor's own defaults — byte-identical to the behaviour before presets existed. Tested explicitly, because every existing task would otherwise change behaviour on upgrade.

## Making the run measurable

Two things were unmeasurable and are no longer:

- **Quota deltas were structurally impossible to observe.** `quota_state` reads the file the *hourly* job rewrites, so a run lasting minutes sampled the same snapshot twice. Every delta recorded up to today is `~0pp` — not because runs are free, but because the measurement could not show anything else. The snapshot is now force-refreshed before and after each iteration.
- **Effort was recorded nowhere** — not the usage ledger, not the run record. "Was xhigh worth it?" could not be answered from own data at all.

`model`, `effort`, `tokens_out` and the quota before/after now land in the run record as **fields**, with the percentage-point delta computed, rather than being formatted into a free-text `note` that only a human could read.

## Testing

`tools/loop/tests/execution-presets.sh` — **17 assertions, 17 passing.** Driven through a real ralph run in a fully isolated sandbox (LOOP_HOME, LOOPCTL, both executor binaries, the machine name, the quota file and the agent config are all redirected) against fake executors that record their exact argv.

Covers: claude flags, codex flags, the run-record fields, the computed quota delta, no-config behaviour, and unknown-preset fallback.

`tools/loop/tests/max-turns-no-fallback.sh` — still **14/14**, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
