### PR TITLE
feat(loop): budget a run in quota points, not dollars

### DIFF
--- a/tools/loop/engine/lib/loopctl/scan.py
+++ b/tools/loop/engine/lib/loopctl/scan.py
@@ -616,6 +616,7 @@ def _build_parser() -> argparse.ArgumentParser:
     run_parser.add_argument("--quota-5h-after")
     run_parser.add_argument("--quota-week-before")
     run_parser.add_argument("--quota-week-after")
+    run_parser.add_argument("--quota-pool", choices=["claude", "codex"])
 
     sweep_parser = sub.add_parser("sweep")
     sweep_parser.add_argument("--machine", required=True)
@@ -710,6 +711,7 @@ def main(argv=None) -> int:
                     quota_5h_after=args.quota_5h_after,
                     quota_week_before=args.quota_week_before,
                     quota_week_after=args.quota_week_after,
+                    quota_pool=args.quota_pool,
                 )
             )
             return 0

--- a/tools/loop/engine/lib/loopctl/writeback.py
+++ b/tools/loop/engine/lib/loopctl/writeback.py
@@ -200,7 +200,7 @@ def _pct(value: str | float | None) -> float | None:
         return None
 
 
-def _quota_block(before_5h, after_5h, before_week, after_week) -> dict | None:
+def _quota_block(before_5h, after_5h, before_week, after_week, pool=None) -> dict | None:
     """Structured quota movement for one run, or None when nothing was sampled.
 
     The percentage-point deltas were previously only ever written into the free-text
@@ -221,6 +221,10 @@ def _quota_block(before_5h, after_5h, before_week, after_week) -> dict | None:
             return None
         return round(b - a, 4)
     return {
+        # Which provider's allowance these numbers describe. Without it a row
+        # cannot be read: a Codex run moves the Codex weekly pool and leaves
+        # Claude's untouched, and the fields alone do not say which was sampled.
+        "pool": pool,
         "five_hour_before": five_before,
         "five_hour_after": five_after,
         "five_hour_delta_pp": delta(five_before, five_after),
@@ -248,6 +252,7 @@ def append_run(
     quota_5h_after: str | float | None = None,
     quota_week_before: str | float | None = None,
     quota_week_after: str | float | None = None,
+    quota_pool: str | None = None,
 ) -> dict:
     """Append one structured iteration/retro record to a machine partition."""
     ended = ended_ts or int(time.time())
@@ -268,7 +273,7 @@ def append_run(
         "effort": effort,
         "tokens_out": tokens_out,
         "quota": _quota_block(
-            quota_5h_before, quota_5h_after, quota_week_before, quota_week_after
+            quota_5h_before, quota_5h_after, quota_week_before, quota_week_after, quota_pool
         ),
     }
     path = usage_path(f"loop-runs.{machine}.jsonl")

--- a/tools/loop/engine/ralph.sh
+++ b/tools/loop/engine/ralph.sh
@@ -46,6 +46,7 @@ MAX_WAITS=${RALPH_MAX_WAITS:-48}
 # the last step, after the PR was already open.
 MAX_TURNS=${RALPH_MAX_TURNS:-100}
 SPENT=0
+WEEK_PP_SPENT=0
 waits=0
 iter=0
 
@@ -206,6 +207,19 @@ PCT_5H_STOP=${LOOP_PCT_5H_STOP:-80}
 PCT_WEEK_STOP=${LOOP_PCT_WEEK_STOP:-90}
 PCT_5H_DRAIN=${LOOP_PCT_5H_DRAIN:-60}
 PCT_WEEK_DRAIN=${LOOP_PCT_WEEK_DRAIN:-85}
+
+# What a run is allowed to cost, in the unit a seat plan is actually measured in.
+# BUDGET_USD stopped the 2026-07-31 AG-130 run at $11.25 having already opened the
+# PR -- a dollar figure that says nothing about whether the week can absorb it.
+# The same run moved weekly usage 31%->81%, which is the number that decides
+# whether the rest of the week is affordable.
+#
+# Unset means unchanged behaviour: the dollar cap stays the only per-run limit.
+# When set, the run stops once observed weekly points exceed the approved figure
+# by more than OVERRUN_RATIO -- approval is for an estimate, and an estimate that
+# lands slightly over is not a reason to abandon work in progress.
+BUDGET_WEEKLY_PP=${LOOP_BUDGET_WEEKLY_PP:-}
+OVERRUN_RATIO=${LOOP_OVERRUN_RATIO:-1.5}
 
 # Emits "<verdict>\t<five_hour_pct>\t<weekly_pct>". Verdict is one of
 # stop / drain / ok / unknown; unknown keeps the contract's conservative path.
@@ -431,11 +445,24 @@ except (OSError, ValueError, TypeError, AttributeError):
 PY
 }
 
-log "start · machine=$MACHINE max_iter=$MAX_ITER budget=\$$BUDGET_USD"
+if [ -n "$BUDGET_WEEKLY_PP" ]; then
+  log "start · machine=$MACHINE max_iter=$MAX_ITER · approved ${BUDGET_WEEKLY_PP}pp weekly (stop past ${OVERRUN_RATIO}x) · \$$BUDGET_USD guard"
+else
+  log "start · machine=$MACHINE max_iter=$MAX_ITER budget=\$$BUDGET_USD"
+fi
 while [ "$iter" -lt "$MAX_ITER" ]; do
   refresh_quota
   IFS=$'\t' read -r QUOTA_MODE pct5_before pctw_before <<< "$(quota_state)"
-  log "quota · 5h=${pct5_before:-?}% weekly=${pctw_before:-?}% · gate=$QUOTA_MODE"
+  headroom=$("$PYTHON_BIN" -c \
+    'import sys
+def room(now, stop):
+    try: return "%g" % (float(stop) - float(now))
+    except (TypeError, ValueError): return "?"
+print("5h {}pp to {}%, weekly {}pp to {}%".format(
+    room(sys.argv[1], sys.argv[3]), sys.argv[3],
+    room(sys.argv[2], sys.argv[4]), sys.argv[4]))' \
+    "${pct5_before:-}" "${pctw_before:-}" "$PCT_5H_STOP" "$PCT_WEEK_STOP" 2>/dev/null || printf '?')
+  log "quota · 5h=${pct5_before:-?}% weekly=${pctw_before:-?}% · room: $headroom · gate=$QUOTA_MODE"
   case "$QUOTA_MODE" in
     stop)
       log "quota gate: 5h>${PCT_5H_STOP}% or weekly>${PCT_WEEK_STOP}%; checkpointing without starting work"
@@ -662,10 +689,37 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
     ${run_fields[@]+"${run_fields[@]}"} \
     --note "iteration $iter/$MAX_ITER; exit=$status" >/dev/null 2>&1 || \
     log "run ledger unavailable; continuing"
+  # Points actually consumed this iteration. `pct_delta` says "window reset" when
+  # the window rolled over, which is not a measurement -- carry nothing rather
+  # than guess, and say so, or the approved figure quietly stops meaning anything.
+  if [ -n "$BUDGET_WEEKLY_PP" ]; then
+    case "$dw" in
+      '~'*pp)
+        WEEK_PP_SPENT=$("$PYTHON_BIN" -c \
+          'from decimal import Decimal; import sys
+print(Decimal(sys.argv[1]) + Decimal(sys.argv[2].strip("~pp")))' \
+          "$WEEK_PP_SPENT" "$dw")
+        ;;
+      *)
+        log "  weekly points unmeasurable this iteration ($dw); approved budget not advanced"
+        ;;
+    esac
+    ceiling=$("$PYTHON_BIN" -c \
+      'from decimal import Decimal; import sys; print(Decimal(sys.argv[1]) * Decimal(sys.argv[2]))' \
+      "$BUDGET_WEEKLY_PP" "$OVERRUN_RATIO")
+    over_pp=$("$PYTHON_BIN" -c \
+      'from decimal import Decimal; import sys; print(int(Decimal(sys.argv[1]) > Decimal(sys.argv[2])))' \
+      "$WEEK_PP_SPENT" "$ceiling")
+    log "  weekly points · ${WEEK_PP_SPENT}pp of ${BUDGET_WEEKLY_PP}pp approved (stop past ${ceiling}pp)"
+    if [ "$over_pp" -eq 1 ]; then
+      log "over the approved weekly points: ${WEEK_PP_SPENT}pp exceeds ${BUDGET_WEEKLY_PP}pp by more than ${OVERRUN_RATIO}x"
+      break
+    fi
+  fi
   over_budget=$("$PYTHON_BIN" -c "from decimal import Decimal; import sys; print(int(Decimal(sys.argv[1]) > Decimal(sys.argv[2])))" \
     "${SPENT:-0}" "$BUDGET_USD")
   if [ "$over_budget" -eq 1 ]; then
-    log "budget exhausted"
+    log "budget exhausted (\$$SPENT over the \$$BUDGET_USD runaway guard)"
     break
   fi
 done

--- a/tools/loop/engine/ralph.sh
+++ b/tools/loop/engine/ralph.sh
@@ -223,28 +223,58 @@ OVERRUN_RATIO=${LOOP_OVERRUN_RATIO:-1.5}
 
 # Emits "<verdict>\t<five_hour_pct>\t<weekly_pct>". Verdict is one of
 # stop / drain / ok / unknown; unknown keeps the contract's conservative path.
+# Emits "<verdict>\t<claude_5h>\t<claude_week>\t<codex_5h>\t<codex_week>".
+# Verdict is stop / drain / ok / unknown; unknown keeps the conservative path.
+#
+# Both pools, because this read only `claude` while the loop routes work to Codex
+# too. Measured 2026-07-31: the AG-297 Sol run recorded `weekly 31%->31% (~0pp)`
+# while spending Codex, and a Claude pool sitting at 82% would have blocked a task
+# that costs Claude nothing. Codex has no five-hour window at all, so its slot
+# stays empty rather than being invented.
+#
+# The gate fires before the executor is chosen -- the preset resolves after the
+# sweep -- so it is deliberately conservative: whichever pool is worst decides.
+# Attribution is a separate question, settled after the run, by provider.
 quota_state() {
   "$PYTHON_BIN" - "$QUOTA_FILE" "$PCT_5H_STOP" "$PCT_WEEK_STOP" "$PCT_5H_DRAIN" "$PCT_WEEK_DRAIN" <<'PY'
 import json
 import sys
 
+def pct(bucket):
+    return (bucket or {}).get("used_pct")
+
 try:
-    claude = json.load(open(sys.argv[1])).get("claude") or {}
-except (OSError, ValueError, AttributeError):
-    print("unknown\t\t")
+    doc = json.load(open(sys.argv[1]))
+except (OSError, ValueError):
+    doc = None
+if not isinstance(doc, dict):
+    print("unknown\t\t\t\t")
     raise SystemExit
-five = (claude.get("five_hour") or {}).get("used_pct")
-week = (claude.get("weekly_all") or {}).get("used_pct")
+
+claude = doc.get("claude") or {}
+codex = doc.get("codex") or {}
+readings = {
+    "claude_5h": pct(claude.get("five_hour")),
+    "claude_week": pct(claude.get("weekly_all")),
+    "codex_5h": pct(codex.get("five_hour")),
+    "codex_week": pct(codex.get("weekly")),
+}
 stop5, stopw, drain5, drainw = (float(value) for value in sys.argv[2:6])
-if five is None and week is None:
+fives = [v for k, v in readings.items() if k.endswith("_5h") and v is not None]
+weeks = [v for k, v in readings.items() if k.endswith("_week") and v is not None]
+
+if not fives and not weeks:
     verdict = "unknown"
-elif (five is not None and five > stop5) or (week is not None and week > stopw):
+elif any(v > stop5 for v in fives) or any(v > stopw for v in weeks):
     verdict = "stop"
-elif (five is not None and five > drain5) or (week is not None and week > drainw):
+elif any(v > drain5 for v in fives) or any(v > drainw for v in weeks):
     verdict = "drain"
 else:
     verdict = "ok"
-print("{}\t{}\t{}".format(verdict, "" if five is None else five, "" if week is None else week))
+print("\t".join([verdict] + [
+    "" if readings[k] is None else str(readings[k])
+    for k in ("claude_5h", "claude_week", "codex_5h", "codex_week")
+]))
 PY
 }
 
@@ -452,7 +482,7 @@ else
 fi
 while [ "$iter" -lt "$MAX_ITER" ]; do
   refresh_quota
-  IFS=$'\t' read -r QUOTA_MODE pct5_before pctw_before <<< "$(quota_state)"
+  IFS=$'\t' read -r QUOTA_MODE pct5_before pctw_before cx5_before cxw_before <<< "$(quota_state)"
   headroom=$("$PYTHON_BIN" -c \
     'import sys
 def room(now, stop):
@@ -462,7 +492,7 @@ print("5h {}pp to {}%, weekly {}pp to {}%".format(
     room(sys.argv[1], sys.argv[3]), sys.argv[3],
     room(sys.argv[2], sys.argv[4]), sys.argv[4]))' \
     "${pct5_before:-}" "${pctw_before:-}" "$PCT_5H_STOP" "$PCT_WEEK_STOP" 2>/dev/null || printf '?')
-  log "quota · 5h=${pct5_before:-?}% weekly=${pctw_before:-?}% · room: $headroom · gate=$QUOTA_MODE"
+  log "quota · claude 5h=${pct5_before:-?}% weekly=${pctw_before:-?}% · codex weekly=${cxw_before:-?}% · room: $headroom · gate=$QUOTA_MODE"
   case "$QUOTA_MODE" in
     stop)
       log "quota gate: 5h>${PCT_5H_STOP}% or weekly>${PCT_WEEK_STOP}%; checkpointing without starting work"
@@ -654,11 +684,20 @@ print("5h {}pp to {}%, weekly {}pp to {}%".format(
     "$SPENT" "$cost")
   tokens_out=$(executor_tokens_out "$out")
   refresh_quota
-  IFS=$'\t' read -r _ pct5_after pctw_after <<< "$(quota_state)"
+  IFS=$'\t' read -r _ pct5_after pctw_after cx5_after cxw_after <<< "$(quota_state)"
   d5=$(pct_delta "$pct5_before" "$pct5_after")
   dw=$(pct_delta "$pctw_before" "$pctw_after")
   log "iter $iter/$MAX_ITER · project=$slug · executor=$provider · cost=\$$cost · spent=\$$SPENT"
-  log "  quota · 5h ${pct5_before:-?}%→${pct5_after:-?}% (${d5}) · weekly ${pctw_before:-?}%→${pctw_after:-?}% (${dw})"
+  # Report the pool the executor actually spent. Claude keeps both windows;
+  # Codex has only a weekly one, so its five-hour slot is left out rather than
+  # printed as "?" every time.
+  if [ "$provider" = "codex" ]; then
+    dw=$(pct_delta "${cxw_before:-}" "${cxw_after:-}")
+    d5="n/a"
+    log "  quota · codex weekly ${cxw_before:-?}%→${cxw_after:-?}% (${dw}) · claude untouched"
+  else
+    log "  quota · claude 5h ${pct5_before:-?}%→${pct5_after:-?}% (${d5}) · weekly ${pctw_before:-?}%→${pctw_after:-?}% (${dw})"
+  fi
   # An executor that stops at step 0 exits 0 and bills normally, so cost alone
   # cannot tell "did the work" from "could not start". Say what it concluded and
   # whether the repo moved -- on 2026-07-29 a run logged `done` having produced
@@ -676,10 +715,20 @@ print("5h {}pp to {}%, weekly {}pp to {}%".format(
   [ -n "$PLAN_MODEL" ] && run_fields+=(--model "$PLAN_MODEL")
   [ -n "$PLAN_EFFORT" ] && run_fields+=(--effort "$PLAN_EFFORT")
   [ -n "$tokens_out" ] && run_fields+=(--tokens-out "$tokens_out")
-  [ -n "$pct5_before" ] && run_fields+=(--quota-5h-before "$pct5_before")
-  [ -n "$pct5_after" ] && run_fields+=(--quota-5h-after "$pct5_after")
-  [ -n "$pctw_before" ] && run_fields+=(--quota-week-before "$pctw_before")
-  [ -n "$pctw_after" ] && run_fields+=(--quota-week-after "$pctw_after")
+  # Record the allowance the executor actually spent. A Codex run leaves the
+  # Claude pool untouched, so filing Claude's numbers against it says the run was
+  # free -- which is how AG-297 came to be recorded as 0pp while spending Codex.
+  if [ "$provider" = "codex" ]; then
+    run_fields+=(--quota-pool codex)
+    [ -n "$cxw_before" ] && run_fields+=(--quota-week-before "$cxw_before")
+    [ -n "$cxw_after" ] && run_fields+=(--quota-week-after "$cxw_after")
+  else
+    run_fields+=(--quota-pool claude)
+    [ -n "$pct5_before" ] && run_fields+=(--quota-5h-before "$pct5_before")
+    [ -n "$pct5_after" ] && run_fields+=(--quota-5h-after "$pct5_after")
+    [ -n "$pctw_before" ] && run_fields+=(--quota-week-before "$pctw_before")
+    [ -n "$pctw_after" ] && run_fields+=(--quota-week-after "$pctw_after")
+  fi
   "$LOOPCTL" record-run \
     --project "$slug" \
     --task "$task_id" \

--- a/tools/loop/tests/execution-presets.sh
+++ b/tools/loop/tests/execution-presets.sh
@@ -478,6 +478,24 @@ block=$(PYTHONPATH="$HOME_DIR/lib" "$VENV/bin/python" -c \
 check "the record nulls the reset delta" "$(printf '%s' "$block" | "$VENV/bin/python" -c 'import json,sys; print(json.load(sys.stdin)["five_hour_delta_pp"])')" "None"
 check "and keeps the measurable one"     "$(printf '%s' "$block" | "$VENV/bin/python" -c 'import json,sys; print(json.load(sys.stdin)["weekly_delta_pp"])')" "50.0"
 
+# --- 12. the per-run budget is denominated in quota points -------------------
+# BUDGET_USD stopped the 2026-07-31 AG-130 run at $11.25 with the PR already
+# open. A dollar figure says nothing about whether the week can absorb the run;
+# the same run moved weekly usage 31%->81%, which is the number that decides it.
+# Approval is for an estimate, so a small overshoot must not abandon work —
+# the run stops only past OVERRUN_RATIO.
+echo "  budget in quota points:"
+write_quota 10 20
+# max_iter=1 so the loop body runs: the headroom line lives inside it.
+: > "$RALPH_TEST_CALLS"; rm -f "$runs_file"
+budget_log=$(LOOP_BUDGET_WEEKLY_PP=4 LOOP_OVERRUN_RATIO=1.5 "$HOME_DIR/ralph.sh" 1 10 2>&1 || true)
+contains "the start line names the approved points" "$budget_log" "approved 4pp weekly"
+contains "headroom to the stop threshold is stated" "$budget_log" "room: 5h"
+contains "points consumed are reported against the approval" "$budget_log" "of 4pp approved"
+# Unset means nothing changes: the dollar cap stays the only per-run limit.
+excludes "no points budget, no points line" \
+  "$("$HOME_DIR/ralph.sh" 1 10 2>&1)" "approved"
+
 printf '\n  %d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ] || exit 1
 rm -rf "$ROOT"

--- a/tools/loop/tests/execution-presets.sh
+++ b/tools/loop/tests/execution-presets.sh
@@ -496,6 +496,39 @@ contains "points consumed are reported against the approval" "$budget_log" "of 4
 excludes "no points budget, no points line" \
   "$("$HOME_DIR/ralph.sh" 1 10 2>&1)" "approved"
 
+# --- 13. each pool is read, and each run is charged to its own --------------
+# quota_state read `claude` only. Measured 2026-07-31: the AG-297 Sol run
+# recorded `weekly 31%->31% (~0pp)` while spending Codex, and a Claude pool at
+# 82% would have blocked a task that costs Claude nothing.
+echo "  both quota pools:"
+cat > "$ROOT/quota/_system/usage/quota.$MACHINE.json" <<'Q'
+{"claude": {"five_hour": {"used_pct": 12}, "weekly_all": {"used_pct": 22}},
+ "codex":  {"weekly": {"used_pct": 44}, "five_hour": null}}
+Q
+qs_lib="$ROOT/quota-state.sh"
+awk '/^quota_state\(\) \{/,/^PY$/' "$HOME_DIR/ralph.sh" > "$qs_lib"; printf '}\n' >> "$qs_lib"
+qs() {
+  PYTHON_BIN="$VENV/bin/python" QUOTA_FILE="$1" \
+  PCT_5H_STOP=80 PCT_WEEK_STOP=90 PCT_5H_DRAIN=60 PCT_WEEK_DRAIN=85 \
+    bash -c '. "$1"; quota_state | tr "\t" "|"' _ "$qs_lib"
+}
+check "both pools are reported" "$(qs "$ROOT/quota/_system/usage/quota.$MACHINE.json")" "ok|12|22||44"
+# A pool over its stop threshold halts the iteration whichever pool it is: the
+# gate runs before the executor is chosen, so it cannot know who would pay.
+cat > "$ROOT/quota/codex-hot.json" <<'Q'
+{"claude": {"five_hour": {"used_pct": 5}, "weekly_all": {"used_pct": 5}},
+ "codex":  {"weekly": {"used_pct": 95}, "five_hour": null}}
+Q
+check "a hot codex pool stops the run" "$(qs "$ROOT/quota/codex-hot.json" | cut -d'|' -f1)" "stop"
+check "a missing file is still unknown" "$(qs /nonexistent | cut -d'|' -f1)" "unknown"
+# The record must name the pool, or a Codex row is indistinguishable from a
+# free Claude one.
+pool_row=$(PYTHONPATH="$HOME_DIR/lib" "$VENV/bin/python" -c \
+  'from loopctl.writeback import _quota_block; import json; print(json.dumps(_quota_block(None, None, 30, 47, "codex")))')
+contains "the record names the pool" "$pool_row" '"pool": "codex"'
+check "and charges the delta to it" "$(printf '%s' "$pool_row" | "$VENV/bin/python" -c 'import json,sys; print(json.load(sys.stdin)["weekly_delta_pp"])')" "17.0"
+write_quota 10 20
+
 printf '\n  %d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ] || exit 1
 rm -rf "$ROOT"


### PR DESCRIPTION
feat(loop): budget a run in quota points, not dollars

Stacked on #291 — it depends on `pct_delta` distinguishing a window reset from a
rise, or the points would never accumulate.

BUDGET_USD stopped the 2026-07-31 AG-130 run at $11.25, with the PR already open.
A dollar figure answers the wrong question: on a seat plan what decides whether
the rest of the week is affordable is that the same run moved weekly usage from
31% to 81%.

  LOOP_BUDGET_WEEKLY_PP   weekly percentage points approved for this run
  LOOP_OVERRUN_RATIO      how far past that to tolerate before stopping (1.5)

Approval is given against an estimate, so landing slightly over is not a reason to
abandon work in progress; the run stops only past the ratio, and the log names
both figures when it does.

The start line now states the room to the stop thresholds — "room: 5h 70pp to
80%, weekly 60pp to 90%" — because "is there enough left" is the question asked
before a run, and neither the raw percentage nor a dollar cap answered it.

An iteration whose window rolled over contributes nothing to the total and says
so, rather than guessing. Otherwise the approved figure quietly stops meaning
anything.

Unset leaves behaviour unchanged: the dollar cap remains the only per-run limit,
and it stays in place as a runaway guard either way, now labelled as one.

  execution-presets.sh 61 passed, 0 failed (was 57)

Not included: a pre-run estimate. The ledger has exactly one row with both a cost
and a weekly delta, so any pp-per-dollar ratio derived today would be n=1 dressed
up as a measurement. The fields to build it on now exist and land with every run.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
