### PR TITLE
fix(loop): pin the machine identity so per-machine files stop splitting

### DIFF
--- a/tools/loop/engine/lib/loopctl/scan.py
+++ b/tools/loop/engine/lib/loopctl/scan.py
@@ -163,17 +163,28 @@ def _now() -> int:
 def _host_machine() -> str:
     """The one name this host's telemetry is filed under.
 
-    The short form, because that is what ralph derives with `hostname -s` and
-    what every existing partition is named. `os.uname().nodename` can carry a
-    `.local` suffix -- the same host under another spelling, and filing those
-    apart is precisely the split this is here to prevent. Using the long form as
-    the default sent a bare `record-run` to its own third partition, and once the
-    guard below existed it rejected ralph's own writes outright: measured
-    2026-07-30, one run logged "run ledger unavailable" and left no row at all.
+    The short form, because that is what every existing partition is named, and
+    derived in the same order ralph derives it -- the two disagreeing is what
+    splits the files. `os.uname().nodename` can carry a `.local` suffix, and it
+    also follows DHCP: measured 2026-07-30 the short name was Angibles-MacBook-Air
+    for one run and Angibles-Air for the next, on one laptop, which opened a third
+    partition and left the quota gate reading a file that did not exist.
+    LocalHostName is the stable macOS name and does not move with the network.
     """
     override = os.environ.get("LOOP_MACHINE")
     if override:
         return override
+    try:
+        proc = subprocess.run(
+            ["scutil", "--get", "LocalHostName"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if proc.returncode == 0 and proc.stdout.strip():
+            return proc.stdout.strip().split(".")[0]
+    except (OSError, subprocess.SubprocessError):
+        pass  # not macOS, or scutil is unavailable
     return os.uname().nodename.split(".")[0]
 
 

--- a/tools/loop/engine/ralph.sh
+++ b/tools/loop/engine/ralph.sh
@@ -9,7 +9,15 @@ CLAUDE_BIN=${CLAUDE_BIN:-$(command -v claude 2>/dev/null || echo "$HOME/.local/b
 CODEX_BIN=${CODEX_BIN:-$(command -v codex 2>/dev/null || echo "$HOME/.local/bin/codex")}
 AGY_BIN=${AGY_BIN:-$(command -v agy 2>/dev/null || echo "$HOME/.local/bin/agy")}
 PYTHON_BIN=${LOOP_PYTHON:-"$LOOP_HOME/.venv/bin/python"}
-MACHINE=${LOOP_MACHINE:-${USAGE_MACHINE:-$(hostname -s)}}
+# `hostname -s` is not an identity: it follows DHCP. Measured 2026-07-30, it
+# returned Angibles-MacBook-Air for one run and Angibles-Air for the next on the
+# same laptop, which forked the run ledger into a third partition and left the
+# quota gate reading a quota.<machine>.json that did not exist -- so the gate
+# silently degraded to "unknown" and the run proceeded ungated. LocalHostName is
+# the stable macOS name and does not move with the network; loopctl derives it the
+# same way, and the two must agree or every per-machine file splits.
+MACHINE=${LOOP_MACHINE:-${USAGE_MACHINE:-$(scutil --get LocalHostName 2>/dev/null || hostname -s 2>/dev/null)}}
+MACHINE=${MACHINE%%.*}
 EXECUTORS=${LOOP_EXECUTORS:-claude,codex,agy}
 AGENT_CONFIG=${LOOP_AGENT_CONFIG:-}
 # Resolved per iteration from the agent config's preset for this task. Empty

--- a/tools/loop/tests/execution-presets.sh
+++ b/tools/loop/tests/execution-presets.sh
@@ -368,6 +368,17 @@ check "this host's own name still records" "$?" "0"
 check "a .local spelling of this host is accepted" "$?" "0"
 partitions=$(ls "$VAULT/_system/usage/" | grep -c '^loop-runs\.' || true)
 check "both spellings share one partition" "$partitions" "1"
+# The invariant that actually broke: ralph and loopctl each derive the machine name
+# independently, and on 2026-07-30 they disagreed -- ralph used `hostname -s`,
+# loopctl used os.uname().nodename. DHCP then moved the short name mid-session and
+# opened a third partition, while the quota gate read a file that did not exist.
+# With nothing pinned, both must land on the same string.
+ralph_derived=$(env -u LOOP_MACHINE -u USAGE_MACHINE bash -c \
+  'm=${LOOP_MACHINE:-${USAGE_MACHINE:-$(scutil --get LocalHostName 2>/dev/null || hostname -s 2>/dev/null)}}; printf "%s" "${m%%.*}"')
+loopctl_derived=$(env -u LOOP_MACHINE PYTHONPATH="$HOME_DIR/lib" "$VENV/bin/python" -c \
+  'from loopctl.scan import _host_machine; print(_host_machine())')
+check "ralph and loopctl derive one machine name" "$ralph_derived" "$loopctl_derived"
+check "the derived name carries no domain suffix" "${loopctl_derived##*.}" "$loopctl_derived"
 
 printf '\n  %d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
fix(loop): pin the machine identity so per-machine files stop splitting

`hostname -s` is not an identity: it follows DHCP. On 2026-07-30 it returned
Angibles-MacBook-Air for one run and Angibles-Air for the next, on one laptop.
Consequences, all silent:

  - a third run-ledger partition, loop-runs.Angibles-Air.jsonl
  - the quota gate read quota.Angibles-Air.json, which does not exist, so it
    degraded to "unknown" and the run proceeded ungated
  - the task claim recorded loop-Angibles-Air

Both sides now derive the name the same way and in the same order: LOOP_MACHINE,
then USAGE_MACHINE (ralph only), then `scutil --get LocalHostName` -- the stable
macOS name, which does not move with the network -- then the short nodename, with
any domain suffix stripped.

The guard shipped in #284 only made a single call self-consistent. It could not
catch the name itself changing between calls, which is why this needed a second
pass.

The new assertions compare the two derivations directly with nothing pinned. That
is the invariant that broke, and nothing was testing it. One of them caught a
mistake in its own first draft.

  execution-presets.sh    39 passed, 0 failed (was 37)
  rate-limit-detection.sh 11 passed, 0 failed

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
