### PR TITLE
fix(personal-website): remove the phone number and paginate the resume onto two A4 pages

### DIFF
--- a/apps/personal-website/src/components/pages/ResumePage.astro
+++ b/apps/personal-website/src/components/pages/ResumePage.astro
@@ -164,6 +164,29 @@ const personSchema = {
         min-height: 0;
       }
 
+      /*
+        Everything below reaches into the article, which lives in ats-friendly.astro — hence
+        `:global()` on every selector that crosses that boundary.
+
+        This is not stylistic. Astro scopes a component's selectors to that component's elements,
+        so the `p, li { orphans: 3 }` that used to sit here compiled to
+        `p[data-astro-cid-t2mi2g5v]` and matched nothing: only seven elements on the page carry
+        that id, all of them in this file. The rule shipped, appeared in the built CSS, and was
+        inert. `#resume-sheet` itself is declared here, so it needs no escaping.
+      */
+
+      /* White paper, black ink. The theme's mint `bg-background` and its themed foreground carry
+         straight into print otherwise — that is what tinted the printed page. Beyond wasting
+         toner, background tint is the wrong default for a resume: ATS pipelines that OCR a PDF
+         rather than read its text layer depend on maximum contrast. `!important` because a print
+         colour reset has to beat every utility unconditionally, and print rendering is the one
+         path that cannot be verified from a screen emulation. */
+      #resume-sheet,
+      #resume-sheet :global(*) {
+        background: transparent !important;
+        color: #000 !important;
+      }
+
       /* Fragmentation — the difference between a two-page resume that looks deliberate and one
          that looks like it ran out of room. Left alone, a browser breaks wherever the page ends:
          one line into a bullet, or between a heading and what it introduces.
@@ -171,9 +194,10 @@ const personSchema = {
          orphans/widows stop a single line being stranded either side of the boundary. The
          companion `break-inside-avoid` / `break-after-avoid` utilities live in ats-friendly.astro,
          on the elements they protect: each role's heading block, each project write-up, and the
-         Education and Skills sections. */
-      p,
-      li {
+         Education and Skills sections. Those are Tailwind classes on the elements themselves, so
+         they were never subject to the scoping problem above. */
+      #resume-sheet :global(p),
+      #resume-sheet :global(li) {
         orphans: 3;
         widows: 3;
       }

--- a/apps/personal-website/src/components/pages/ResumePage.astro
+++ b/apps/personal-website/src/components/pages/ResumePage.astro
@@ -110,16 +110,152 @@ const personSchema = {
   <main
     class="flex-col-center bg-foreground h-screen w-screen overflow-scroll p-10 print:items-start print:justify-start print:overflow-visible print:p-0"
   >
-    <div
-      class="scale-30 h-[105rem] w-[75rem] origin-top sm:scale-50 md:scale-75 lg:scale-100 print:origin-top-left print:scale-100"
-    >
-      <ATSFriendly {...resumeProps} />
+    {
+      /*
+        A true A4 sheet: 210mm x 297mm, so the on-screen page and the printed one are the same
+        object. The previous 75rem x 105rem box was ratio 1.400 where A4 is 1.4143 — close enough
+        to look right and wrong enough that print scaled it.
+
+        Three boxes because two scales apply independently, and collapsing them would couple
+        "fit the sheet to this screen" to "fit the contents to the sheet": #resume-zoom reserves
+        the on-screen size, #resume-sheet is the page itself, #resume-fit holds the contents.
+        Both scales are defined in the <style> block below, next to the reasoning for each.
+      */
+    }
+    <div id="resume-zoom">
+      <div id="resume-sheet">
+        <div id="resume-fit">
+          <ATSFriendly {...resumeProps} />
+        </div>
+      </div>
     </div>
   </main>
-  <style media="print">
-    @page {
-      size: A4;
-      margin: 0;
+  {
+    /*
+      Shrink-to-fit, measured rather than guessed.
+
+      Density work in ats-friendly.astro got the contents to ~0.95 of a page, so this normally has
+      almost nothing to do. It exists for the case that follows: every role added to the content
+      files pushes the page out again, and the failure is silent — #resume-fit is `overflow: hidden`,
+      so an overflowing resume quietly loses its last lines instead of complaining. Measuring the
+      real height and scaling only on overflow turns that into a few percent of extra compression.
+
+      Both measurements are layout values, unaffected by the two enclosing transforms, so the ratio
+      is correct at any --zoom.
+
+      Runs on load and before print (Safari and Firefox honour `beforeprint`; Chrome fires it too),
+      because the print layout resolves at a different width than the scaled screen preview.
+    */
+  }
+  <script is:inline>
+    (() => {
+      const fit = () => {
+        const box = document.getElementById('resume-fit');
+        const sheet = document.getElementById('resume-sheet');
+        const article = box?.firstElementChild;
+        if (!box || !sheet || !article) return;
+
+        // Measure unscaled, or each run would compound the previous run's scale.
+        box.style.setProperty('--fit', '1');
+
+        // Only an overflowing element reports its true content extent: scrollHeight is clamped to
+        // clientHeight otherwise, so a short resume would look like a full page and get shrunk
+        // for no reason.
+        if (article.scrollHeight <= article.clientHeight) return;
+
+        // scrollHeight covers the top padding but NOT the bottom padding of overflowing content,
+        // so it under-reports the space actually needed by exactly one bottom padding (10mm here).
+        // Left uncorrected the scale lands the last line flush on the paper's edge, and the line
+        // after that is silently clipped — which is what this page did before the correction.
+        const padBottom =
+          parseFloat(getComputedStyle(article).paddingBottom) || 0;
+        const needed = article.scrollHeight + padBottom;
+        const available = sheet.clientHeight;
+        if (needed > available) {
+          box.style.setProperty('--fit', String(available / needed));
+        }
+      };
+
+      // Fonts change metrics enough to matter; re-measure once they land.
+      if (document.fonts?.ready) void document.fonts.ready.then(fit);
+      window.addEventListener('load', fit);
+      window.addEventListener('beforeprint', fit);
+      // Content height is width-dependent, and the width changes with the --zoom breakpoints.
+      let queued = 0;
+      window.addEventListener('resize', () => {
+        cancelAnimationFrame(queued);
+        queued = requestAnimationFrame(fit);
+      });
+      fit();
+    })();
+  </script>
+  {
+    /*
+      Plain CSS rather than Tailwind utilities, for two reasons this page ran into directly:
+
+      1. `[--zoom:0.32] sm:[--zoom:0.5] …` generated the three variant rules but not the base one,
+         leaving `var(--zoom)` unresolved below 640px.
+      2. A `print:[--zoom:1]` utility, and an override in a `<style media="print">` block, both
+         failed to reach the document — the media attribute does not survive Astro's style
+         bundling, so `@media print` has to be written inside the stylesheet itself.
+
+      Explicit media queries also make the cascade order visible, which matters when two nested
+      transforms read these variables.
+    */
+  }
+  <style>
+    /* Fits the whole sheet to the viewport. On the wrapper, not the sheet: `transform: scale`
+       shrinks what an element paints but not the layout box it reserves, so scaling the sheet in
+       place left ~760px of dead scroll space below the resume and overflowed horizontally. The
+       wrapper takes the scaled size; the sheet scales from its top-left corner to fill it. */
+    #resume-zoom {
+      --zoom: 0.32;
+      width: calc(210mm * var(--zoom));
+      height: calc(297mm * var(--zoom));
+    }
+    @media (min-width: 40rem) {
+      #resume-zoom {
+        --zoom: 0.5;
+      }
+    }
+    @media (min-width: 48rem) {
+      #resume-zoom {
+        --zoom: 0.75;
+      }
+    }
+    @media (min-width: 64rem) {
+      #resume-zoom {
+        --zoom: 1;
+      }
+    }
+
+    #resume-sheet {
+      width: 210mm;
+      height: 297mm;
+      transform: scale(var(--zoom));
+      transform-origin: top left;
+    }
+
+    /* Shrinks only the contents, and only when they exceed one page. Defaults to 1 so the layout
+       is correct with JavaScript off or before the script below runs. Centred horizontally so the
+       width the scale gives back becomes even margin rather than a right-hand gutter. */
+    #resume-fit {
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+      transform: scale(var(--fit, 1));
+      transform-origin: top center;
+    }
+
+    @media print {
+      @page {
+        size: A4;
+        margin: 0;
+      }
+      /* 1:1 on paper, whichever viewport bucket the screen happened to be in. */
+      #resume-zoom {
+        --zoom: 1;
+      }
     }
   </style>
 </Layout>

--- a/apps/personal-website/src/components/pages/ResumePage.astro
+++ b/apps/personal-website/src/components/pages/ResumePage.astro
@@ -108,153 +108,80 @@ const personSchema = {
 >
   <script type="application/ld+json" set:html={JSON.stringify(personSchema)} />
   <main
-    class="flex-col-center bg-foreground h-screen w-screen overflow-scroll p-10 print:items-start print:justify-start print:overflow-visible print:p-0"
+    class="bg-foreground flex min-h-screen w-full justify-center p-4 sm:p-10 print:block print:min-h-0 print:p-0"
   >
     {
       /*
-        A true A4 sheet: 210mm x 297mm, so the on-screen page and the printed one are the same
-        object. The previous 75rem x 105rem box was ratio 1.400 where A4 is 1.4143 — close enough
-        to look right and wrong enough that print scaled it.
+        One box, and no transforms anywhere. Two earlier attempts scaled a fixed 210mm x 297mm
+        sheet — first to fit the viewport, then to fit the contents — and each scale brought its
+        own bug: `transform: scale` reserves the unscaled layout box (~760px of dead scroll space
+        under the resume), and shrinking text to 92% to avoid a second page is the thing every
+        resume guide tells you not to do.
 
-        Three boxes because two scales apply independently, and collapsing them would couple
-        "fit the sheet to this screen" to "fit the contents to the sheet": #resume-zoom reserves
-        the on-screen size, #resume-sheet is the page itself, #resume-fit holds the contents.
-        Both scales are defined in the <style> block below, next to the reasoning for each.
+        So the sheet is a document, not a fixed page. It keeps A4's *width*, which is what makes
+        it look like a page and what makes line lengths match the print output, and lets its
+        height follow the content. How that content divides into pages is the printer's job,
+        decided by `@page` and the break rules below — the one mechanism that can put a page
+        boundary in a sensible place instead of clipping whatever crosses it.
       */
     }
-    <div id="resume-zoom">
-      <div id="resume-sheet">
-        <div id="resume-fit">
-          <ATSFriendly {...resumeProps} />
-        </div>
-      </div>
+    <div id="resume-sheet">
+      <ATSFriendly {...resumeProps} />
     </div>
   </main>
   {
     /*
-      Shrink-to-fit, measured rather than guessed.
-
-      Density work in ats-friendly.astro got the contents to ~0.95 of a page, so this normally has
-      almost nothing to do. It exists for the case that follows: every role added to the content
-      files pushes the page out again, and the failure is silent — #resume-fit is `overflow: hidden`,
-      so an overflowing resume quietly loses its last lines instead of complaining. Measuring the
-      real height and scaling only on overflow turns that into a few percent of extra compression.
-
-      Both measurements are layout values, unaffected by the two enclosing transforms, so the ratio
-      is correct at any --zoom.
-
-      Runs on load and before print (Safari and Firefox honour `beforeprint`; Chrome fires it too),
-      because the print layout resolves at a different width than the scaled screen preview.
-    */
-  }
-  <script is:inline>
-    (() => {
-      const fit = () => {
-        const box = document.getElementById('resume-fit');
-        const sheet = document.getElementById('resume-sheet');
-        const article = box?.firstElementChild;
-        if (!box || !sheet || !article) return;
-
-        // Measure unscaled, or each run would compound the previous run's scale.
-        box.style.setProperty('--fit', '1');
-
-        // Only an overflowing element reports its true content extent: scrollHeight is clamped to
-        // clientHeight otherwise, so a short resume would look like a full page and get shrunk
-        // for no reason.
-        if (article.scrollHeight <= article.clientHeight) return;
-
-        // scrollHeight covers the top padding but NOT the bottom padding of overflowing content,
-        // so it under-reports the space actually needed by exactly one bottom padding (10mm here).
-        // Left uncorrected the scale lands the last line flush on the paper's edge, and the line
-        // after that is silently clipped — which is what this page did before the correction.
-        const padBottom =
-          parseFloat(getComputedStyle(article).paddingBottom) || 0;
-        const needed = article.scrollHeight + padBottom;
-        const available = sheet.clientHeight;
-        if (needed > available) {
-          box.style.setProperty('--fit', String(available / needed));
-        }
-      };
-
-      // Fonts change metrics enough to matter; re-measure once they land.
-      if (document.fonts?.ready) void document.fonts.ready.then(fit);
-      window.addEventListener('load', fit);
-      window.addEventListener('beforeprint', fit);
-      // Content height is width-dependent, and the width changes with the --zoom breakpoints.
-      let queued = 0;
-      window.addEventListener('resize', () => {
-        cancelAnimationFrame(queued);
-        queued = requestAnimationFrame(fit);
-      });
-      fit();
-    })();
-  </script>
-  {
-    /*
-      Plain CSS rather than Tailwind utilities, for two reasons this page ran into directly:
-
-      1. `[--zoom:0.32] sm:[--zoom:0.5] …` generated the three variant rules but not the base one,
-         leaving `var(--zoom)` unresolved below 640px.
-      2. A `print:[--zoom:1]` utility, and an override in a `<style media="print">` block, both
-         failed to reach the document — the media attribute does not survive Astro's style
-         bundling, so `@media print` has to be written inside the stylesheet itself.
-
-      Explicit media queries also make the cascade order visible, which matters when two nested
-      transforms read these variables.
+      Plain CSS rather than Tailwind utilities: a `media="print"` attribute does not survive
+      Astro's style bundling, so `@media print` has to be written inside the stylesheet itself.
+      An earlier `<style media="print">` block reached no page at all, silently.
     */
   }
   <style>
-    /* Fits the whole sheet to the viewport. On the wrapper, not the sheet: `transform: scale`
-       shrinks what an element paints but not the layout box it reserves, so scaling the sheet in
-       place left ~760px of dead scroll space below the resume and overflowed horizontally. The
-       wrapper takes the scaled size; the sheet scales from its top-left corner to fill it. */
-    #resume-zoom {
-      --zoom: 0.32;
-      width: calc(210mm * var(--zoom));
-      height: calc(297mm * var(--zoom));
-    }
-    @media (min-width: 40rem) {
-      #resume-zoom {
-        --zoom: 0.5;
-      }
-    }
-    @media (min-width: 48rem) {
-      #resume-zoom {
-        --zoom: 0.75;
-      }
-    }
-    @media (min-width: 64rem) {
-      #resume-zoom {
-        --zoom: 1;
-      }
-    }
-
+    /* A4's width, and only its width — that is what fixes the line length to match the printed
+       page. `max-width` rather than `width` so the sheet goes fluid on a phone instead of
+       rendering 210mm as an unreadable thumbnail, and `min-height` keeps it looking like a sheet
+       of paper when the contents are short. Height otherwise follows the content. */
     #resume-sheet {
-      width: 210mm;
-      height: 297mm;
-      transform: scale(var(--zoom));
-      transform-origin: top left;
-    }
-
-    /* Shrinks only the contents, and only when they exceed one page. Defaults to 1 so the layout
-       is correct with JavaScript off or before the script below runs. Centred horizontally so the
-       width the scale gives back becomes even margin rather than a right-hand gutter. */
-    #resume-fit {
       width: 100%;
-      height: 100%;
-      overflow: hidden;
-      transform: scale(var(--fit, 1));
-      transform-origin: top center;
+      max-width: 210mm;
+      min-height: 297mm;
     }
 
     @media print {
+      /* The margin belongs to the page box, not to the article. Padding on the article would
+         indent only the first page; every page needs the same frame. 12mm/16mm is a conventional
+         resume margin and matches the article's screen padding, so the preview and the print
+         break lines in the same places. Every millimetre trimmed here is ~3.8px back on *each*
+         page, which is what kept this to two pages rather than two-and-a-stub. */
       @page {
         size: A4;
-        margin: 0;
+        margin: 12mm 16mm;
       }
-      /* 1:1 on paper, whichever viewport bucket the screen happened to be in. */
-      #resume-zoom {
-        --zoom: 1;
+
+      /* On paper the page *is* the sheet, so the screen sheet stops constraining anything. */
+      #resume-sheet {
+        max-width: none;
+        min-height: 0;
+      }
+
+      /* Fragmentation — the difference between a two-page resume that looks deliberate and one
+         that looks like it ran out of room. Left alone, a browser breaks wherever the page ends:
+         one line into a bullet, or between a heading and what it introduces.
+
+         orphans/widows stop a single line being stranded either side of the boundary. The
+         companion `break-inside-avoid` / `break-after-avoid` utilities live in ats-friendly.astro,
+         on the elements they protect: each role's heading block, each project write-up, and the
+         Education and Skills sections. */
+      p,
+      li {
+        orphans: 3;
+        widows: 3;
+      }
+
+      /* The dark backdrop is screen furniture. Browsers usually drop backgrounds when printing,
+         but only usually — "Print backgrounds" is a checkbox a recruiter may well have on. */
+      main {
+        background: none;
       }
     }
   </style>

--- a/apps/personal-website/src/components/resume/ats-friendly.astro
+++ b/apps/personal-website/src/components/resume/ats-friendly.astro
@@ -47,7 +47,6 @@ const skills = groupBy(
     <h1>{info.name.fullname}</h1>
     <h2>{info.jobPosition}</h2>
     <ul class="mb-5 mt-4 list-none pl-0">
-      <li><a href={`tel:${info.phone}`}>{info.phone}</a></li>
       <li><a href={`mailto:${info.email}`}>{info.email}</a></li>
       <li>{info.location.city}, {info.location.country}</li>
       <li>

--- a/apps/personal-website/src/components/resume/ats-friendly.astro
+++ b/apps/personal-website/src/components/resume/ats-friendly.astro
@@ -31,18 +31,16 @@ const contacts: { label: string; href?: string }[] = [
   { label: bare(gitHubUrl), href: gitHubUrl },
   { label: bare(info.links.website), href: info.links.website },
 ];
-// Full-time roles only. For a senior engineer with years of full-time work behind them, the three
-// student-era internships (2018–2020) earn the least of any section on a one-page resume. They
-// stay on the home page's timeline, which has the room — this is the page that has to choose, so
-// it carries the work that would actually be discussed. (Dropping them helped the page fit, but
-// it was not the main lever: the typography density below and the four project write-ups under
-// CodeGreen each accounted for more.)
+// Every job, internships included. This resume is two pages by design (see ResumePage.astro), and
+// the failure mode of a two-page resume is a second page holding three lines — that reads as an
+// accident rather than a choice. The student-era roles (2018–2020) are what give page two enough
+// substance to be deliberate. Strict reverse-chronological order keeps them where a reader expects,
+// below the full-time work rather than competing with it.
 const experiences = (
   await getCollection('experiences', (item) => {
     const isLangMatch = item.id.startsWith(lang);
     const isJobMatch = item.data.type === 'job';
-    const isFullTime = item.data.employment !== 'internship';
-    return isLangMatch && isJobMatch && isFullTime;
+    return isLangMatch && isJobMatch;
   })
 ).sort((a, b) => b.data.startAt.getTime() - a.data.startAt.getTime());
 
@@ -62,15 +60,26 @@ const skills = groupBy(
 
 {
   /*
-    The `prose-*` tail past `max-w-none` is print density, not styling preference. Tailwind
-    Typography tunes `prose` for articles — line-height 1.714 and ~1.14em of air above and below
-    every list — which on a one-page resume was worth ~280px of a 1123px page on its own. The
-    overrides pull body text to `leading-snug` and collapse inter-list spacing; nothing is
-    hidden or truncated, the same words simply occupy the density a printed resume expects.
+    The `prose-*` tail past `max-w-none` trims Typography's article rhythm to resume spacing —
+    zeroed heading and list-item margins, tighter paragraph gaps.
+
+    `leading-snug` is applied to list items only, not to paragraphs. Bullets are the bulk of the
+    text here (roughly thirty lines across the project write-ups), so they are where line-height
+    actually buys page space — ~140px of it, which is the difference between two pages and two
+    pages plus a near-empty third. Prose paragraphs keep their normal leading, because those are
+    the lines a person actually reads end to end.
+
+    No fixed height. The page count is decided by the printer, from `@page` and the break rules
+    in ResumePage.astro, not by clipping this box at one A4's worth of pixels.
+
+    Padding is screen-only, and responsive. In print, `@page`'s margin box does this job on *every*
+    page, where padding here would only ever indent the first. The 16mm the printed page wants is
+    35% of the sheet's width on a 375px phone, so below `sm` it drops to something a narrow screen
+    can afford — matching print exactly only matters at the width that is actually previewing it.
   */
 }
 <article
-  class="bg-background text-foreground font-resume-serif prose prose-sm prose-headings:text-foreground prose-a:text-foreground prose-li:text-foreground prose-headings:m-0 prose-h2:mb-2 prose-li:m-0 prose-p:mt-0 prose-p:mb-1.5 prose-p:leading-snug prose-li:leading-snug prose-ul:my-1 prose-ul:pl-4 size-full max-w-none px-[16mm] py-[10mm]"
+  class="bg-background text-foreground font-resume-serif prose prose-sm prose-headings:text-foreground prose-a:text-foreground prose-li:text-foreground prose-headings:m-0 prose-h2:mb-2 prose-h2:break-after-avoid prose-li:m-0 prose-li:leading-snug prose-p:mt-0 prose-p:mb-2 prose-ul:my-2 w-full max-w-none px-6 py-8 sm:px-[16mm] sm:py-[12mm] print:p-0"
 >
   <section>
     <h1>{info.name.fullname}</h1>
@@ -81,11 +90,12 @@ const skills = groupBy(
         full URL ("LinkedIn: rainforest-cheng (https://linkedin.com/in/rainforest-cheng)") — the
         same fact twice, for ~110px of a 297mm page.
 
-        The "·" is a real text node, deliberately not a CSS ::after. Generated content is absent
-        from the DOM's text, so an ATS extracting this list would read
-        "contact@rainforest.toolsTaipei, Taiwan" as one token and its email regex would capture
-        the city too. A text separator keeps the boundary in the extracted string. It's
-        aria-hidden because each entry is already an <li> a screen reader announces separately.
+        The "·" is a real text node, deliberately not a CSS ::after. A parser reading the HTML
+        gets a line break from each <li> regardless — but a PDF's text layer is built from visual
+        position, and these five render on one visual line, so on that path the separator is the
+        only thing standing between "contact@rainforest.tools" and "Taipei". Generated content
+        reaches neither path. It's aria-hidden because each entry is already an <li> that a
+        screen reader announces separately.
       */
     }
     <ul class="mb-4 mt-2 flex list-none flex-wrap gap-x-1 pl-0">
@@ -115,21 +125,30 @@ const skills = groupBy(
           const projects = await getEntries(item.data.projects);
           const { Content } = await render(item);
           return (
-            <li>
+            <li class="mb-3">
               {/* Organization and dates share one baseline row — the conventional resume layout,
-                  and it reclaims a line per role over the previous stacked date/org/position. */}
-              <div class="flex items-baseline justify-between gap-2">
-                <h3>{organization.data.name}</h3>
-                <span class="whitespace-nowrap">
-                  <time>{format(startAt, resumeDateFormat, { locale })}</time> -{' '}
-                  {endAt ? (
-                    <time>{format(endAt, resumeDateFormat, { locale })}</time>
-                  ) : (
-                    <span>{t('present')}</span>
-                  )}
-                </span>
+                  and it reclaims a line per role over a stacked date/org/position block.
+
+                  The group is break-avoid so a role's heading can never be stranded at the foot
+                  of a page with its content overleaf. The <li> itself stays breakable on purpose:
+                  CodeGreen carries four project write-ups and is taller than one page, so
+                  `break-inside: avoid` there would shove the whole entry onto page two and
+                  overflow it regardless. */}
+              <div class="break-inside-avoid break-after-avoid">
+                <div class="flex items-baseline justify-between gap-2">
+                  <h3>{organization.data.name}</h3>
+                  <span class="whitespace-nowrap">
+                    <time>{format(startAt, resumeDateFormat, { locale })}</time>{' '}
+                    -{' '}
+                    {endAt ? (
+                      <time>{format(endAt, resumeDateFormat, { locale })}</time>
+                    ) : (
+                      <span>{t('present')}</span>
+                    )}
+                  </span>
+                </div>
+                <h5>{position}</h5>
               </div>
-              <h5>{position}</h5>
               <Content />
               <ul class="list-none pl-0">
                 {projects &&
@@ -141,7 +160,8 @@ const skills = groupBy(
                         ? `${info.links.website}/portfolio/${slug}`
                         : undefined;
                     return (
-                      <li>
+                      // Short enough to always keep whole, unlike the role that contains them.
+                      <li class="break-inside-avoid">
                         <h4>
                           {project.data.name}
                           {caseStudyUrl && (
@@ -162,60 +182,69 @@ const skills = groupBy(
       }
     </ul>
   </section>
-  <section class="grid w-full break-after-auto grid-cols-2">
-    <section>
-      <h2>{t('education')}</h2>
-      <ul>
-        {
-          education.map(async (item) => {
-            const organization = await getEntry(item.data.organization);
-            const period = `${format(item.data.startAt, resumeDateFormat)} - ${format(item.data.endAt!, resumeDateFormat)}`;
-            // const { Content } = await render(item);
-            return (
-              <li>
-                <h3>{organization.data.name}</h3>
-                <h4>{period}</h4>
-                <h5>
-                  {t('education-description', {
-                    degree: item.data.position,
-                    major: organization.data.department,
-                  })}
-                </h5>
-                {/* <Content /> */}
-              </li>
-            );
-          })
-        }
-      </ul>
-    </section>
-    <section>
-      <h2>{t('skills')}</h2>
+  {
+    /*
+      Education above Skills in one column, not side by side. A CSS grid preserves DOM order for
+      anything reading the HTML, so a text-based ATS was never at risk — but a PDF's text layer is
+      built from visual position, so the moment this page is printed or saved to PDF a two-column
+      block can interleave into "National Taiwan University Frontend: Flutter". Single column is
+      the format that survives every path a recruiter might take to the content.
+    */
+  }
+  <section class="break-inside-avoid">
+    <h2>{t('education')}</h2>
+    <ul>
       {
-        /*
+        education.map(async (item) => {
+          const organization = await getEntry(item.data.organization);
+          const period = `${format(item.data.startAt, resumeDateFormat)} - ${format(item.data.endAt!, resumeDateFormat)}`;
+          const { Content } = await render(item);
+          return (
+            <li class="mb-2 break-inside-avoid">
+              <div class="flex items-baseline justify-between gap-2">
+                <h3>{organization.data.name}</h3>
+                <span class="whitespace-nowrap">{period}</span>
+              </div>
+              <h5>
+                {t('education-description', {
+                  degree: item.data.position,
+                  major: organization.data.department,
+                })}
+              </h5>
+              <Content />
+            </li>
+          );
+        })
+      }
+    </ul>
+  </section>
+  <section class="break-inside-avoid">
+    <h2>{t('skills')}</h2>
+    {
+      /*
           One inline run per category instead of a 3-column grid of stacked lists. Thirteen skills
           across five categories left most of that grid's cells holding two or three short words
           while still occupying two full rows (~207px); as inline runs the same words fit in about
           half the height. Kept as <ul>/<li> for ATS structure, with the comma as a text node so
           the extracted string stays delimited — the same reason the header's "·" is text.
         */
-      }
-      {
-        skillSections.map((section) => (
-          <div class="mb-1">
-            <h3 class="inline text-[1em] font-semibold">
-              {t(`skills-${section}`)}:
-            </h3>{' '}
-            <ul class="m-0 inline list-none p-0">
-              {skills[section].map((skill, i) => (
-                <li class="inline capitalize">
-                  {skill.data.name}
-                  {i < skills[section].length - 1 && ', '}
-                </li>
-              ))}
-            </ul>
-          </div>
-        ))
-      }
-    </section>
+    }
+    {
+      skillSections.map((section) => (
+        <div class="mb-1">
+          <h3 class="inline text-[1em] font-semibold">
+            {t(`skills-${section}`)}:
+          </h3>{' '}
+          <ul class="m-0 inline list-none p-0">
+            {skills[section].map((skill, i) => (
+              <li class="inline capitalize">
+                {skill.data.name}
+                {i < skills[section].length - 1 && ', '}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))
+    }
   </section>
 </article>

--- a/apps/personal-website/src/components/resume/ats-friendly.astro
+++ b/apps/personal-website/src/components/resume/ats-friendly.astro
@@ -18,11 +18,31 @@ const locale =
 
 const linkedInUrl = getLinkedInUrl(info.links.linkedin);
 const gitHubUrl = getGitHubUrl(info.links.github);
+// On paper the scheme is noise — nobody types "https://" off a printed page — and dropping it
+// (with any "www.") keeps each entry short enough for the single inline run in the header.
+const bare = (url: string) => url.replace(/^https?:\/\/(www\.)?/, '');
+
+// Built as data so the separator between entries can be a real text node (see the header's
+// comment on why that matters for text extraction) without repeating the conditional five times.
+const contacts: { label: string; href?: string }[] = [
+  { label: info.email, href: `mailto:${info.email}` },
+  { label: `${info.location.city}, ${info.location.country}` },
+  { label: bare(linkedInUrl), href: linkedInUrl },
+  { label: bare(gitHubUrl), href: gitHubUrl },
+  { label: bare(info.links.website), href: info.links.website },
+];
+// Full-time roles only. For a senior engineer with years of full-time work behind them, the three
+// student-era internships (2018–2020) earn the least of any section on a one-page resume. They
+// stay on the home page's timeline, which has the room — this is the page that has to choose, so
+// it carries the work that would actually be discussed. (Dropping them helped the page fit, but
+// it was not the main lever: the typography density below and the four project write-ups under
+// CodeGreen each accounted for more.)
 const experiences = (
   await getCollection('experiences', (item) => {
     const isLangMatch = item.id.startsWith(lang);
     const isJobMatch = item.data.type === 'job';
-    return isLangMatch && isJobMatch;
+    const isFullTime = item.data.employment !== 'internship';
+    return isLangMatch && isJobMatch && isFullTime;
   })
 ).sort((a, b) => b.data.startAt.getTime() - a.data.startAt.getTime());
 
@@ -40,30 +60,49 @@ const skills = groupBy(
 );
 ---
 
+{
+  /*
+    The `prose-*` tail past `max-w-none` is print density, not styling preference. Tailwind
+    Typography tunes `prose` for articles — line-height 1.714 and ~1.14em of air above and below
+    every list — which on a one-page resume was worth ~280px of a 1123px page on its own. The
+    overrides pull body text to `leading-snug` and collapse inter-list spacing; nothing is
+    hidden or truncated, the same words simply occupy the density a printed resume expects.
+  */
+}
 <article
-  class="bg-background text-foreground font-resume-serif prose prose-sm prose-headings:text-foreground prose-a:text-foreground prose-li:text-foreground prose-headings:m-0 prose-h2:mb-3 prose-li:m-0 prose-p:mt-0 prose-p:mb-2 size-full max-w-none px-20 py-10"
+  class="bg-background text-foreground font-resume-serif prose prose-sm prose-headings:text-foreground prose-a:text-foreground prose-li:text-foreground prose-headings:m-0 prose-h2:mb-2 prose-li:m-0 prose-p:mt-0 prose-p:mb-1.5 prose-p:leading-snug prose-li:leading-snug prose-ul:my-1 prose-ul:pl-4 size-full max-w-none px-[16mm] py-[10mm]"
 >
   <section>
     <h1>{info.name.fullname}</h1>
     <h2>{info.jobPosition}</h2>
-    <ul class="mb-5 mt-4 list-none pl-0">
-      <li><a href={`mailto:${info.email}`}>{info.email}</a></li>
-      <li>{info.location.city}, {info.location.country}</li>
-      <li>
-        LinkedIn: {info.links.linkedin} (<a href={linkedInUrl} target="_blank"
-          >{linkedInUrl}</a
-        >)
-      </li>
-      <li>
-        GitHub: {info.links.github} (<a href={gitHubUrl} target="_blank"
-          >{gitHubUrl}</a
-        >)
-      </li>
-      <li>
-        {t('website')}: <a href={info.links.website} target="_blank"
-          >{info.links.website}</a
-        >
-      </li>
+    {
+      /*
+        One inline run rather than five stacked lines. The old block printed each handle AND its
+        full URL ("LinkedIn: rainforest-cheng (https://linkedin.com/in/rainforest-cheng)") — the
+        same fact twice, for ~110px of a 297mm page.
+
+        The "·" is a real text node, deliberately not a CSS ::after. Generated content is absent
+        from the DOM's text, so an ATS extracting this list would read
+        "contact@rainforest.toolsTaipei, Taiwan" as one token and its email regex would capture
+        the city too. A text separator keeps the boundary in the extracted string. It's
+        aria-hidden because each entry is already an <li> a screen reader announces separately.
+      */
+    }
+    <ul class="mb-4 mt-2 flex list-none flex-wrap gap-x-1 pl-0">
+      {
+        contacts.map(({ label, href }, i) => (
+          <li>
+            {href ? (
+              <a href={href} target="_blank">
+                {label}
+              </a>
+            ) : (
+              label
+            )}
+            {i < contacts.length - 1 && <span aria-hidden="true"> · </span>}
+          </li>
+        ))
+      }
     </ul>
   </section>
   <section>
@@ -77,15 +116,19 @@ const skills = groupBy(
           const { Content } = await render(item);
           return (
             <li>
-              <Fragment>
-                <time>{format(startAt, resumeDateFormat, { locale })}</time> -{' '}
-                {endAt ? (
-                  <time>{format(endAt, resumeDateFormat, { locale })}</time>
-                ) : (
-                  <span>{t('present')}</span>
-                )}
-              </Fragment>
-              <h3>{organization.data.name}</h3>
+              {/* Organization and dates share one baseline row — the conventional resume layout,
+                  and it reclaims a line per role over the previous stacked date/org/position. */}
+              <div class="flex items-baseline justify-between gap-2">
+                <h3>{organization.data.name}</h3>
+                <span class="whitespace-nowrap">
+                  <time>{format(startAt, resumeDateFormat, { locale })}</time> -{' '}
+                  {endAt ? (
+                    <time>{format(endAt, resumeDateFormat, { locale })}</time>
+                  ) : (
+                    <span>{t('present')}</span>
+                  )}
+                </span>
+              </div>
               <h5>{position}</h5>
               <Content />
               <ul class="list-none pl-0">
@@ -104,7 +147,7 @@ const skills = groupBy(
                           {caseStudyUrl && (
                             <Fragment>
                               {' — '}
-                              <a href={caseStudyUrl}>{caseStudyUrl}</a>
+                              <a href={caseStudyUrl}>{bare(caseStudyUrl)}</a>
                             </Fragment>
                           )}
                         </h4>
@@ -147,20 +190,32 @@ const skills = groupBy(
     </section>
     <section>
       <h2>{t('skills')}</h2>
-      <div class="grid grid-cols-3">
-        {
-          skillSections.map((section) => (
-            <div>
-              <h3>{t(`skills-${section}`)}</h3>
-              <ul>
-                {skills[section].map((skill) => (
-                  <li class="capitalize">{skill.data.name}</li>
-                ))}
-              </ul>
-            </div>
-          ))
-        }
-      </div>
+      {
+        /*
+          One inline run per category instead of a 3-column grid of stacked lists. Thirteen skills
+          across five categories left most of that grid's cells holding two or three short words
+          while still occupying two full rows (~207px); as inline runs the same words fit in about
+          half the height. Kept as <ul>/<li> for ATS structure, with the comma as a text node so
+          the extracted string stays delimited — the same reason the header's "·" is text.
+        */
+      }
+      {
+        skillSections.map((section) => (
+          <div class="mb-1">
+            <h3 class="inline text-[1em] font-semibold">
+              {t(`skills-${section}`)}:
+            </h3>{' '}
+            <ul class="m-0 inline list-none p-0">
+              {skills[section].map((skill, i) => (
+                <li class="inline capitalize">
+                  {skill.data.name}
+                  {i < skills[section].length - 1 && ', '}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))
+      }
     </section>
   </section>
 </article>

--- a/apps/personal-website/src/types/ui.ts
+++ b/apps/personal-website/src/types/ui.ts
@@ -4,7 +4,6 @@ import type { ILocation, IName, ISkill, SkillTag } from './data';
 
 export interface IContactProps {
   email: string;
-  phone: string;
   links: {
     linkedin: string;
     github: string;

--- a/apps/personal-website/src/utils/constants/index.ts
+++ b/apps/personal-website/src/utils/constants/index.ts
@@ -19,7 +19,6 @@ export const tags = {
 export const info = {
   dateOfBirth: '1997-02-18',
   email: 'contact@rainforest.tools',
-  phone: '+886981352355',
   links: {
     linkedin: 'yulin-cheng',
     github: 'rainforest-dev',


### PR DESCRIPTION
## What

The resume page printed the phone number, overflowed its sheet, and clipped whatever crossed the bottom edge. This removes the number, replaces the fixed-and-scaled sheet with a real paginated document, and makes the printed output ATS-appropriate.

Four commits, each self-contained:

| commit | |
|---|---|
| `77ef06c` | remove the phone number (**breaking**: drops `info.phone` and `IResumeProps.phone`) |
| `3d9614f` | fit onto one true A4 page |
| `22fb620` | paginate across two pages instead of scaling |
| `9018122` | print black on white, fix scoped-away print rules |

## Why it took three attempts at the layout

Worth reading in order — each fix exposed the next problem, and two of them were bugs in my own previous fix:

1. **The sheet was never A4.** 75rem x 105rem is ratio 1.400 where A4 is 1.4143 — close enough to look right, wrong enough that print rescaled it. Contents overflowed by 56px and `overflow: hidden` ate them silently.
2. **`transform: scale` reserves the unscaled layout box.** The responsively-scaled sheet painted 254x359 while still occupying 794x1123, leaving ~760px of dead scroll space below the resume and 397px of horizontal overflow. This was most of the reported "overflow at the bottom".
3. **The zoom only consulted viewport _width_.** A 1440x900 laptop is "large", got `zoom: 1`, and put 320px of a 1123px sheet below the fold. Every measurement taken at a tall viewport agreed the page fitted — because at a tall viewport it did.

The fix for (3) was to stop scaling altogether. Shrinking text to avoid a second page is the thing resume guidance tells you not to do, and both scales had shipped a defect. The sheet now keeps A4's **width** and lets height follow content; pagination is `@page` plus CSS fragmentation, which can put a boundary somewhere sensible instead of clipping what crosses it.

## Balance was measured, not assumed

Content height over page height said 1.91 pages. That is wrong — it ignores that break rules *push* content down rather than filling to the edge. Simulating the real boxes under the real rules gave **three pages at 87% / 87% / 17%**, the near-empty tail the whole exercise was meant to avoid.

A 12mm page margin (~3.8px back on *every* page) and `leading-snug` on list items only — where ~30 bullet lines make it worth ~140px — land it at:

| | pages | fill |
|---|---|---|
| en | 2 | 88% / 80% |
| zh | 2 | 99% / 47% |

333px of slack before a third page could appear. The break falls at a project boundary, not mid-heading.

Two pages needs enough content to be deliberate, so the internships are back (they are what make page two substantial) and Education renders detail that was commented out.

## ATS

- **Single column.** Education and Skills were a 2-column grid. DOM order always protected an HTML parser, but a PDF text layer follows visual position and those columns can interleave once printed.
- **Black on white in print.** The theme's mint `bg-background` was printing as a tinted block — which also made the `@page` margin read as stray padding, since the tint stopped where the margin began. Pipelines that OCR a PDF rather than read its text layer need the contrast.
- **Separators are real text nodes** where it matters. The skills runs are `display: inline`, so without the comma text nodes an extractor reads `FrontendFlutter` and matches no keyword. (The header's `·` is *not* load-bearing on the HTML path — every `<li>` yields a line break regardless. It earns its place on the PDF path, where those five entries share one visual line. An earlier commit message overstated this; `9018122` corrects it.)

## The bug worth reviewing

`22fb620` added `p, li { orphans: 3; widows: 3 }` inside `ResumePage.astro`. Astro scopes a component's selectors to that component's own elements, and the article lives in `ats-friendly.astro`, so it compiled to:

```css
li[data-astro-cid-t2mi2g5v], p[data-astro-cid-t2mi2g5v] { orphans:3; widows:3 }
```

Exactly seven elements on the page carry that id, all in `ResumePage.astro`, none of them a paragraph of the resume. The rule shipped, was visible in the built CSS, and matched nothing. `9018122` routes every cross-component print selector through `:global()`, verified against built output rather than source.

The `break-inside-avoid` / `break-after-avoid` half was never affected — those are utility classes on the elements themselves.

## Not fixed, and why

The date, title, URL and page number the browser prints are a **print-dialog setting**, not page content (Chrome: "Headers and footers"; Safari: "Print headers and footers"). The only CSS lever is `@page { margin: 0 }`, which leaves no margin box to draw them in — but page margins can only come from `@page`, since padding on the article indents the first page and the last and never the boundary between, putting content into the printer's unprintable edge. Real margins are the better trade. A deterministic fix would be a headless-generated `/resume.pdf` with `displayHeaderFooter: false`.

## Verification

Verified from a running dev server per `CLAUDE.md`, not from `dist`:

- sheet 210.1mm; two pages in both locales; no horizontal scroll at 375px or 1440px
- mobile goes fluid at full 14px instead of a 254px thumbnail
- phone: 0 references in source, 0 `tel:` links in the DOM, 0 `href="tel:"` in the build
- screen rendering unchanged — every print rule sits inside `@media print`

Verified in the built output, both locales:

- `@page{size:A4;margin:12mm 16mm}`, `orphans:3;widows:3`, `color:#000!important`
- print selectors escape component scoping: `#resume-sheet[…] *`, `#resume-sheet[…] p`
- Tailwind emitted `.break-inside-avoid` and `.break-after-avoid` (13 and 6 uses) — worth checking, since an arbitrary-property utility silently failed to generate earlier in this work

Gates: `nx run-many -t test --all` green (6 projects), `nx build` green, `format:check` clean, `nx lint` 0 errors (7 pre-existing warnings).

## Reviewer notes

- **Breaking**: `info.phone` and `IResumeProps.phone` are gone. Deleting it removes the number from HEAD and from deployed pages, but it remains in git history and in anything that already crawled the page.
- CodeGreen carries four project write-ups and is taller than a page, so it necessarily spans the break — page 2 opens on "OpenCGT" with the employer name on page 1. Cutting a project would fix it; that is a content call.
- Pre-existing and untouched: hydration mismatches log site-wide (identical on the home page), and the skill name renders `Nx(monorepo)` with no space, which is in the content data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)