### PR TITLE
fix(loop): stop discarding codex sessions

### DIFF
--- a/tools/loop/engine/ralph.sh
+++ b/tools/loop/engine/ralph.sh
@@ -39,9 +39,10 @@ log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] ralph: $*"; }
 
 # Executor output was read for a cost figure and a verdict line, then dropped. So
 # when the first preset run died on 2026-07-30 there was no way to see what the
-# executor had actually said -- and for codex there is no session either, since
-# `--ephemeral` persists nothing. The log said "rate limited" and that was the
-# entire evidence trail. Keep the output.
+# executor had actually said -- and codex kept no session either, because it still
+# ran with `--ephemeral` then. The log said "rate limited" and that was the entire
+# evidence trail. Keep the output. Transcripts stay the primary record even now
+# that codex sessions persist: they cover every executor, and they are pruned.
 TRANSCRIPTS=${LOOP_TRANSCRIPTS:-"$LOOP_HOME/transcripts"}
 TRANSCRIPT_KEEP=${LOOP_TRANSCRIPT_KEEP:-200}
 
@@ -304,6 +305,13 @@ run_codex() {
   local opts=()
   [ -n "$PLAN_MODEL" ] && opts+=(-m "$PLAN_MODEL")
   [ -n "$PLAN_EFFORT" ] && opts+=(-c "model_reasoning_effort=$PLAN_EFFORT")
+  # No --ephemeral: it kept nothing on disk, which cost a reviewable session for
+  # no gain once transcripts were being saved. Dropped 2026-07-30 so a loop run
+  # can be reopened with `codex resume` and read in the ChatGPT app, where the
+  # reasoning is legible in a way a JSON event stream is not. The cost is one
+  # session file per run under ~/.codex/sessions -- unbounded, unlike transcripts,
+  # which prune to TRANSCRIPT_KEEP.
+  #
   # --add-dir for the same reason claude has had it since 2026-07-29: the sandbox
   # confines writes to project_path, but the contract and loopctl live in
   # LOOP_HOME and `loopctl scan` needs to take a lock there. Without it codex
@@ -325,7 +333,7 @@ run_codex() {
     LOOP_QUOTA_MODE="${QUOTA_MODE:-ok}" "$CODEX_BIN" exec \
     ${opts[@]+"${opts[@]}"} --add-dir "$LOOP_HOME" \
     -c sandbox_workspace_write.network_access=true \
-    --json --ephemeral --sandbox workspace-write -C "$project_path" -)
+    --json --sandbox workspace-write -C "$project_path" -)
 }
 
 run_agy() {

--- a/tools/loop/tests/execution-presets.sh
+++ b/tools/loop/tests/execution-presets.sh
@@ -189,8 +189,9 @@ check "the run record keeps the effort" "$(last_run_field effort)" "xhigh"
 check "the run record keeps output tokens" "$(last_run_field tokens_out)" "4242"
 
 # The executor's output used to be read for a cost figure and then dropped, so a
-# failed run left no evidence at all — and codex keeps no session either, since
-# ralph runs it with --ephemeral.
+# failed run left no evidence at all — and codex kept no session either, because
+# it still ran with --ephemeral then. Transcripts remain the primary record: they
+# cover every executor, and unlike codex sessions they are pruned.
 transcripts=$(ls -1 "$HOME_DIR/transcripts"/*.log 2>/dev/null | wc -l | tr -d ' ')
 check "the executor output is kept" "$([ "${transcripts:-0}" -ge 1 ] && echo yes || echo no)" "yes"
 newest=$(ls -1t "$HOME_DIR/transcripts"/*.log 2>/dev/null | head -1)
@@ -233,6 +234,10 @@ contains "codex can reach the network" "$calls" \
 # reader parsed the whole blob as claude's single result object. `reasoning` is
 # deliberately not added in -- see executor_tokens_out.
 check "the run record keeps codex output tokens" "$(last_run_field tokens_out)" "777"
+# Dropped 2026-07-30 so a loop run is reopenable with `codex resume` and visible
+# in the ChatGPT app. It is one word, easy to reinstate by reflex, and doing so
+# would silently take that back.
+excludes "codex sessions are not thrown away" "$calls" "--ephemeral"
 
 # --- 4. no config at all: unchanged behaviour --------------------------------
 # The regression that matters most. A task with no preset must invoke the CLI


### PR DESCRIPTION
## Why

`--ephemeral` kept nothing on disk, so a loop run could not be reopened with `codex resume` and never appeared in the ChatGPT app.

That was the right trade when the executor's output was *also* being thrown away — neither could be audited, and at least nothing lingered. Transcripts have since made the output durable, which leaves `--ephemeral` costing a reviewable session for no gain. A JSON event stream is a poor substitute for reading the reasoning in the app.

## What stays the primary record

Transcripts, not sessions. They cover **every** executor rather than just codex, and they prune to `TRANSCRIPT_KEEP`.

## The cost, stated plainly

One session file per run under `~/.codex/sessions`, which nothing prunes. That directory is already 585 MB from interactive use, so loop runs are not what will fill it — but this change does add to it, and no pruning ships here.

## Guard

The suite now asserts `--ephemeral` is absent from codex's argv. It is one word, easy to reinstate by reflex, and doing so would silently take the visibility back.

| suite | before | after |
|---|---|---|
| `execution-presets.sh` | 34 passed | **35 passed**, 0 failed |
| `rate-limit-detection.sh` | 11 passed | **11 passed**, 0 failed |

Two comments asserting codex keeps no session are now false. Both are rewritten in the past tense with the reason it no longer holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
