### PR TITLE
fix(loop): a fallback executor must not inherit another provider's model

### DIFF
--- a/tools/loop/engine/ralph.sh
+++ b/tools/loop/engine/ralph.sh
@@ -275,6 +275,10 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
   # task's model.
   preferred=""; PLAN_MODEL=""; PLAN_EFFORT=""
   IFS=$'\t' read -r preferred PLAN_MODEL PLAN_EFFORT <<< "$(preferred_plan "$task_id" "${task_item_id:-}")"
+  # Kept aside because the executor loop clears PLAN_* for any non-preferred
+  # candidate and needs the originals back if it comes round to the preferred one.
+  plan_model_for_preferred="$PLAN_MODEL"
+  plan_effort_for_preferred="$PLAN_EFFORT"
   ordered_executors=()
   if [ -n "$preferred" ]; then
     ordered_executors+=("$preferred")
@@ -295,6 +299,16 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
   status=1
   provider_rate_limited=0
   for candidate in "${ordered_executors[@]}"; do
+    # A model name belongs to one provider. The preset resolved a model for the
+    # PREFERRED executor, so a fallback to a different provider must drop it --
+    # on 2026-07-30 a codex-routed task fell back to claude still carrying
+    # `--model gpt-5.6-terra`, and claude rejected the model instead of running.
+    # Fallback is a degraded path by definition; it takes the provider's default.
+    if [ "$candidate" = "$preferred" ]; then
+      PLAN_MODEL="$plan_model_for_preferred"; PLAN_EFFORT="$plan_effort_for_preferred"
+    else
+      PLAN_MODEL=""; PLAN_EFFORT=""
+    fi
     sid=$(uuidgen)
     candidate_out=$(run_executor "$candidate" "$slug" "$project_path" "$prompt" "$sid" 2>&1) || candidate_status=$?
     candidate_status=${candidate_status:-0}

--- a/tools/loop/tests/execution-presets.sh
+++ b/tools/loop/tests/execution-presets.sh
@@ -229,6 +229,43 @@ calls=$(cat "$RALPH_TEST_CALLS")
 contains "claude still runs on an unknown preset" "$calls" "claude "
 excludes "an unknown preset invents no model" "$calls" "--model"
 
+# --- 5b. a fallback to another provider must not carry the model with it ------
+# Measured failure, 2026-07-30: a codex-routed task fell back to claude still
+# carrying `--model gpt-5.6-terra`, and claude refused the model rather than
+# running. A model name belongs to one provider.
+echo "  fallback drops the model:"
+cat > "$ROOT/agents.json" <<JSON
+{
+  "default_agent": "claude",
+  "presets": {"trial-terra": {"provider": "codex", "model": "gpt-5.6-terra", "effort": "medium"}},
+  "tasks": {"$TASK_KEY": {"preset": "trial-terra"}}
+}
+JSON
+export LOOP_AGENT_CONFIG="$ROOT/agents.json"
+# codex reports a rate limit, so ralph moves on to claude.
+cat > "$ROOT/fake-codex" <<'FAKE'
+#!/usr/bin/env bash
+printf 'codex %s\n' "$*" >> "$RALPH_TEST_CALLS"
+echo '{"type":"error","message":"rate limit reached"}'
+exit 1
+FAKE
+chmod +x "$ROOT/fake-codex"
+run_ralph
+calls=$(cat "$RALPH_TEST_CALLS")
+contains "codex was tried first, with its model" "$calls" "-m gpt-5.6-terra"
+claude_line=$(printf '%s\n' "$calls" | grep '^claude ' || true)
+check "claude was reached as the fallback" "$([ -n "$claude_line" ] && echo yes || echo no)" "yes"
+excludes "the fallback carries no foreign model" "$claude_line" "gpt-5.6-terra"
+excludes "the fallback carries no effort either" "$claude_line" "--effort"
+# Restore the success-shaped codex for anything after this.
+cat > "$ROOT/fake-codex" <<'FAKE'
+#!/usr/bin/env bash
+printf 'codex %s\n' "$*" >> "$RALPH_TEST_CALLS"
+echo '{"type":"result","subtype":"success","result":"done"}'
+exit 0
+FAKE
+chmod +x "$ROOT/fake-codex"
+
 # --- 6. a Notion-shaped task: id is a URL, the config is keyed by item_id -----
 # The near-miss this exists for. A Notion task's `id` is its page URL, while the
 # key a person writes in the config -- and the one the greenlight file and the


### PR DESCRIPTION
Found by running it. The first real preset run failed on this, 2026-07-30.

AG-132 resolved to `codex` / `gpt-5.6-terra` / `medium`. Codex reported a rate limit, ralph fell back to the next executor — and handed Claude `--model gpt-5.6-terra`:

```
14:25:30  executor=codex rate limited; trying next executor
14:25:34  executor=claude failed (exit=1) · There's an issue with the selected
          model (gpt-5.6-terra). It may not exist or you may not have access to it.
```

The iteration died on a model-name error instead of attempting the work on a provider that was perfectly available.

## Change

A model name belongs to exactly one provider. The preset resolves a model for the **preferred** executor; every other candidate is a degraded path and takes that provider's own default. `PLAN_MODEL` / `PLAN_EFFORT` are now set per candidate inside the executor loop rather than once per task, and restored if the loop reaches the preferred one.

## Testing

Four assertions reproducing the measured sequence: codex rate-limits, claude is reached as the fallback, and the claude invocation carries neither the foreign model nor the effort.

**Confirmed non-vacuous** — with the fix reverted the suite goes red on exactly the right line:

```
FAIL  the fallback carries no foreign model
      got=present: gpt-5.6-terra
      want=absent
```

- `tools/loop/tests/execution-presets.sh` — **24 passing** (was 20)
- `tools/loop/tests/max-turns-no-fallback.sh` — **14/14**, no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)
