### PR TITLE
Record that both on-device features work in Edge, and how slowly

### DIFF
--- a/apps/personal-website/src/data/blog/web-ai.mdx
+++ b/apps/personal-website/src/data/blog/web-ai.mdx
@@ -55,6 +55,22 @@ plan I started with.
 It also rules out version sniffing. `navigator.userAgent` cannot answer this question. Only feature
 detection can, and it has to be per-feature — three separate probes, three separate answers.
 
+### Present is not the same as working, so I checked
+
+"Present" is a weak claim, so both features were driven end to end in each browser against the live
+site. Both work in both — and Edge is markedly slower:
+
+|                          | Chrome 150 | Edge 150                         |
+| ------------------------ | ---------- | -------------------------------- |
+| Summarize a post         | 5–13s      | **24.8s**                        |
+| Translate a post to 中文 | 3.9s       | **36.5s** (incl. first download) |
+
+The outputs differ in wording, not just timing. Asked for the same three key points, Chrome returned
+"The left and right positions of the indicator are calculated based on…" where Edge returned
+"Calculate indicator left and right positions using…". Different models behind the same API — which
+is itself the useful signal that something real is running, and the reason the stub in the next
+section was so hard to spot.
+
 ## Three failures that do not look like failures
 
 This is the part worth your attention. Each of these cost real debugging time, and none of them


### PR DESCRIPTION
Closes the one gap I'd been flagging as unverified.

The post claimed only that Summarizer and Translator are **"present"** in Edge — a weak claim, and at the time an honest one, because the earlier session never got a summary out of Edge. Its renderer wedged and I said so rather than assuming it worked.

## Retried, and it works

Both features driven end to end in **both** browsers, against the live site:

| | Chrome 150 | Edge 150 |
|---|---|---|
| Summarize a post | 5–13s | **24.8s** |
| Translate a post to 中文 | 3.9s | **36.5s** (incl. first download) |

Edge works and is **2–9× slower**. Code blocks and all three KaTeX nodes survive its translation, same as Chrome.

**The earlier failure was the model still downloading, not a defect.** Once cached, `availability()` reports `available` and both features complete. Worth knowing that Edge's first run is long enough to look broken — which is exactly why the download progress state and the separate download timeout budget (#261) matter there more than in Chrome.

## The detail I think earns its place in the post

The outputs differ in **wording**, not just timing. Same three key points requested:

- Chrome: *"The left and right positions of the indicator are calculated based on…"*
- Edge: *"Calculate indicator left and right positions using…"*

Different models behind one API. That's the signal which distinguishes a real model from the stub described two sections later — the single hardest failure in the whole post to detect, since it resolves successfully and passes every capability check.

Build and format:check pass. Verified in a running dev server per the `CLAUDE.md` rule added in #269, not just against `dist`.

Refs: no-ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)