### PR TITLE
fix(loop): the machine guard rejected ralph's own writes

### DIFF
--- a/tools/loop/engine/lib/loopctl/scan.py
+++ b/tools/loop/engine/lib/loopctl/scan.py
@@ -161,8 +161,20 @@ def _now() -> int:
 
 
 def _host_machine() -> str:
-    """The one name this host's telemetry is filed under."""
-    return os.environ.get("LOOP_MACHINE") or os.uname().nodename
+    """The one name this host's telemetry is filed under.
+
+    The short form, because that is what ralph derives with `hostname -s` and
+    what every existing partition is named. `os.uname().nodename` can carry a
+    `.local` suffix -- the same host under another spelling, and filing those
+    apart is precisely the split this is here to prevent. Using the long form as
+    the default sent a bare `record-run` to its own third partition, and once the
+    guard below existed it rejected ralph's own writes outright: measured
+    2026-07-30, one run logged "run ledger unavailable" and left no row at all.
+    """
+    override = os.environ.get("LOOP_MACHINE")
+    if override:
+        return override
+    return os.uname().nodename.split(".")[0]
 
 
 def _load(path: Path):
@@ -635,12 +647,16 @@ def main(argv=None) -> int:
             # beside the real one -- same run, same host, two files, neither
             # complete. A host records under one name only; wanting another
             # means setting LOOP_MACHINE, not passing a string.
-            if args.machine != _host_machine():
+            # Compared on the first dot-segment, so `air` and `air.local` are one
+            # host, then normalised to the canonical name so both spellings land
+            # in the same file. A genuinely different name still fails.
+            host = _host_machine()
+            if args.machine.split(".")[0].casefold() != host.split(".")[0].casefold():
                 raise ValueError(
                     f"record-run --machine {args.machine!r} is not this host; "
-                    f"it records as {_host_machine()!r} "
-                    "(set LOOP_MACHINE to change that)"
+                    f"it records as {host!r} (set LOOP_MACHINE to change that)"
                 )
+            args.machine = host
             _print_json(
                 append_run(
                     project=args.project,

--- a/tools/loop/tests/execution-presets.sh
+++ b/tools/loop/tests/execution-presets.sh
@@ -358,6 +358,16 @@ check "no second partition was created" "$after" "$before"
 "$LOOPCTL" record-run --project sandbox --task "$TASK_KEY" \
   --executor codex --machine "$MACHINE" >/dev/null 2>&1
 check "this host's own name still records" "$?" "0"
+# The regression the first guard shipped with: ralph derives the machine name
+# with `hostname -s` while loopctl defaulted to os.uname().nodename, which on
+# macOS carries `.local`. The guard then rejected ralph's own record-run and a
+# 2026-07-30 run logged "run ledger unavailable" with no row written. Same host,
+# two spellings -- accepted, and filed under one name.
+"$LOOPCTL" record-run --project sandbox --task "$TASK_KEY" \
+  --executor codex --machine "$MACHINE.local" >/dev/null 2>&1
+check "a .local spelling of this host is accepted" "$?" "0"
+partitions=$(ls "$VAULT/_system/usage/" | grep -c '^loop-runs\.' || true)
+check "both spellings share one partition" "$partitions" "1"
 
 printf '\n  %d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
fix(loop): the machine guard rejected ralph's own writes

The guard added in #282 compared --machine against os.uname().nodename, which on
macOS carries a `.local` suffix, while ralph derives the name with `hostname -s`.
Same host, two spellings, so every ralph run failed to record: measured
2026-07-30, a run logged "run ledger unavailable; continuing" and left no
iteration row at all.

The mismatch predates the guard. `--machine` already defaulted to the long form,
so any bare `record-run` was writing to a third partition of its own -- the guard
turned a silent split into a hard failure, which is how it surfaced.

Now: the short form is canonical, comparison is on the first dot-segment, and the
value is normalised before writing, so `air` and `air.local` land in one file
while a genuinely foreign name still fails.

  execution-presets.sh 37 passed, 0 failed (was 35)

Verified against the real host: `Angibles-MacBook-Air` and
`Angibles-MacBook-Air.local` both accepted, `Angible's MacBook Air` still refused.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
