### PR TITLE
docs(loop): a sandbox pre-flight failure is not a connectivity failure

### DIFF
--- a/tools/loop/engine/contract.md
+++ b/tools/loop/engine/contract.md
@@ -66,6 +66,16 @@ the `openapi-sync` skill, which fetches the backend dev spec. `blocked` is legit
 only when the sync ran and the contract is still absent, and the reason must say so.
 Never hand-edit generated types and never infer an API shape to get past this.
 
+A connectivity pre-flight that fails inside the sandbox is not a connectivity
+problem. `openapi-sync` opens with `curl -fsSI` against the backend spec; macOS
+curl validates through the keychain, which the sandbox cannot read, so it returns
+exit 60 "unable to get local issuer certificate" while the network is fine.
+Measured 2026-08-03: the same host answered `HTTP 200` to a node fetch from the
+same sandbox in the same second, and the certificate was a valid Amazon-issued
+one. Setting CURL_CA_BUNDLE does not help — the failure is in Secure Transport,
+not the bundle. The sync target itself runs on node and is unaffected. Check the
+sync's own result, never the pre-flight.
+
 Measured 2026-07-30 on AG-132: an executor read the `openapi-sync` skill, saw the
 contract missing from the checked-in `api.gen.ts`, and recorded `blocked` claiming
 the backend PR was unmerged — while that PR had merged six days earlier and the dev


### PR DESCRIPTION
docs(loop): a sandbox pre-flight failure is not a connectivity failure

AG-289 stopped on 2026-08-03 with "OpenAPI sync preflight did not pass: curl exit
60 (SSL certificate problem: unable to get local issuer certificate)". It made no
edits and reported that honestly. The network was fine the whole time.

macOS curl validates through the keychain, which the sandbox cannot read. The sync
target itself runs on node, which carries its own CA bundle. Measured from one
sandbox in the same second:

  curl -fsSI   exit 60
  node fetch   HTTP 200
  openssl      subject=CN=cloud.angible.net, issuer=Amazon ECDSA 384 M01

CURL_CA_BUNDLE=/etc/ssl/cert.pem does not help; the failure is in Secure
Transport, not the bundle.

This trap was already documented — on AG-132's task note, and nowhere else. Three
later tickets ran without it and the first one to reach the pre-flight stopped on
it. A trap that applies to every ticket using `openapi-sync` belongs in the
contract, not in whichever note happened to discover it.

Sits directly above the existing rule that a missing generated artefact is not a
blocker until you regenerate it: same failure mode, one step earlier. That rule
tells you to run the sync; this one stops you abandoning it before you start.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
