### PR TITLE
fix(loop): charge a codex run from its own session, not the newest file

### DIFF
--- a/tools/loop/engine/ralph.sh
+++ b/tools/loop/engine/ralph.sh
@@ -141,6 +141,79 @@ print("\n".join(parts) if saw_json else raw)
 ' 2>/dev/null || printf '%s' "$1"
 }
 
+# Weekly points a codex run actually spent, read from the session it just wrote.
+#
+# The exporter samples "the newest session file", which is not this run's: codex
+# exec spawns guardian and subagent sessions alongside it, and the newest one can
+# be a sibling that carries no rate_limits yet. Measured 2026-07-31, both samples
+# of the AG-288 Luna run came back empty and the record stored `quota: null`,
+# while the run's own session held the answer all along.
+#
+# Every `token_count` event carries `rate_limits.primary.used_percent`, so the
+# first and last of them bracket exactly this run and nothing else. That is a
+# cleaner measurement than any before/after file read: a shared pool moves for
+# other reasons between two samples, and a session file cannot.
+codex_weekly_pp() {
+  local transcript="$1"
+  [ -f "$transcript" ] || return 0
+  "$PYTHON_BIN" - "$transcript" "$HOME/.codex/sessions" <<'PY' 2>/dev/null || true
+import glob
+import json
+import os
+import sys
+
+# The thread id codex announces is the session filename's suffix.
+thread = None
+try:
+    with open(sys.argv[1]) as handle:
+        for line in handle:
+            line = line.strip()
+            if not line.startswith("{"):
+                continue
+            try:
+                event = json.loads(line)
+            except ValueError:
+                continue
+            if event.get("type") == "thread.started" and event.get("thread_id"):
+                thread = event["thread_id"]
+                break
+except OSError:
+    pass
+if not thread:
+    raise SystemExit
+
+matches = glob.glob(os.path.join(sys.argv[2], "**", f"*{thread}.jsonl"), recursive=True)
+if not matches:
+    raise SystemExit
+
+first = last = None
+try:
+    with open(matches[0]) as handle:
+        for line in handle:
+            line = line.strip()
+            if '"token_count"' not in line:
+                continue
+            try:
+                payload = (json.loads(line).get("payload") or {})
+            except ValueError:
+                continue
+            if payload.get("type") != "token_count":
+                continue
+            primary = ((payload.get("rate_limits") or {}).get("primary") or {})
+            used = primary.get("used_percent")
+            if used is None:
+                continue
+            if first is None:
+                first = used
+            last = used
+except OSError:
+    raise SystemExit
+
+if first is not None and last is not None:
+    print("{}\t{}".format(first, last))
+PY
+}
+
 rate_limited() {
   executor_error_text "$1" |
     grep -qiE 'rate.?limit|too many requests|(usage|weekly|5-?hour|daily)[ -]?limit|quota (exceeded|reached|limit)'
@@ -692,6 +765,12 @@ print("5h {}pp to {}%, weekly {}pp to {}%".format(
   # Codex has only a weekly one, so its five-hour slot is left out rather than
   # printed as "?" every time.
   if [ "$provider" = "codex" ]; then
+    # The run's own session beats sampling a shared file twice. Fall back to the
+    # file only when the session cannot be located.
+    own=$(codex_weekly_pp "${transcript:-}")
+    if [ -n "$own" ]; then
+      IFS=$'\t' read -r cxw_before cxw_after <<< "$own"
+    fi
     dw=$(pct_delta "${cxw_before:-}" "${cxw_after:-}")
     d5="n/a"
     log "  quota · codex weekly ${cxw_before:-?}%→${cxw_after:-?}% (${dw}) · claude untouched"

--- a/tools/loop/tests/execution-presets.sh
+++ b/tools/loop/tests/execution-presets.sh
@@ -529,6 +529,45 @@ contains "the record names the pool" "$pool_row" '"pool": "codex"'
 check "and charges the delta to it" "$(printf '%s' "$pool_row" | "$VENV/bin/python" -c 'import json,sys; print(json.load(sys.stdin)["weekly_delta_pp"])')" "17.0"
 write_quota 10 20
 
+# --- 14. a codex run is charged from its own session -------------------------
+# The exporter samples "the newest session file", which is not necessarily this
+# run's: codex exec writes guardian and subagent sessions alongside it. Measured
+# 2026-07-31, both samples of the AG-288 Luna run came back empty and the record
+# stored `quota: null`, while the run's own session held 53%→57% throughout.
+echo "  codex points from its own session:"
+sessions="$ROOT/codex-sessions/2026/07/31"
+mkdir -p "$sessions"
+mk_session() {  # <thread> <first-pct> <last-pct>
+  local f="$sessions/rollout-2026-07-31T00-00-00-$1.jsonl"
+  printf '{"type":"session_meta","payload":{"source":"exec"}}\n' > "$f"
+  for pct in "$2" "$3"; do
+    printf '{"type":"event_msg","payload":{"type":"token_count","rate_limits":{"primary":{"used_percent":%s,"window_minutes":10080}}}}\n' "$pct" >> "$f"
+  done
+}
+mk_session "thread-real" 53.0 57.0
+# A sibling written later with no rate_limits at all — the exact shape that made
+# "newest file" return nothing.
+printf '{"type":"session_meta","payload":{"source":"exec"}}\n' > "$sessions/rollout-2026-07-31T23-59-59-thread-guardian.jsonl"
+cat > "$ROOT/fake-transcript.log" <<'T'
+{"type":"thread.started","thread_id":"thread-real"}
+{"type":"turn.completed","usage":{"output_tokens":47983}}
+T
+cpp_lib="$ROOT/codex-pp.sh"
+awk '/^codex_weekly_pp\(\) \{/,/^PY$/' "$HOME_DIR/ralph.sh" > "$cpp_lib"; printf '}\n' >> "$cpp_lib"
+cpp() {  # <fake-home> <transcript>
+  PYTHON_BIN="$VENV/bin/python" HOME="$1" \
+    bash -c '. "$1"; type codex_weekly_pp >/dev/null 2>&1 || { echo "HELPER-NOT-LOADED"; exit 0; }; codex_weekly_pp "$2"' \
+    _ "$cpp_lib" "$2"
+}
+# HOME is redirected so the helper looks in the sandbox's .codex/sessions.
+mkdir -p "$ROOT/fakehome/.codex"; ln -sfn "$ROOT/codex-sessions" "$ROOT/fakehome/.codex/sessions"
+check "the run's own session is found and bracketed" \
+  "$(cpp "$ROOT/fakehome" "$ROOT/fake-transcript.log" | tr '\t' '>')" "53.0>57.0"
+# A transcript naming no thread must yield nothing rather than someone else's run.
+printf '{"type":"turn.completed"}\n' > "$ROOT/no-thread.log"
+check "no thread id means no number" "$(cpp "$ROOT/fakehome" "$ROOT/no-thread.log")" ""
+check "a missing transcript is silent" "$(cpp "$ROOT/fakehome" /nonexistent.log)" ""
+
 printf '\n  %d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ] || exit 1
 rm -rf "$ROOT"


### PR DESCRIPTION
fix(loop): charge a codex run from its own session, not the newest file

The Codex attribution added in #292 produced nothing on its first real use. The
AG-288 Luna run on 2026-07-31 stored `quota: null` while its own session held
53% → 57% the whole time.

The exporter samples "the newest session file". That is not this run's: codex exec
writes guardian and subagent sessions alongside it, and the newest can be a
sibling carrying no rate_limits yet. Two samples of a shared file also cannot tell
this run's spend from anything else that touched the pool between them; a session
file can, because it belongs to exactly one run.

Every `token_count` event carries `rate_limits.primary.used_percent`, and codex
announces its `thread_id` in the stream ralph already captures — the session
filename ends with it. First and last bracket the run exactly.

Verified against the three codex runs already on disk:

  AG-288 Luna   53% → 57%    4pp    47,983 output tokens
  AG-297 Sol    41% → 49%    8pp    36,010 output tokens
  AG-132 Terra  23% → 24%    1pp    12,359 output tokens

Which is the first real read on relative cost: Sol spends about 2.2pp per 10k
output tokens against 0.8 for Terra and Luna — roughly 2.7x — and Luna produced
33% more output than Sol for half the quota.

The file sampling stays as the fallback for when the session cannot be located.

  execution-presets.sh 69 passed, 0 failed (was 66)

Two of the new assertions passed vacuously on first run: the helper had not
loaded, so an empty result matched the expected empty result. The probe now fails
loudly with HELPER-NOT-LOADED instead.

Claude has no equivalent. Its pool moves for reasons other than the run — this
session was spending it throughout — so the 50pp recorded against AG-130 is an
upper bound, not an attribution. Claude's per-run cost is exact only in dollars,
from the result envelope.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
