### PR TITLE
fix(loop): stop losing iterations to ambient gh state

### DIFF
--- a/tools/loop/engine/lib/loopctl/scan.py
+++ b/tools/loop/engine/lib/loopctl/scan.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import os
 import subprocess
@@ -71,6 +72,48 @@ def _merge_task(task, sig, derived_state: str, prior_task: dict | None) -> dict:
     return output
 
 
+@contextlib.contextmanager
+def _gh_account(project):
+    """Pin gh to the project's account for the duration of a scan.
+
+    `gh auth switch` is global, so whichever account was last selected anywhere
+    leaks into the loop. Measured 2026-07-30: merging a PR on the personal
+    monorepo left gh on the personal login, and the next company iteration read
+    the registry as stale because `gh pr list` could not see the repo -- the
+    executor then correctly refused to work, and the iteration was wasted.
+
+    A token is minted per project instead of trusting ambient state. A project
+    that names no account, or an account gh cannot mint a token for, falls
+    through to the ambient login unchanged.
+    """
+    account = getattr(project, "account", None)
+    if not account:
+        yield
+        return
+    try:
+        proc = subprocess.run(
+            ["gh", "auth", "token", "-u", account],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        token = proc.stdout.strip() if proc.returncode == 0 else ""
+    except (OSError, subprocess.SubprocessError):
+        token = ""
+    if not token:
+        yield
+        return
+    prior = os.environ.get("GH_TOKEN")
+    os.environ["GH_TOKEN"] = token
+    try:
+        yield
+    finally:
+        if prior is None:
+            os.environ.pop("GH_TOKEN", None)
+        else:
+            os.environ["GH_TOKEN"] = prior
+
+
 def scan_project(
     project,
     now_ts: int,
@@ -106,9 +149,10 @@ def scan_project(
     tasks_out = []
     states = []
     try:
-        tasks = adapter.enumerate_tasks(project)
-        for task in tasks:
-            sig = adapter.task_signals(project, task)
+        with _gh_account(project):
+            tasks = adapter.enumerate_tasks(project)
+            signal_rows = [(task, adapter.task_signals(project, task)) for task in tasks]
+        for task, sig in signal_rows:
             prior_task = prior_tasks.get(str(task.id))
             overlay = (prior_task or {}).get("overlay") or {}
             if overlay.get("blocked_reason"):
@@ -146,6 +190,7 @@ def scan_project(
         "source": project.source,
         "policy": project.policy,
         "stop_at": project.stop_at,
+        "account": project.account,
         "machines": project.machines,
         "lifecycle": lifecycle,
         "scanned_ts": now_ts,

--- a/tools/loop/engine/lib/loopctl/signals.py
+++ b/tools/loop/engine/lib/loopctl/signals.py
@@ -7,6 +7,19 @@ from loopctl.errors import SourceUnreachable
 
 
 def run(args: list[str], cwd) -> tuple[int, str]:
+    code, out, _ = run_full(args, cwd)
+    return code, out
+
+
+def run_full(args: list[str], cwd) -> tuple[int, str, str]:
+    """Same as run, but keeps stderr.
+
+    stderr was captured and dropped, so a failing signal reported only its exit
+    code. On 2026-07-30 a scan went stale with `gh pr list failed for branch X
+    (exit 1)`, which reads like a branch problem; the discarded stderr said
+    `Could not resolve to a Repository` -- gh was signed in to the wrong account.
+    Diagnosing that took minutes of guessing at branches and sandboxes.
+    """
     timeout = int(os.environ.get("LOOP_SIGNAL_TIMEOUT", "15"))
     try:
         proc = subprocess.run(
@@ -20,27 +33,37 @@ def run(args: list[str], cwd) -> tuple[int, str]:
         raise SourceUnreachable(
             f"signal command timed out after {timeout}s: {args[0]}"
         ) from exc
-    return proc.returncode, proc.stdout.strip()
+    return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+
+
+def _why(stderr: str) -> str:
+    """One line of the command's own error, for a message a human will read."""
+    first = next((ln for ln in stderr.splitlines() if ln.strip()), "")
+    return f": {first[:200]}" if first else ""
 
 
 def branch_exists(repo, branch: str) -> bool:
-    code, _ = run(["git", "rev-parse", "--verify", "--quiet", f"refs/heads/{branch}"], repo)
+    code, _, err = run_full(["git", "rev-parse", "--verify", "--quiet", f"refs/heads/{branch}"], repo)
     if code not in {0, 1}:
-        raise SourceUnreachable(f"git could not inspect branch {branch} (exit {code})")
+        raise SourceUnreachable(
+            f"git could not inspect branch {branch} (exit {code}){_why(err)}"
+        )
     return code == 0
 
 
 def commits_ahead(repo, branch: str, base: str) -> int:
-    code, out = run(["git", "rev-list", "--count", f"{base}..{branch}"], repo)
+    code, out, err = run_full(["git", "rev-list", "--count", f"{base}..{branch}"], repo)
     if code != 0:
-        raise SourceUnreachable(f"git could not compare {branch} with {base} (exit {code})")
+        raise SourceUnreachable(
+            f"git could not compare {branch} with {base} (exit {code}){_why(err)}"
+        )
     return int(out) if out.isdigit() else 0
 
 
 def last_commit_ts(repo, ref: str = "HEAD") -> int | None:
-    code, out = run(["git", "log", "-1", "--format=%ct", ref], repo)
+    code, out, err = run_full(["git", "log", "-1", "--format=%ct", ref], repo)
     if code != 0:
-        raise SourceUnreachable(f"git could not inspect {ref} (exit {code})")
+        raise SourceUnreachable(f"git could not inspect {ref} (exit {code}){_why(err)}")
     return int(out) if out.isdigit() else None
 
 
@@ -50,13 +73,15 @@ _PR_STATE = {"OPEN": "open", "MERGED": "merged"}
 
 
 def pr_for_branch(repo, branch: str) -> dict | None:
-    code, out = run(
+    code, out, err = run_full(
         ["gh", "pr", "list", "--head", branch, "--state", "all",
          "--json", "number,state,url", "--limit", "1"],
         repo,
     )
     if code != 0:
-        raise SourceUnreachable(f"gh pr list failed for branch {branch} (exit {code})")
+        raise SourceUnreachable(
+            f"gh pr list failed for branch {branch} (exit {code}){_why(err)}"
+        )
     if not out:
         return None
     try:
@@ -71,14 +96,16 @@ def pr_for_branch(repo, branch: str) -> dict | None:
 
 
 def checks_conclusion(repo, branch: str) -> str:
-    code, out = run(["gh", "pr", "checks", branch], repo)
+    code, out, err = run_full(["gh", "pr", "checks", branch], repo)
     if not out:
         # `gh pr checks` exits 1 with no output when an open draft/stacked PR
         # has no check runs. That is a valid "no signal" state, not a transport
         # failure that should make the whole project registry stale.
         if code in {0, 1}:
             return "none"
-        raise SourceUnreachable(f"gh pr checks failed for branch {branch} (exit {code})")
+        raise SourceUnreachable(
+            f"gh pr checks failed for branch {branch} (exit {code}){_why(err)}"
+        )
     low = out.lower()
     if code == 0:
         return "pending" if "pending" in low else "success"
@@ -88,4 +115,4 @@ def checks_conclusion(repo, branch: str) -> str:
         return "pending"
     if any(token in low for token in ("fail", "cancel", "timed out", "startup_failure")):
         return "failure"
-    raise SourceUnreachable(f"gh pr checks was unreachable for branch {branch}")
+    raise SourceUnreachable(f"gh pr checks was unreachable for branch {branch}{_why(err)}")

--- a/tools/loop/engine/ralph.sh
+++ b/tools/loop/engine/ralph.sh
@@ -437,6 +437,23 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
     break
   fi
 
+  # loopctl pins gh per project for its own scans; the executor shells out to gh
+  # itself -- to open the PR, most of all -- so it needs the same token. Unset
+  # first, or a project with no account inherits the previous project's.
+  unset GH_TOKEN
+  gh_account=$("$LOOPCTL" show "$slug" 2>/dev/null | "$PYTHON_BIN" -c \
+    'import json, sys; print((json.load(sys.stdin) or {}).get("account") or "")' \
+    2>/dev/null || printf '')
+  if [ -n "$gh_account" ]; then
+    if GH_TOKEN=$(gh auth token -u "$gh_account" 2>/dev/null) && [ -n "$GH_TOKEN" ]; then
+      export GH_TOKEN
+      log "  gh · pinned to $gh_account"
+    else
+      unset GH_TOKEN
+      log "  gh · account '$gh_account' has no token; using the ambient login"
+    fi
+  fi
+
   next_json=$("$LOOPCTL" next "$slug" 2>/dev/null || printf '[]')
   task_pair=$(printf '%s' "$next_json" | "$PYTHON_BIN" -c \
     'import json, sys; rows=json.load(sys.stdin); row=rows[0] if rows else {}; print("{}\t{}".format(row.get("id") or "", (row.get("metadata") or {}).get("item_id") or ""))' \

--- a/tools/loop/tests/execution-presets.sh
+++ b/tools/loop/tests/execution-presets.sh
@@ -389,6 +389,25 @@ for f in install.sh relay/pull.sh engine/ralph.sh; do
   check "$f derives the machine name the one way" "$hits" "1"
 done
 
+# --- 8. a failing signal says why -------------------------------------------
+# `gh pr list failed for branch X (exit 1)` reads like a branch problem. On
+# 2026-07-30 it was the wrong gh account, and the answer was in the stderr the
+# runner captured and threw away.
+echo "  signal failures are legible:"
+signal_msg=$(PYTHONPATH="$HOME_DIR/lib" "$VENV/bin/python" - <<'PYEOF'
+from loopctl import signals
+from loopctl.errors import SourceUnreachable
+try:
+    signals.run_full(["/bin/sh", "-c", "echo boom-from-stderr >&2; exit 1"], ".")
+except SourceUnreachable as exc:
+    print("unexpected:", exc); raise SystemExit
+code, out, err = signals.run_full(["/bin/sh", "-c", "echo boom-from-stderr >&2; exit 1"], ".")
+print(f"{code}|{err}|{signals._why(err)}")
+PYEOF
+)
+contains "run_full keeps stderr" "$signal_msg" "boom-from-stderr"
+contains "the reason is appended, not swallowed" "$signal_msg" ": boom-from-stderr"
+
 printf '\n  %d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ] || exit 1
 rm -rf "$ROOT"

--- a/tools/loop/tests/execution-presets.sh
+++ b/tools/loop/tests/execution-presets.sh
@@ -408,6 +408,37 @@ PYEOF
 contains "run_full keeps stderr" "$signal_msg" "boom-from-stderr"
 contains "the reason is appended, not swallowed" "$signal_msg" ": boom-from-stderr"
 
+# --- 9. gh is pinned to the project's account, not to ambient state ----------
+# `gh auth switch` is global. Merging on the personal repo left gh personal, and
+# the next company iteration read the registry as stale. A project that names an
+# account gets a token minted for it; one that names none is left alone.
+echo "  gh account is per project:"
+mkdir -p "$ROOT/ghbin"
+cat > "$ROOT/ghbin/gh" <<'FAKE'
+#!/usr/bin/env bash
+if [ "$1" = "auth" ] && [ "$2" = "token" ]; then
+  [ "$4" = "known-account" ] && { echo "token-for-$4"; exit 0; }
+  exit 1
+fi
+exit 0
+FAKE
+chmod +x "$ROOT/ghbin/gh"
+gh_probe() {
+  PATH="$ROOT/ghbin:$PATH" PYTHONPATH="$HOME_DIR/lib" "$VENV/bin/python" - "$1" <<'PYEOF'
+import os, sys, types
+from loopctl.scan import _gh_account
+project = types.SimpleNamespace(account=(sys.argv[1] or None))
+os.environ.pop("GH_TOKEN", None)
+with _gh_account(project):
+    print("inside=" + os.environ.get("GH_TOKEN", "(unset)"))
+print("after=" + os.environ.get("GH_TOKEN", "(unset)"))
+PYEOF
+}
+contains "a named account mints a token" "$(gh_probe known-account)" "inside=token-for-known-account"
+contains "the token does not outlive the scan" "$(gh_probe known-account)" "after=(unset)"
+contains "no account leaves the ambient login alone" "$(gh_probe '')" "inside=(unset)"
+contains "an unmintable account falls through" "$(gh_probe other-account)" "inside=(unset)"
+
 printf '\n  %d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ] || exit 1
 rm -rf "$ROOT"


### PR DESCRIPTION
Two changes, both about the same failure: ambient `gh` state silently costing loop iterations. One prevents it, the other makes it diagnosable when something like it happens again. Two commits, reviewable separately.

## 1. A failing signal should say why it failed

`signals.run` captured stderr and threw it away, so every failure reported only an exit code. On 2026-07-30 a scan went stale with

```
gh pr list failed for branch claude/adoring-blackburn-a752c3 (exit 1)
```

which reads like a branch problem. It was not — gh was signed in to the personal account, which cannot see the company repo. The stderr saying exactly that had already been discarded, so the diagnosis went through the branch, the sandbox and the network before landing on the account. It now reads:

```
... (exit 1): GraphQL: Could not resolve to a Repository with the name
'angible/service-dashboard-frontend'. (repository)
```

`run_full` returns stderr; `run` keeps its signature so nothing else moves. All six failure paths — both gh calls and the three git calls — append one trimmed line of the command's own error.

## 2. Pin gh to the project's account

`gh auth switch` is global. That was the **third** iteration lost to it, and the mitigation until now was remembering to switch back.

`Project.account` already existed in the config dataclass, parsed and never read. It now means something: loopctl mints a token with `gh auth token -u` and sets `GH_TOKEN` for the duration of the scan, restoring the prior value afterwards.

Pinning inside `scan_project` rather than in ralph is deliberate — `sweep` scans **every** project before any slug is known, so an outer pin would miss the one scan that decides whether work starts at all. ralph exports the same token for the iteration too, because the executor shells out to gh itself, most importantly to open the PR.

A project that names no account, or names one gh cannot mint a token for, falls through to the ambient login exactly as before.

## Tests

| suite | before | after |
|---|---|---|
| `execution-presets.sh` | 42 passed | **48 passed**, 0 failed |
| `rate-limit-detection.sh` | 11 passed | **11 passed**, 0 failed |

The gh test drives `_gh_account` against a fake `gh` on PATH and covers all four paths: a named account mints a token, the token does not outlive the scan, no account leaves the ambient login alone, and an unmintable account falls through.

## Not included

Nothing sets `account:` yet. That is a config change on each machine, and `config.yaml` is owner-maintained state this repo deliberately does not write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
