### PR TITLE
fix(loop): look preset up by item_id, not the Notion page URL

### DIFF
--- a/tools/loop/engine/ralph.sh
+++ b/tools/loop/engine/ralph.sh
@@ -204,9 +204,9 @@ IFS=',' read -r -a executor_list <<< "$EXECUTORS"
 # preset, or a preset naming an unknown provider all fall through to the
 # executor's own defaults, which is exactly how the loop behaved before presets.
 preferred_plan() {
-  local task_id="$1"
+  local task_id="$1" item_id="${2:-}"
   [ -n "$AGENT_CONFIG" ] && [ -f "$AGENT_CONFIG" ] || return 0
-  "$PYTHON_BIN" - "$AGENT_CONFIG" "$task_id" <<'PY'
+  "$PYTHON_BIN" - "$AGENT_CONFIG" "$task_id" "$item_id" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -215,7 +215,16 @@ PROVIDERS = {"claude", "codex", "agy"}
 
 try:
     document = json.loads(Path(sys.argv[1]).read_text())
-    task = (document.get("tasks") or {}).get(str(sys.argv[2])) or {}
+    tasks = document.get("tasks") or {}
+    # A Notion-sourced task's `id` is its page URL; the human key the greenlight
+    # file and the contract both use is `metadata.item_id` (`AG-132`). Try that
+    # first so the config stays keyed by something a person can read, and fall
+    # back to the raw id for sources that have no item_id (obsidian-base).
+    task = {}
+    for key in (str(sys.argv[3]), str(sys.argv[2])):
+        if key and key in tasks:
+            task = tasks[key] or {}
+            break
     presets = document.get("presets") or {}
     name = task.get("preset") or document.get("default_preset")
     preset = presets.get(name) or {} if name else {}
@@ -258,12 +267,14 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
   fi
 
   next_json=$("$LOOPCTL" next "$slug" 2>/dev/null || printf '[]')
-  task_id=$(printf '%s' "$next_json" | "$PYTHON_BIN" -c \
-    'import json, sys; rows=json.load(sys.stdin); print(rows[0].get("id", "") if rows else "")' 2>/dev/null || printf '')
+  task_pair=$(printf '%s' "$next_json" | "$PYTHON_BIN" -c \
+    'import json, sys; rows=json.load(sys.stdin); row=rows[0] if rows else {}; print("{}\t{}".format(row.get("id") or "", (row.get("metadata") or {}).get("item_id") or ""))' \
+    2>/dev/null || printf '\t')
+  IFS=$'\t' read -r task_id task_item_id <<< "$task_pair"
   # Reset every iteration: a task with no preset must not inherit the previous
   # task's model.
   preferred=""; PLAN_MODEL=""; PLAN_EFFORT=""
-  IFS=$'\t' read -r preferred PLAN_MODEL PLAN_EFFORT <<< "$(preferred_plan "$task_id")"
+  IFS=$'\t' read -r preferred PLAN_MODEL PLAN_EFFORT <<< "$(preferred_plan "$task_id" "${task_item_id:-}")"
   ordered_executors=()
   if [ -n "$preferred" ]; then
     ordered_executors+=("$preferred")

--- a/tools/loop/tests/execution-presets.sh
+++ b/tools/loop/tests/execution-presets.sh
@@ -229,6 +229,43 @@ calls=$(cat "$RALPH_TEST_CALLS")
 contains "claude still runs on an unknown preset" "$calls" "claude "
 excludes "an unknown preset invents no model" "$calls" "--model"
 
+# --- 6. a Notion-shaped task: id is a URL, the config is keyed by item_id -----
+# The near-miss this exists for. A Notion task's `id` is its page URL, while the
+# key a person writes in the config -- and the one the greenlight file and the
+# contract already use -- is `metadata.item_id` (`AG-132`). Looking up by `id`
+# alone matched nothing, so every task silently fell through to default_preset
+# and the whole routing experiment would have run on one model.
+echo "  notion-shaped id:"
+cat > "$ROOT/agents.json" <<'JSON'
+{
+  "default_agent": "claude",
+  "default_preset": "slice",
+  "presets": {
+    "slice": {"provider": "claude", "model": "claude-opus-5", "effort": "high"},
+    "trial-terra": {"provider": "codex", "model": "gpt-5.6-terra", "effort": "medium"}
+  },
+  "tasks": {"AG-132": {"preset": "trial-terra"}}
+}
+JSON
+resolver="$ROOT/resolver.sh"
+awk '/^preferred_plan\(\) \{/,/^\}/' "$HOME_DIR/ralph.sh" > "$resolver"
+resolve() {
+  AGENT_CONFIG="$ROOT/agents.json" PYTHON_BIN="$VENV/bin/python" \
+    bash -c '. "$1"; preferred_plan "$2" "$3"' _ "$resolver" "$2" "$3" | tr '\t' ' '
+}
+url="https://app.notion.com/p/39f0f67c1d0c81aaba20dd126c204cc8"
+check "item_id wins over the url id" "$(resolve _ "$url" AG-132)" "codex gpt-5.6-terra medium"
+check "an unmapped item_id takes the default preset" "$(resolve _ "$url" AG-999)" "claude claude-opus-5 high"
+# A source with no item_id at all (obsidian-base) must still resolve by id.
+cat > "$ROOT/agents.json" <<'JSON'
+{
+  "default_agent": "claude",
+  "presets": {"deep": {"provider": "claude", "model": "claude-opus-5", "effort": "xhigh"}},
+  "tasks": {"_system/tasks/T-1.md": {"preset": "deep"}}
+}
+JSON
+check "id still resolves when there is no item_id" "$(resolve _ "_system/tasks/T-1.md" "")" "claude claude-opus-5 xhigh"
+
 printf '\n  %d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ] || exit 1
 rm -rf "$ROOT"


### PR DESCRIPTION
Follow-up to #273, caught before it did any damage.

The registry in the vault repo is keyed by `AG-132`. `preferred_plan` looked the task up by its `id` — and for a Notion-sourced task that `id` is the **page URL** (`adapters/notion.py` sets `id=str(task_ref)`), while the human key is `metadata.item_id`.

So the lookup matched nothing. Every task fell through to `default_preset`, which means the routing experiment would have quietly run **all twelve tasks on one model** and produced a confident, meaningless result. Worse than a crash, because nothing would have looked wrong.

`AG-132` is also the key the greenlight file and the contract already use (`scan.py` matches greenlight bullets on `metadata.item_id`), so keying the config that way is the consistent choice — the lookup was the thing that was wrong.

## Change

ralph reads both `id` and `metadata.item_id` from `loopctl next`; `preferred_plan` tries item_id first and falls back to the raw id for sources that have none (obsidian-base uses the note path).

## Testing

Three new assertions covering exactly the shape that failed — a URL id resolved against an `AG-`-keyed config — plus the unmapped and no-item_id paths.

- `tools/loop/tests/execution-presets.sh` — **20 passing** (was 17)
- `tools/loop/tests/max-turns-no-fallback.sh` — **14/14**, no regression

Verified afterwards against the real registry: all eleven assigned tasks resolve to their intended model, and both a held task and an unknown one fall back to the conservative default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
