### PR TITLE
fix(loop): let the sandboxed codex executor reach the network

### DIFF
--- a/tools/loop/engine/ralph.sh
+++ b/tools/loop/engine/ralph.sh
@@ -260,9 +260,22 @@ run_codex() {
   # LOOP_HOME and `loopctl scan` needs to take a lock there. Without it codex
   # cannot scan its own queue -- measured 2026-07-30, `scan` exited 2 on a lock
   # it could not create, and the executor correctly refused to start work.
+  #
+  # The network grant, because workspace-write denies the network and every signal
+  # the loop turns on crosses it: `loopctl scan` resolves a task's PR with
+  # `gh pr list`, which fails inside the sandbox, marking the registry stale -- and
+  # a stale registry is a full stop under the contract. Measured 2026-07-30: three
+  # AG-132 runs ended exactly there, the executor refusing correctly each time.
+  # Pushing a branch and opening the PR need the network too, so without this no
+  # codex task could ever finish, while claude -- which runs under no OS sandbox at
+  # all -- was unaffected. Scoped to loop runs rather than config.toml, and narrower
+  # than danger-full-access: probed with `codex sandbox`, a write outside
+  # project_path is still "Operation not permitted" with the grant applied. Inert
+  # unless the mode is workspace-write, which --sandbox sets below.
   (cd "$project_path" && printf '%s' "$prompt" | LOOP_PROJECT="$slug" LOOP_EXECUTOR=codex \
     LOOP_QUOTA_MODE="${QUOTA_MODE:-ok}" "$CODEX_BIN" exec \
     ${opts[@]+"${opts[@]}"} --add-dir "$LOOP_HOME" \
+    -c sandbox_workspace_write.network_access=true \
     --json --ephemeral --sandbox workspace-write -C "$project_path" -)
 }
 

--- a/tools/loop/tests/execution-presets.sh
+++ b/tools/loop/tests/execution-presets.sh
@@ -217,6 +217,11 @@ contains "codex effort goes through -c" "$calls" "-c model_reasoning_effort=medi
 # exits 2 on a lock it cannot create in LOOP_HOME, and the executor correctly
 # refuses to start work. claude has had the same grant since 2026-07-29.
 contains "codex can reach LOOP_HOME" "$calls" "--add-dir $HOME_DIR"
+# Measured 2026-07-30, three AG-132 runs: workspace-write denies the network, so
+# `loopctl scan` could not resolve the task's PR with `gh pr list`, the registry
+# read stale, and the contract stopped the run. Pushing the branch needs it too.
+contains "codex can reach the network" "$calls" \
+  "-c sandbox_workspace_write.network_access=true"
 
 # --- 4. no config at all: unchanged behaviour --------------------------------
 # The regression that matters most. A task with no preset must invoke the CLI


### PR DESCRIPTION
## Why

Three AG-132 runs on 2026-07-30 ended identically: `loopctl scan` reported the registry stale and the codex executor correctly refused to start work. Not the model, not the gh account, not the project path — codex runs under `--sandbox workspace-write`, which denies network access, so the `gh pr list` in `signals.pr_for_branch()` could not reach api.github.com. A stale registry is a full stop under the contract, so the executor was right every time.

Pushing a branch and opening a PR need the network too, so **no codex task could ever have finished**. This blocked the whole Terra/Luna/Sol preset experiment, not just the scan.

## Evidence

Probed with `codex sandbox` — no model invocation, so no quota spent:

| probe | result |
|---|---|
| default, as ralph ran it | `gh` cannot reach api.github.com |
| no sandbox (control) | returns PR 2416 |
| `sandbox_permissions=["network-full-access"]` | fails — not this version's shape |
| `sandbox_mode=danger-full-access` | succeeds, but far too wide |
| `workspace-write` + `sandbox_workspace_write.network_access=true` | succeeds |
| ↑ same flags, write outside the workspace | `Operation not permitted` |
| ↑ same flags, write inside the workspace | succeeds |

The grant is targeted: the network opens and write confinement does not move.

## Scope

Passed in `run_codex`'s argv, not written to `~/.codex/config.toml` — it covers loop runs only and leaves interactive codex untouched. `run_claude` already ran under no OS sandbox at all, so this brings codex to parity rather than past it. The flag is inert unless the mode is `workspace-write`, which `--sandbox` sets on the same line.

## Tests

`tools/loop/tests/execution-presets.sh` — 29 passed, 0 failed (new: "codex can reach the network").
`tools/loop/tests/rate-limit-detection.sh` — 11 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
