### PR TITLE
fix(loop): count codex output tokens, and keep one partition per host

### DIFF
--- a/tools/loop/engine/lib/loopctl/scan.py
+++ b/tools/loop/engine/lib/loopctl/scan.py
@@ -160,6 +160,11 @@ def _now() -> int:
     return int(time.time())
 
 
+def _host_machine() -> str:
+    """The one name this host's telemetry is filed under."""
+    return os.environ.get("LOOP_MACHINE") or os.uname().nodename
+
+
 def _load(path: Path):
     return load_config(path)
 
@@ -551,7 +556,7 @@ def _build_parser() -> argparse.ArgumentParser:
     run_parser.add_argument("--project", required=True)
     run_parser.add_argument("--task", required=True)
     run_parser.add_argument("--executor", required=True)
-    run_parser.add_argument("--machine", default=os.environ.get("LOOP_MACHINE") or os.uname().nodename)
+    run_parser.add_argument("--machine", default=_host_machine())
     run_parser.add_argument("--cost", default="0")
     run_parser.add_argument("--status", default="completed")
     run_parser.add_argument("--note")
@@ -623,6 +628,19 @@ def main(argv=None) -> int:
             return 0
 
         if args.cmd == "record-run":
+            # The machine name picks the file the row lands in, so a free-form
+            # value silently forks the telemetry rather than failing. On
+            # 2026-07-30 an executor passed the macOS display name, "Angible's
+            # MacBook Air", and its iteration row went to a second partition
+            # beside the real one -- same run, same host, two files, neither
+            # complete. A host records under one name only; wanting another
+            # means setting LOOP_MACHINE, not passing a string.
+            if args.machine != _host_machine():
+                raise ValueError(
+                    f"record-run --machine {args.machine!r} is not this host; "
+                    f"it records as {_host_machine()!r} "
+                    "(set LOOP_MACHINE to change that)"
+                )
             _print_json(
                 append_run(
                     project=args.project,

--- a/tools/loop/engine/ralph.sh
+++ b/tools/loop/engine/ralph.sh
@@ -130,6 +130,55 @@ rate_limited() {
     grep -qiE 'rate.?limit|too many requests|(usage|weekly|5-?hour|daily)[ -]?limit|quota (exceeded|reached|limit)'
 }
 
+# Output tokens for one run, or nothing when the output does not say.
+#
+# Same two-reading shape as executor_error_text, and for the same reason: reading
+# the blob as one JSON object is claude's envelope, and codex's newline-delimited
+# events make that parse fail, so every codex run recorded tokens_out as null --
+# the 3,208 output tokens of the 2026-07-30 AG-132 run existed only in its
+# transcript. Codex can report several turns, so they are summed. Its
+# `reasoning_output_tokens` is left out: whether it is already inside
+# `output_tokens` is not documented, and double-counting would be worse than
+# under-reporting a field used for cost-per-run comparisons.
+executor_tokens_out() {
+  printf '%s' "$1" | "$PYTHON_BIN" -c '
+import json, sys
+
+raw = sys.stdin.read()
+total = 0
+found = False
+
+# Claude: one result object carrying one usage block.
+try:
+    doc = json.loads(raw)
+except ValueError:
+    doc = None
+if isinstance(doc, dict):
+    value = (doc.get("usage") or {}).get("output_tokens")
+    if isinstance(value, int):
+        total += value
+        found = True
+
+# Codex: one usage block per completed turn.
+for line in raw.splitlines():
+    line = line.strip()
+    if not line.startswith("{"):
+        continue
+    try:
+        event = json.loads(line)
+    except ValueError:
+        continue
+    if str(event.get("type") or "") != "turn.completed":
+        continue
+    value = (event.get("usage") or {}).get("output_tokens")
+    if isinstance(value, int):
+        total += value
+        found = True
+
+print(total if found else "")
+' 2>/dev/null || printf ''
+}
+
 [ -x "$LOOPCTL" ] || { log "loopctl missing at $LOOPCTL; run obsidian-setup"; exit 1; }
 [ -f "$CONTRACT" ] || { log "contract missing at $CONTRACT; run obsidian-setup"; exit 1; }
 [ -x "$PYTHON_BIN" ] || PYTHON_BIN=$(command -v python3)
@@ -519,9 +568,7 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
   SPENT=$("$PYTHON_BIN" -c \
     'from decimal import Decimal; import sys; print(Decimal(sys.argv[1]) + Decimal(sys.argv[2]))' \
     "$SPENT" "$cost")
-  tokens_out=$(printf '%s' "$out" | "$PYTHON_BIN" -c \
-    'import json, sys; data=sys.stdin.read(); print((json.loads(data).get("usage") or {}).get("output_tokens", "") if data.strip() else "")' \
-    2>/dev/null || printf '')
+  tokens_out=$(executor_tokens_out "$out")
   refresh_quota
   IFS=$'\t' read -r _ pct5_after pctw_after <<< "$(quota_state)"
   d5=$(pct_delta "$pct5_before" "$pct5_after")

--- a/tools/loop/tests/execution-presets.sh
+++ b/tools/loop/tests/execution-presets.sh
@@ -109,10 +109,17 @@ printf 'claude %s\n' "$*" >> "$RALPH_TEST_CALLS"
 echo '{"type":"result","subtype":"success","total_cost_usd":0.5,"usage":{"output_tokens":4242},"result":"done"}'
 exit 0
 FAKE
+# Codex speaks newline-delimited events, not claude's single result object. The
+# fake used to emit claude's shape, which is why nothing caught that ralph read
+# output tokens with one `json.loads` of the whole blob -- a parse that fails on
+# every real codex run.
 cat > "$ROOT/fake-codex" <<'FAKE'
 #!/usr/bin/env bash
 printf 'codex %s\n' "$*" >> "$RALPH_TEST_CALLS"
-echo '{"type":"result","subtype":"success","result":"done"}'
+echo '{"type":"thread.started","thread_id":"t-1"}'
+echo '{"type":"turn.started"}'
+echo '{"type":"item.completed","item":{"id":"i-1","type":"agent_message","text":"done"}}'
+echo '{"type":"turn.completed","usage":{"input_tokens":1000,"cached_input_tokens":800,"output_tokens":777,"reasoning_output_tokens":123}}'
 exit 0
 FAKE
 chmod +x "$ROOT/fake-claude" "$ROOT/fake-codex"
@@ -222,6 +229,10 @@ contains "codex can reach LOOP_HOME" "$calls" "--add-dir $HOME_DIR"
 # read stale, and the contract stopped the run. Pushing the branch needs it too.
 contains "codex can reach the network" "$calls" \
   "-c sandbox_workspace_write.network_access=true"
+# Measured 2026-07-30: every codex run recorded tokens_out as null, because the
+# reader parsed the whole blob as claude's single result object. `reasoning` is
+# deliberately not added in -- see executor_tokens_out.
+check "the run record keeps codex output tokens" "$(last_run_field tokens_out)" "777"
 
 # --- 4. no config at all: unchanged behaviour --------------------------------
 # The regression that matters most. A task with no preset must invoke the CLI
@@ -282,7 +293,7 @@ excludes "the fallback carries no effort either" "$claude_line" "--effort"
 cat > "$ROOT/fake-codex" <<'FAKE'
 #!/usr/bin/env bash
 printf 'codex %s\n' "$*" >> "$RALPH_TEST_CALLS"
-echo '{"type":"result","subtype":"success","result":"done"}'
+echo '{"type":"turn.completed","usage":{"output_tokens":777}}'
 exit 0
 FAKE
 chmod +x "$ROOT/fake-codex"
@@ -323,6 +334,25 @@ cat > "$ROOT/agents.json" <<'JSON'
 }
 JSON
 check "id still resolves when there is no item_id" "$(resolve _ "_system/tasks/T-1.md" "")" "claude claude-opus-5 xhigh"
+
+# --- 7. one host, one telemetry partition ------------------------------------
+# On 2026-07-30 an executor recorded its own iteration row with
+# `--machine "Angible's MacBook Air"` -- the macOS display name, not the host
+# name -- and the row landed in a second .jsonl beside the real one. Same run,
+# same host, two files, neither complete. The name picks the file, so a
+# free-form value has to fail rather than fork the data.
+echo "  one machine, one partition:"
+before=$(ls "$VAULT/_system/usage/" | wc -l | tr -d ' ')
+bogus_out=$("$LOOPCTL" record-run --project sandbox --task "$TASK_KEY" \
+  --executor codex --machine "Some Laptop’s Display Name" 2>&1)
+check "a foreign machine name is refused" "$?" "2"
+contains "the error names this host" "$bogus_out" "$MACHINE"
+after=$(ls "$VAULT/_system/usage/" | wc -l | tr -d ' ')
+check "no second partition was created" "$after" "$before"
+# The host's own name still works, or the guard would have broken recording.
+"$LOOPCTL" record-run --project sandbox --task "$TASK_KEY" \
+  --executor codex --machine "$MACHINE" >/dev/null 2>&1
+check "this host's own name still records" "$?" "0"
 
 printf '\n  %d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
Two gaps the 2026-07-30 AG-132 run exposed. Both quietly corrupt the telemetry the model-routing experiment exists to produce, which is why they are worth fixing before collecting more data points rather than after.

## 1. `tokens_out` was null on every codex run

The reader parsed the whole executor blob with one `json.loads` and took `usage.output_tokens` — claude's envelope. Codex emits newline-delimited events, so the parse failed and the field went empty. That run's **3,208 output tokens existed only in the transcript**.

`executor_tokens_out` now unions the two readings — the same shape, and for the same reason, as `executor_error_text` — and sums codex's per-turn usage.

`reasoning_output_tokens` is deliberately excluded: whether it already sits inside `output_tokens` is undocumented, and double-counting is worse than under-reporting a field whose only job is comparing cost per run.

## 2. `record-run` accepted any `--machine` string

The machine name picks which `.jsonl` the row lands in, so a wrong value forks the data instead of failing. The executor passed the macOS *display* name, `Angible's MacBook Air`, and its iteration row went to a second partition beside the real one — same run, same host, two files, neither complete.

A host now records under one name only. Wanting another means setting `LOOP_MACHINE`, not passing a string. The check raises at the CLI boundary and exits 2 with the host's actual name in the message.

## Why the tests missed the token bug

The codex fake in the preset suite emitted **claude's** shape. It now speaks events, so the codex path is exercised for real.

| suite | before | after |
|---|---|---|
| `execution-presets.sh` | 29 passed | **34 passed**, 0 failed |
| `rate-limit-detection.sh` | 11 passed | **11 passed**, 0 failed |

New assertions: the codex token count, and all four sides of the machine guard — a foreign name is refused, the error names this host, no second partition appears, and the host's own name still records.

## Left alone on purpose

The stray partition from that run stays where it is: it is gitignored, nothing in the repo reads it, and folding a backdated row into an append-only log would be worse than leaving one misfiled file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
