### PR TITLE
fix(loop): derive the machine name in one place, not five

### DIFF
--- a/tools/loop/engine/lib/loopctl/__init__.py
+++ b/tools/loop/engine/lib/loopctl/__init__.py
@@ -1,6 +1,37 @@
 """loopctl — deterministic loop state engine."""
 
+import os
+import subprocess
+
 __version__ = "0.2.0"
+
+
+def host_machine() -> str:
+    """The one name this host's per-machine files are keyed on.
+
+    Lives here because five call sites derived it independently and drifted:
+    ralph, install.sh, relay/pull.sh, `enroll`, and the Observatory mirror. On
+    2026-07-30 `hostname -s` followed DHCP from Angibles-MacBook-Air to
+    Angibles-Air mid-session, which opened a third run-ledger partition, pointed
+    the quota gate at a file that did not exist, and left install.sh unable to
+    find the host in hosts.yaml. LocalHostName is the stable macOS name and does
+    not move with the network. The shell sites derive it in this same order.
+    """
+    override = os.environ.get("LOOP_MACHINE")
+    if override:
+        return override
+    try:
+        proc = subprocess.run(
+            ["scutil", "--get", "LocalHostName"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if proc.returncode == 0 and proc.stdout.strip():
+            return proc.stdout.strip().split(".")[0]
+    except (OSError, subprocess.SubprocessError):
+        pass  # not macOS, or scutil is unavailable
+    return os.uname().nodename.split(".")[0]
 
 PIPELINE_STATES = [
     "not-started",

--- a/tools/loop/engine/lib/loopctl/scan.py
+++ b/tools/loop/engine/lib/loopctl/scan.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import yaml
 
-from loopctl import AGENT_STATES, PIPELINE_STATES, registry, signals
+from loopctl import AGENT_STATES, PIPELINE_STATES, host_machine, registry, signals
 from loopctl import greenlight as greenlight_mod
 from loopctl.adapters import github, notion, obsidian_base, vault
 from loopctl.config import (
@@ -161,31 +161,8 @@ def _now() -> int:
 
 
 def _host_machine() -> str:
-    """The one name this host's telemetry is filed under.
-
-    The short form, because that is what every existing partition is named, and
-    derived in the same order ralph derives it -- the two disagreeing is what
-    splits the files. `os.uname().nodename` can carry a `.local` suffix, and it
-    also follows DHCP: measured 2026-07-30 the short name was Angibles-MacBook-Air
-    for one run and Angibles-Air for the next, on one laptop, which opened a third
-    partition and left the quota gate reading a file that did not exist.
-    LocalHostName is the stable macOS name and does not move with the network.
-    """
-    override = os.environ.get("LOOP_MACHINE")
-    if override:
-        return override
-    try:
-        proc = subprocess.run(
-            ["scutil", "--get", "LocalHostName"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        if proc.returncode == 0 and proc.stdout.strip():
-            return proc.stdout.strip().split(".")[0]
-    except (OSError, subprocess.SubprocessError):
-        pass  # not macOS, or scutil is unavailable
-    return os.uname().nodename.split(".")[0]
+    """The one name this host's telemetry is filed under. See loopctl.host_machine."""
+    return host_machine()
 
 
 def _load(path: Path):
@@ -729,7 +706,7 @@ def main(argv=None) -> int:
 
         cfg_path = Path(args.config).expanduser()
         if args.cmd == "enroll":
-            machines = args.machines or [os.environ.get("LOOP_MACHINE") or os.uname().nodename]
+            machines = args.machines or [host_machine()]
             if args.dry_run:
                 inferred_source, inferred_policy = _infer_enrollment(Path(args.path).expanduser())
                 _print_json(

--- a/tools/loop/engine/lib/loopctl/writeback.py
+++ b/tools/loop/engine/lib/loopctl/writeback.py
@@ -11,6 +11,8 @@ import json
 import os
 import tempfile
 import time
+
+from loopctl import host_machine
 import urllib.error
 import urllib.request
 import re
@@ -176,7 +178,7 @@ def publish_task_state(
             "pr": task.get("pr"),
             "note": (task.get("overlay") or {}).get("note"),
             "project": slug,
-            "machine": machine or os.environ.get("LOOP_MACHINE") or os.uname().nodename,
+            "machine": machine or host_machine(),
             "updated_ts": now,
             "updated_at": _iso(now),
             "notion_writeback": notion_state,

--- a/tools/loop/install.sh
+++ b/tools/loop/install.sh
@@ -35,7 +35,11 @@ for arg in "$@"; do
 done
 
 [ -f "$MANIFEST" ] || { echo "manifest missing: $MANIFEST" >&2; exit 1; }
-[ -n "$HOST" ] || HOST=$(hostname -s 2>/dev/null || echo "")
+# LocalHostName, not `hostname -s`: the latter follows DHCP and moved
+# mid-session on 2026-07-30. Kept identical to ralph.sh and
+# loopctl.host_machine -- these must all agree or per-machine files split.
+[ -n "$HOST" ] || HOST=$(scutil --get LocalHostName 2>/dev/null || hostname -s 2>/dev/null)
+HOST=${HOST%%.*}
 
 say() { printf '%s\n' "$*"; }
 run() { if [ "$DRY" -eq 1 ]; then say "  would: $*"; else "$@"; fi; }

--- a/tools/loop/relay/pull.sh
+++ b/tools/loop/relay/pull.sh
@@ -8,7 +8,11 @@ set -uo pipefail
 REMOTE=${GREENLIGHT_REMOTE:-rainforest-mini}
 REMOTE_DIR=${GREENLIGHT_REMOTE_DIR:-/Users/rainforest/.claude/loop/greenlight-outbox}
 LOOPCTL=${LOOPCTL:-$HOME/.claude/loop/loopctl}
-MACHINE=${LOOP_MACHINE:-$(hostname -s)}
+# LocalHostName, not `hostname -s`: the latter follows DHCP and moved
+# mid-session on 2026-07-30. Kept identical to ralph.sh and
+# loopctl.host_machine -- these must all agree or per-machine files split.
+MACHINE=${LOOP_MACHINE:-$(scutil --get LocalHostName 2>/dev/null || hostname -s 2>/dev/null)}
+MACHINE=${MACHINE%%.*}
 SSH_OPTS=(-o BatchMode=yes -o ConnectTimeout=10 -o ConnectionAttempts=1)
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] greenlight-pull: $*"; }

--- a/tools/loop/tests/execution-presets.sh
+++ b/tools/loop/tests/execution-presets.sh
@@ -379,6 +379,15 @@ loopctl_derived=$(env -u LOOP_MACHINE PYTHONPATH="$HOME_DIR/lib" "$VENV/bin/pyth
   'from loopctl.scan import _host_machine; print(_host_machine())')
 check "ralph and loopctl derive one machine name" "$ralph_derived" "$loopctl_derived"
 check "the derived name carries no domain suffix" "${loopctl_derived##*.}" "$loopctl_derived"
+# install.sh and relay/pull.sh derive it too, and install.sh failing to find the
+# host in hosts.yaml is how the third site was found -- after the first fix
+# claimed "both sides agree". Compare the literal expression so a fourth site
+# cannot drift silently.
+canon='$(scutil --get LocalHostName 2>/dev/null || hostname -s 2>/dev/null)'
+for f in install.sh relay/pull.sh engine/ralph.sh; do
+  hits=$(grep -c -F "$canon" "$ENGINE/../$f" 2>/dev/null || echo 0)
+  check "$f derives the machine name the one way" "$hits" "1"
+done
 
 printf '\n  %d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
fix(loop): derive the machine name in one place, not five

#286 fixed ralph and loopctl and claimed "both sides agree". There were five
sites. `install.sh` still used `hostname -s`, so the very next install failed:

  no roles for host 'Angibles-Air'.
  hosts.yaml knows: Angibles-MacBook-Air rainforest-mini

`relay/pull.sh`, `enroll`'s default machine list, and the Observatory mirror in
writeback were the other three.

Python now has one `loopctl.host_machine()`; scan and writeback call it. The three
shell sites keep the same expression, and the suite compares the literal string in
each file, because a shared sourced helper across install.sh, engine/ralph.sh and
relay/pull.sh does not survive the installed layout.

  execution-presets.sh 42 passed, 0 failed (was 39)

The lesson is in the count: a "the two sides now agree" fix is worth grepping for
the third caller before shipping.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
