### PR TITLE
fix(loop): a rolled-over quota window is not negative usage

### DIFF
--- a/tools/loop/engine/lib/loopctl/writeback.py
+++ b/tools/loop/engine/lib/loopctl/writeback.py
@@ -212,7 +212,14 @@ def _quota_block(before_5h, after_5h, before_week, after_week) -> dict | None:
     week_before, week_after = _pct(before_week), _pct(after_week)
     if all(v is None for v in (five_before, five_after, week_before, week_after)):
         return None
-    delta = lambda a, b: None if a is None or b is None else round(b - a, 4)
+    # A window that rolled over mid-run reads lower afterwards. Usage inside a
+    # window cannot fall, so a negative difference measures the reset, not the
+    # run -- null is the honest answer. Measured 2026-07-31: an AG-130 run
+    # recorded five_hour_delta_pp = -36.0.
+    def delta(a, b):
+        if a is None or b is None or b < a:
+            return None
+        return round(b - a, 4)
     return {
         "five_hour_before": five_before,
         "five_hour_after": five_after,

--- a/tools/loop/engine/ralph.sh
+++ b/tools/loop/engine/ralph.sh
@@ -247,10 +247,19 @@ refresh_quota() {
 
 # Percentage-point delta between two quota readings, for the per-iteration
 # estimate.
+#
+# A quota window that rolls over mid-run reads lower afterwards, and subtracting
+# gives a negative "usage" that is arithmetic, not measurement. On 2026-07-31 an
+# AG-130 run logged `5h 44%→8.0% (~-36.0pp)`, which reads as if the iteration
+# handed 36 points back. Usage within a window cannot fall, so a lower "after" is
+# a reset and the iteration's own cost is unmeasurable from these two samples --
+# say that instead of printing a number.
 pct_delta() {
   [ -n "$1" ] && [ -n "$2" ] || { printf '?'; return; }
   "$PYTHON_BIN" -c \
-    'from decimal import Decimal; import sys; print(Decimal(sys.argv[2]) - Decimal(sys.argv[1]))' \
+    'from decimal import Decimal; import sys
+before, after = Decimal(sys.argv[1]), Decimal(sys.argv[2])
+print("window reset" if after < before else "~{}pp".format(after - before))' \
     "$1" "$2"
 }
 
@@ -622,7 +631,7 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
   d5=$(pct_delta "$pct5_before" "$pct5_after")
   dw=$(pct_delta "$pctw_before" "$pctw_after")
   log "iter $iter/$MAX_ITER · project=$slug · executor=$provider · cost=\$$cost · spent=\$$SPENT"
-  log "  quota · 5h ${pct5_before:-?}%→${pct5_after:-?}% (~${d5}pp) · weekly ${pctw_before:-?}%→${pctw_after:-?}% (~${dw}pp)"
+  log "  quota · 5h ${pct5_before:-?}%→${pct5_after:-?}% (${d5}) · weekly ${pctw_before:-?}%→${pctw_after:-?}% (${dw})"
   # An executor that stops at step 0 exits 0 and bills normally, so cost alone
   # cannot tell "did the work" from "could not start". Say what it concluded and
   # whether the repo moved -- on 2026-07-29 a run logged `done` having produced

--- a/tools/loop/tests/execution-presets.sh
+++ b/tools/loop/tests/execution-presets.sh
@@ -458,6 +458,26 @@ contains "and says what refused it" "$mirror_out" "Permission denied"
 clean_out=$("$LOOPCTL" set sandbox "$TASK_KEY" queued --note "mirror probe ok" 2>&1)
 excludes "a working mirror reports nothing" "$clean_out" "mirror_error"
 
+# --- 11. a rolled-over quota window is not negative usage ---------------------
+# 2026-07-31: an AG-130 run logged `5h 44%→8.0% (~-36.0pp)` and recorded
+# five_hour_delta_pp = -36.0. Usage inside a window cannot fall; a lower "after"
+# means the window reset, and this run's cost is unmeasurable from those two
+# samples. Both the log line and the run record must say so rather than invent a
+# refund.
+echo "  a window reset is not a refund:"
+delta_lib="$ROOT/pct-delta.sh"
+awk '/^pct_delta\(\) \{/,/^\}/' "$HOME_DIR/ralph.sh" > "$delta_lib"
+delta_probe() {
+  PYTHON_BIN="$VENV/bin/python" bash -c '. "$1"; pct_delta "$2" "$3"' _ "$delta_lib" "$1" "$2"
+}
+check "a reset is named, not subtracted" "$(delta_probe 44 8)" "window reset"
+check "a real rise still reports points"  "$(delta_probe 31 81)" "~50pp"
+check "no movement is zero, not blank"    "$(delta_probe 10 10)" "~0pp"
+block=$(PYTHONPATH="$HOME_DIR/lib" "$VENV/bin/python" -c \
+  'from loopctl.writeback import _quota_block; import json; print(json.dumps(_quota_block(44, 8, 31, 81)))')
+check "the record nulls the reset delta" "$(printf '%s' "$block" | "$VENV/bin/python" -c 'import json,sys; print(json.load(sys.stdin)["five_hour_delta_pp"])')" "None"
+check "and keeps the measurable one"     "$(printf '%s' "$block" | "$VENV/bin/python" -c 'import json,sys; print(json.load(sys.stdin)["weekly_delta_pp"])')" "50.0"
+
 printf '\n  %d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ] || exit 1
 rm -rf "$ROOT"


### PR DESCRIPTION
fix(loop): a rolled-over quota window is not negative usage

The AG-130 run on 2026-07-31 logged

  quota · 5h 44%→8.0% (~-36.0pp) · weekly 31%→81.0% (~50.0pp)

and recorded `five_hour_delta_pp: -36.0`. The weekly figure is real -- that run
cost $11.25 of Opus 5 and half the weekly allowance with it. The five-hour figure
is not a measurement at all: the window rolled over mid-run. Usage inside a window
cannot fall, so a lower "after" says the window reset and this run's five-hour
cost is unmeasurable from those two samples.

Reporting it as -36pp reads as a refund, and it is the kind of number that
silently averages into a cost comparison. The log now prints `window reset` and
the run record stores null. A rise is unchanged: `~50pp` still reads `~50pp`.

Both sites had the same subtraction independently -- ralph's `pct_delta` for the
log line and writeback's `_quota_block` for the record -- so both are fixed and
both are covered.

  execution-presets.sh 57 passed, 0 failed (was 52)

This also corrects an earlier claim of mine in this work: I said the quota
snapshot was stale. It is not. Running the exporter by hand refreshed it
immediately, and today's readings are internally consistent -- 44/31 held across
the Codex-only AG-297 run because Codex does not touch the Claude pool, then moved
to 81% weekly when Opus 5 ran. The defect was only ever in how a reset is
presented.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
