### PR TITLE
fix(loop): let codex publish task state, and say so when it cannot

### DIFF
--- a/tools/loop/engine/lib/loopctl/scan.py
+++ b/tools/loop/engine/lib/loopctl/scan.py
@@ -380,11 +380,15 @@ def set_task_state(
         task["pr"] = pr
     registry.write_project_state(slug, document)
     # Registry writes stay authoritative; this mirror is best-effort so a
-    # temporarily unavailable iCloud/local vault never blocks execution.
+    # temporarily unavailable iCloud/local vault never blocks execution. Not
+    # silent, though: on 2026-07-30 the executor took AG-132 to pr-ready, the
+    # registry recorded it, `loopctl set` reported success -- and Loop
+    # Observatory went on showing "Queued" for an hour, because the sandbox had
+    # denied the mirror write and the failure was swallowed here.
     try:
         publish_task_state(slug, task)
-    except OSError:
-        pass
+    except OSError as exc:
+        task["mirror_error"] = f"{type(exc).__name__}: {exc}"
     return task
 
 
@@ -417,12 +421,11 @@ def set_task_note(slug: str, task_id: str, note: str, *, now_ts: int | None = No
     overlay["updated_ts"] = now_ts or _now()
     task["overlay"] = overlay
     registry.write_project_state(slug, document)
-    # Best-effort, exactly as in set_task_state: an unavailable vault must not
-    # fail the caller that was only leaving a note.
+    # Best-effort and reported, exactly as in set_task_state.
     try:
         publish_task_state(slug, task)
-    except OSError:
-        pass
+    except OSError as exc:
+        task["mirror_error"] = f"{type(exc).__name__}: {exc}"
     return task
 
 

--- a/tools/loop/engine/ralph.sh
+++ b/tools/loop/engine/ralph.sh
@@ -19,6 +19,12 @@ PYTHON_BIN=${LOOP_PYTHON:-"$LOOP_HOME/.venv/bin/python"}
 MACHINE=${LOOP_MACHINE:-${USAGE_MACHINE:-$(scutil --get LocalHostName 2>/dev/null || hostname -s 2>/dev/null)}}
 MACHINE=${MACHINE%%.*}
 EXECUTORS=${LOOP_EXECUTORS:-claude,codex,agy}
+# Where `loopctl set` mirrors task state for Loop Observatory. Resolved through
+# loopctl so this cannot drift from the path writeback actually writes to; empty
+# if that fails, and the grant below is simply skipped.
+VAULT_USAGE=$("$PYTHON_BIN" -c \
+  'import sys; sys.path.insert(0, "'"${LOOP_HOME}"'/lib"); from loopctl.writeback import usage_path; print(usage_path("").parent)' \
+  2>/dev/null || printf '')
 AGENT_CONFIG=${LOOP_AGENT_CONFIG:-}
 # Resolved per iteration from the agent config's preset for this task. Empty
 # means "say nothing", so each executor falls back to its own default -- the
@@ -337,9 +343,18 @@ run_codex() {
   # than danger-full-access: probed with `codex sandbox`, a write outside
   # project_path is still "Operation not permitted" with the grant applied. Inert
   # unless the mode is workspace-write, which --sandbox sets below.
+  # The vault usage dir alongside LOOP_HOME, because `loopctl set` mirrors task
+  # state to tasks-progress.json there and the sandbox denies it otherwise.
+  # Measured 2026-07-30: the executor took AG-132 to pr-ready, the local registry
+  # recorded it, and Loop Observatory kept showing "Queued" -- the mirror write
+  # had been refused with "Operation not permitted" and nothing surfaced it,
+  # because publishing is best-effort by design. claude is unaffected: it runs
+  # under no OS sandbox.
+  local codex_dirs=(--add-dir "$LOOP_HOME")
+  [ -n "$VAULT_USAGE" ] && [ -d "$VAULT_USAGE" ] && codex_dirs+=(--add-dir "$VAULT_USAGE")
   (cd "$project_path" && printf '%s' "$prompt" | LOOP_PROJECT="$slug" LOOP_EXECUTOR=codex \
     LOOP_QUOTA_MODE="${QUOTA_MODE:-ok}" "$CODEX_BIN" exec \
-    ${opts[@]+"${opts[@]}"} --add-dir "$LOOP_HOME" \
+    ${opts[@]+"${opts[@]}"} "${codex_dirs[@]}" \
     -c sandbox_workspace_write.network_access=true \
     --json --sandbox workspace-write -C "$project_path" -)
 }

--- a/tools/loop/tests/execution-presets.sh
+++ b/tools/loop/tests/execution-presets.sh
@@ -438,6 +438,25 @@ contains "a named account mints a token" "$(gh_probe known-account)" "inside=tok
 contains "the token does not outlive the scan" "$(gh_probe known-account)" "after=(unset)"
 contains "no account leaves the ambient login alone" "$(gh_probe '')" "inside=(unset)"
 contains "an unmintable account falls through" "$(gh_probe other-account)" "inside=(unset)"
+# --- 10. a refused Observatory mirror is reported, not swallowed -------------
+# On 2026-07-30 the executor took AG-132 to pr-ready inside the codex sandbox.
+# The registry recorded it and `loopctl set` reported success, while the mirror
+# write was refused with "Operation not permitted" and Loop Observatory went on
+# showing "Queued". Still non-fatal -- an unavailable vault must not stop a run --
+# but the caller is told.
+echo "  a refused mirror is visible:"
+readonly_vault="$ROOT/readonly-vault"
+mkdir -p "$readonly_vault/_system/usage"
+chmod a-w "$readonly_vault/_system/usage"
+mirror_out=$(LOOP_VAULT_PATH="$readonly_vault" "$LOOPCTL" set sandbox "$TASK_KEY" queued --note "mirror probe" 2>&1)
+mirror_rc=$?
+chmod u+w "$readonly_vault/_system/usage"
+check "the set still succeeds" "$mirror_rc" "0"
+contains "the refused mirror is named" "$mirror_out" "mirror_error"
+contains "and says what refused it" "$mirror_out" "Permission denied"
+# The happy path must stay clean, or every run would look broken.
+clean_out=$("$LOOPCTL" set sandbox "$TASK_KEY" queued --note "mirror probe ok" 2>&1)
+excludes "a working mirror reports nothing" "$clean_out" "mirror_error"
 
 printf '\n  %d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
fix(loop): let codex publish task state, and say so when it cannot

Loop Observatory showed AG-132 as "Queued" for an hour after the executor had
taken it to pr-ready and opened the PR. Two separate faults, both needed.

run_codex granted --add-dir for LOOP_HOME but not for the vault's _system/usage,
where `loopctl set` mirrors task state for the Observatory. The sandbox refused
the write with "Operation not permitted". claude was unaffected -- it runs under
no OS sandbox -- so this only ever broke codex-routed tasks. The executor reported
this in plain language on its first run and it was noted and not fixed. The path
is resolved through loopctl.writeback.usage_path so it cannot drift from where
writeback actually writes, and the grant is skipped if that resolution fails.
Verified --add-dir is repeatable: two of them parse.

The mirror write was then swallowed by `except OSError: pass`, twice. Best-effort
is the right policy -- an unavailable iCloud vault must not stop a run -- but
silence is what made a refused write look like a successful one for an hour.
`loopctl set` now returns `mirror_error` alongside the state it did record. Still
non-fatal, still exit 0.

  execution-presets.sh 46 passed, 0 failed (was 42)

The new test makes the usage dir read-only and asserts all four properties: the
set still succeeds, the refusal is named, the reason is included, and a working
mirror stays quiet.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
