### PR TITLE
fix(loop): give codex the LOOP_HOME grant claude already had

### DIFF
--- a/tools/loop/engine/ralph.sh
+++ b/tools/loop/engine/ralph.sh
@@ -255,9 +255,14 @@ run_codex() {
   local opts=()
   [ -n "$PLAN_MODEL" ] && opts+=(-m "$PLAN_MODEL")
   [ -n "$PLAN_EFFORT" ] && opts+=(-c "model_reasoning_effort=$PLAN_EFFORT")
+  # --add-dir for the same reason claude has had it since 2026-07-29: the sandbox
+  # confines writes to project_path, but the contract and loopctl live in
+  # LOOP_HOME and `loopctl scan` needs to take a lock there. Without it codex
+  # cannot scan its own queue -- measured 2026-07-30, `scan` exited 2 on a lock
+  # it could not create, and the executor correctly refused to start work.
   (cd "$project_path" && printf '%s' "$prompt" | LOOP_PROJECT="$slug" LOOP_EXECUTOR=codex \
     LOOP_QUOTA_MODE="${QUOTA_MODE:-ok}" "$CODEX_BIN" exec \
-    ${opts[@]+"${opts[@]}"} \
+    ${opts[@]+"${opts[@]}"} --add-dir "$LOOP_HOME" \
     --json --ephemeral --sandbox workspace-write -C "$project_path" -)
 }
 

--- a/tools/loop/tests/execution-presets.sh
+++ b/tools/loop/tests/execution-presets.sh
@@ -213,6 +213,10 @@ calls=$(cat "$RALPH_TEST_CALLS")
 contains "codex ran, not claude" "$calls" "codex "
 contains "codex is told the model" "$calls" "-m gpt-5.6-terra"
 contains "codex effort goes through -c" "$calls" "-c model_reasoning_effort=medium"
+# Measured 2026-07-30: without this, `loopctl scan` inside the codex sandbox
+# exits 2 on a lock it cannot create in LOOP_HOME, and the executor correctly
+# refuses to start work. claude has had the same grant since 2026-07-29.
+contains "codex can reach LOOP_HOME" "$calls" "--add-dir $HOME_DIR"
 
 # --- 4. no config at all: unchanged behaviour --------------------------------
 # The regression that matters most. A task with no preset must invoke the CLI


### PR DESCRIPTION
`run_claude` has passed `--add-dir "$LOOP_HOME"` since 2026-07-29 — the sandbox confines writes to `project_path`, but the contract and `loopctl` live in `LOOP_HOME`. `run_codex` never got the same grant. The omission only became visible once a task was actually routed to codex.

Measured 2026-07-30 on AG-132:

```
loopctl scan → exit 2   (could not create the loop lock inside the sandbox)
```

The executor then did the right thing — refused to start work on a queue it could not scan, and claimed nothing:

> 已停止，未 claim 或修改任何 task／程式碼。

From outside, the run looked like `(executor returned no result text)`. The kept transcript is what turned that into a diagnosis; before this session's transcript change there would have been no evidence at all.

codex spells the flag the same way claude does, so this is one flag.

## Testing

Asserted in `execution-presets.sh`, and confirmed to red without the change:

```
FAIL  codex can reach LOOP_HOME
      got=missing: --add-dir …/loop-home
```

- `execution-presets.sh` — 28 passing
- `rate-limit-detection.sh` — 11 passing
- `max-turns-no-fallback.sh` — 14/14

🤖 Generated with [Claude Code](https://claude.com/claude-code)
