### PR TITLE
fix(loop): read rate limits from structured events, and keep executor output

### DIFF
--- a/tools/loop/engine/ralph.sh
+++ b/tools/loop/engine/ralph.sh
@@ -37,8 +37,96 @@ iter=0
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] ralph: $*"; }
 
+# Executor output was read for a cost figure and a verdict line, then dropped. So
+# when the first preset run died on 2026-07-30 there was no way to see what the
+# executor had actually said -- and for codex there is no session either, since
+# `--ephemeral` persists nothing. The log said "rate limited" and that was the
+# entire evidence trail. Keep the output.
+TRANSCRIPTS=${LOOP_TRANSCRIPTS:-"$LOOP_HOME/transcripts"}
+TRANSCRIPT_KEEP=${LOOP_TRANSCRIPT_KEEP:-200}
+
+# Writes one executor's output and echoes the path, or nothing if it cannot.
+# Best-effort throughout: losing a transcript must never fail a run.
+save_transcript() {
+  local executor="$1" body="$2" label="$3"
+  mkdir -p "$TRANSCRIPTS" 2>/dev/null || return 0
+  local safe
+  safe=$(printf '%s' "${label:-task}" | tr -c 'A-Za-z0-9._-' '-' | cut -c1-48)
+  local path="$TRANSCRIPTS/$(date '+%Y%m%dT%H%M%S')-$MACHINE-$executor-$safe.log"
+  printf '%s' "$body" > "$path" 2>/dev/null || return 0
+  # Bounded so an unattended loop cannot fill the disk with transcripts.
+  ls -1t "$TRANSCRIPTS"/*.log 2>/dev/null | tail -n +"$((TRANSCRIPT_KEEP + 1))" |
+    while IFS= read -r stale; do rm -f "$stale"; done
+  printf '%s' "$path"
+}
+
+# The harness's own error text from an executor's output — never the model's prose.
+#
+# Grepping the whole blob was a live bug: this contract instructs the executor to
+# "rely on the outer runner's rate-limit handling", so an executor that reported
+# following its instructions was read as the provider rate-limiting us. On
+# 2026-07-30 that killed the first preset run and sent a codex task to claude
+# carrying codex's model name. What the model *says* is not provider state.
+#
+# Codex emits newline-delimited events; only `item.type == "error"` messages and
+# failed-turn payloads are the harness speaking. Claude emits one result object;
+# only its `subtype`/`result` when `is_error`. Anything that is not JSON at all
+# (agy prints plain text) falls back to the whole output, since there is no
+# envelope to read and a real message would be in there.
+executor_error_text() {
+  printf '%s' "$1" | "$PYTHON_BIN" -c '
+import json, sys
+
+raw = sys.stdin.read()
+parts = []
+saw_json = False
+
+# Both readings run over the same bytes and the results are unioned, rather than
+# choosing one by shape. A single-line codex event parses as one JSON object, so
+# "parses as a dict" cannot mean "this is claude" -- deciding that way silently
+# dropped genuine codex rate-limit errors. Each reading finds nothing in the
+# other format, so the union is safe.
+
+# Claude: one result object, and only when it says it failed.
+try:
+    doc = json.loads(raw)
+except ValueError:
+    doc = None
+if isinstance(doc, dict):
+    saw_json = True
+    if doc.get("is_error") or str(doc.get("subtype") or "").startswith("error"):
+        for key in ("subtype", "result", "error", "message"):
+            value = doc.get(key)
+            if isinstance(value, str):
+                parts.append(value)
+
+# Codex: newline-delimited events; the harness speaks through error items and
+# failed turns. `agent_message` items are the model talking and are never read.
+for line in raw.splitlines():
+    line = line.strip()
+    if not line.startswith("{"):
+        continue
+    try:
+        event = json.loads(line)
+    except ValueError:
+        continue
+    saw_json = True
+    kind = str(event.get("type") or "")
+    item = event.get("item") if isinstance(event.get("item"), dict) else {}
+    if str(item.get("type") or "") == "error":
+        parts.append(str(item.get("message") or ""))
+    if "failed" in kind or kind.endswith("error"):
+        for key in ("message", "error", "reason"):
+            value = event.get(key)
+            if isinstance(value, str):
+                parts.append(value)
+
+print("\n".join(parts) if saw_json else raw)
+' 2>/dev/null || printf '%s' "$1"
+}
+
 rate_limited() {
-  printf '%s' "$1" |
+  executor_error_text "$1" |
     grep -qiE 'rate.?limit|too many requests|(usage|weekly|5-?hour|daily)[ -]?limit|quota (exceeded|reached|limit)'
 }
 
@@ -312,6 +400,8 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
     sid=$(uuidgen)
     candidate_out=$(run_executor "$candidate" "$slug" "$project_path" "$prompt" "$sid" 2>&1) || candidate_status=$?
     candidate_status=${candidate_status:-0}
+    transcript=$(save_transcript "$candidate" "$candidate_out" "${task_item_id:-$slug}")
+    [ -n "$transcript" ] && log "  transcript · $transcript"
     if [ "$candidate_status" -eq 127 ]; then
       log "executor=$candidate unavailable; trying next executor"
       unset candidate_status

--- a/tools/loop/tests/execution-presets.sh
+++ b/tools/loop/tests/execution-presets.sh
@@ -181,6 +181,18 @@ check "the run record keeps the model" "$(last_run_field model)" "claude-opus-5"
 check "the run record keeps the effort" "$(last_run_field effort)" "xhigh"
 check "the run record keeps output tokens" "$(last_run_field tokens_out)" "4242"
 
+# The executor's output used to be read for a cost figure and then dropped, so a
+# failed run left no evidence at all — and codex keeps no session either, since
+# ralph runs it with --ephemeral.
+transcripts=$(ls -1 "$HOME_DIR/transcripts"/*.log 2>/dev/null | wc -l | tr -d ' ')
+check "the executor output is kept" "$([ "${transcripts:-0}" -ge 1 ] && echo yes || echo no)" "yes"
+newest=$(ls -1t "$HOME_DIR/transcripts"/*.log 2>/dev/null | head -1)
+contains "the transcript holds what the executor said" "$(cat "$newest" 2>/dev/null)" "4242"
+case "$(basename "${newest:-}")" in
+  *-claude-*) check "the transcript names the executor" yes yes ;;
+  *) check "the transcript names the executor" "$(basename "${newest:-none}")" "…-claude-…" ;;
+esac
+
 # --- 2. quota is recorded as fields, with the delta computed -----------------
 echo "  quota fields:"
 check "5h before is a number" "$(last_run_field quota.five_hour_before)" "10.0"

--- a/tools/loop/tests/rate-limit-detection.sh
+++ b/tools/loop/tests/rate-limit-detection.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Does ralph tell a provider rate-limiting us apart from an executor merely
+# talking about rate limits?
+#
+# It did not, and it cost the first preset run. `rate_limited()` grepped the whole
+# executor output, and this contract instructs the executor to "rely on the outer
+# runner's rate-limit handling" -- so an executor reporting that it followed its
+# instructions was read as a provider rate limit. ralph then fell back to another
+# provider and the run died on a model-name error.
+#
+# A pure unit test: the two functions are extracted from the engine under review
+# and driven directly, so it needs no sandbox, no executors and no network.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENGINE=${LOOP_TEST_ENGINE:-"$HERE/../engine"}
+VENV=${LOOP_TEST_VENV:-"$HOME/.claude/loop/.venv"}
+
+[ -f "$ENGINE/ralph.sh" ] || { echo "engine not found at $ENGINE"; exit 2; }
+[ -x "$VENV/bin/python" ] || { echo "no venv at $VENV — set LOOP_TEST_VENV"; exit 2; }
+
+export PYTHON_BIN="$VENV/bin/python"
+LIB=$(mktemp /tmp/ralph-ratelimit-lib-XXXXXX.sh)
+trap 'rm -f "$LIB"' EXIT
+awk '/^executor_error_text\(\) \{/,/^}/' "$ENGINE/ralph.sh" >  "$LIB"
+awk '/^rate_limited\(\) \{/,/^}/'        "$ENGINE/ralph.sh" >> "$LIB"
+# shellcheck disable=SC1090
+. "$LIB"
+
+# Assert the harness itself loaded. Without this the suite reports a cheerful row
+# of passes when the functions are missing: every call fails, every result reads
+# as "not limited", and every open-expecting case passes for the wrong reason.
+for fn in executor_error_text rate_limited; do
+  type "$fn" >/dev/null 2>&1 || {
+    echo "FATAL: $fn did not load from $ENGINE/ralph.sh — the suite would pass vacuously"
+    exit 2
+  }
+done
+
+pass=0; fail=0
+expect() { # expect <name> <limited|open> <payload>
+  local want="$2" got
+  if rate_limited "$3"; then got=limited; else got=open; fi
+  if [ "$got" = "$want" ]; then pass=$((pass+1)); printf '  PASS  %s\n' "$1"
+  else fail=$((fail+1)); printf '  FAIL  %s\n        got=%s want=%s\n' "$1" "$got" "$want"; fi
+}
+
+echo "  the model talking is never provider state:"
+# The exact shape that killed the run on 2026-07-30.
+expect "codex agent prose quoting the contract" open '{"type":"thread.started","thread_id":"x"}
+{"type":"item.completed","item":{"id":"i0","type":"agent_message","text":"Done. I relied on the outer runner rate-limit handling as the contract asks."}}
+{"type":"turn.completed","usage":{"output_tokens":9}}'
+expect "claude result mentioning rate limits" open \
+  '{"type":"result","subtype":"success","is_error":false,"result":"I noted the rate-limit handling in the contract."}'
+# A real warning observed from codex, 2026-07-30. Contains "budget"; not a limit.
+expect "codex skills-budget warning" open \
+  '{"type":"item.completed","item":{"id":"i0","type":"error","message":"Skill descriptions were shortened to fit the 2% skills context budget."}}'
+expect "turn limit is not a rate limit" open \
+  '{"type":"result","subtype":"error_max_turns","is_error":true,"result":null}'
+
+echo "  a real limit is still caught:"
+# Single-line codex output parses as one JSON object. Routing by "parses as a
+# dict" therefore read it as claude, found no is_error, and missed the limit --
+# a false negative, which is worse: the loop would treat it as a hard failure.
+expect "codex error item, single line" limited \
+  '{"type":"item.completed","item":{"id":"i0","type":"error","message":"You have hit your rate limit. Try again later."}}'
+expect "codex failed turn among agent output" limited '{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"i0","type":"agent_message","text":"working"}}
+{"type":"turn.failed","message":"usage limit reached for this week"}'
+expect "claude error result" limited \
+  '{"type":"result","subtype":"error_rate_limit","is_error":true,"result":"5-hour limit reached"}'
+expect "quota wording" limited \
+  '{"type":"item.completed","item":{"id":"i0","type":"error","message":"quota exceeded"}}'
+
+echo "  non-JSON executors keep the old behaviour:"
+# agy prints plain text, so there is no envelope to read and the whole output is
+# all there is. Narrowing must not make these blind.
+expect "agy plain-text limit" limited 'error: too many requests, back off'
+expect "agy plain-text success" open 'wrote three files and committed'
+expect "empty output" open ''
+
+printf '\n  %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
Diagnosis of the first preset run's failure. **Codex was never rate limited** — verified afterwards with the same model and flags, exit 0.

`rate_limited()` grepped the executor's *entire* output for rate-limit wording. This contract instructs the executor to "rely on the outer runner's rate-limit handling" — so an executor reporting that it followed its instructions reads as the provider rate-limiting us:

```
$ printf "I relied on the outer runner's rate-limit handling." | <the old detector>
→ RATE LIMITED
```

That is what happened: codex said it had honoured the contract, ralph concluded codex was limited, fell back to claude, and the run died on a model-name error (fixed separately in #276). **What the model says is not provider state.**

## Only the harness speaks

| executor | read | never read |
|---|---|---|
| codex | `item.type == "error"` messages, failed-turn payloads | `agent_message` items |
| claude | `subtype` / `result` when `is_error` | the assistant's text |
| agy | the whole output — plain text, no envelope to read | — |

Both readings run over the same bytes and are **unioned**, not chosen by shape. Routing by "parses as a dict" read single-line codex output as claude and missed genuine codex rate limits — a false negative, and worse than the original bug: the loop would treat a real limit as a hard failure instead of backing off.

## Executor output is no longer discarded

It was read for a cost figure and a verdict line, then dropped — so a failed run left no evidence at all. For codex there is no session either, since ralph runs it with `--ephemeral`. Each run now writes `$LOOP_HOME/transcripts/<ts>-<machine>-<executor>-<task>.log`, capped at the most recent 200.

## Testing

New `tools/loop/tests/rate-limit-detection.sh` — 11 assertions over real shapes, including the codex skills-budget warning observed today (contains "budget", is not a limit) and the exact prose that caused the failure.

The suite **asserts its own functions loaded**. Without that guard a load failure reports a cheerful row of passes: every call errors, every result reads as "not limited", and every open-expecting case passes for the wrong reason — which is exactly what the first draft of this suite did.

**Verified non-vacuous** against a copy of the engine reverted to the old behaviour:

```
FAIL  codex agent prose quoting the contract
      got=limited want=open
FAIL  claude result mentioning rate limits
      got=limited want=open
```

- `rate-limit-detection.sh` — 11 passing
- `execution-presets.sh` — 27 passing (was 24; adds the transcript assertions)
- `max-turns-no-fallback.sh` — 14/14, no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)
