### PR TITLE
fix(personal-website): restore rainforest.tools — declare .vercel/output as a build output

### DIFF
--- a/apps/personal-website/package.json
+++ b/apps/personal-website/package.json
@@ -90,6 +90,10 @@
         "dependsOn": [
           "^build"
         ],
+        "outputs": [
+          "{projectRoot}/dist",
+          "{projectRoot}/.vercel/output"
+        ],
         "cache": true
       },
       "test": {


### PR DESCRIPTION
## Production is down and this restores it

`rainforest.tools` returns Vercel's platform 404 on every route — `x-vercel-error: NOT_FOUND`, 84 bytes of `text/plain` — on all six domains including `mcp.` and `www.`. The deployment behind them is `READY`, its aliases are assigned, `aliasError` is `null`. Nothing failed, and there is no error anywhere to find.

## Root cause

`@astrojs/vercel` writes the deployable artefact to `{projectRoot}/.vercel/output` — `config.json` with 23 routes, plus `functions/`, `server/`, `static/`.

The Nx `build` target declared only `{projectRoot}/dist`, inherited from `nx.json`'s `targetDefaults`, with `cache: true`. **Nx restores exactly what a target declares.** So on a cache hit it rebuilt `dist/` and left `.vercel/output` absent — and Vercel deployed an output directory containing no routes. A 404 on every path, from a green build.

## Why now, on a docs commit

A production deploy had never before hit a *full* cache. `13ebeec` is docs-only and touches the `loop` project — the first change to reach `main` that did not alter `personal-website`'s input hash.

| deploy | build | result |
|---|---|---|
| 07-31 17:20 | `personal-website:build` ran, 1m 58s | site up |
| 08-03 10:36 | `Cache: 3/3 hit (100%)`, 970ms | **site 404s** |

## Verification

A/B against a single warm cache, deleting the outputs between runs so both replay the production condition exactly:

| config | cache | `dist` | `.vercel/output` |
|---|---|---|---|
| unfixed | 3/3 hit, 71ms | restored | **absent** ← the outage |
| fixed | 3/3 hit, 682ms | restored | restored, 23 routes |

Also confirmed present after the fixed run: `static/resume/index.html` and `functions/`.

Gates: `nx run-many -t test --all` green (6 projects), `format:check` clean.

## Why declare the path rather than disable the cache

The artefact is deterministic and worth caching; `cache: false` would trade a real bug for a two-minute build on every deploy. Added to this project rather than `nx.json`'s `targetDefaults` because it is specific to the Vercel adapter's Build Output API — projects that never produce the directory would carry a path that never matches.

It does grow the Nx cache (the functions bundles are the bulk of the 372 MB Vercel already uploads), which is the right trade against shipping an empty output directory to production.

## Note for whoever merges

Merging restores the site: the changed `package.json` alters the input hash, forcing a real build that writes `.vercel/output`.

For an immediate fix without waiting on this PR, redeploy the latest production deployment from the Vercel dashboard with **"Use existing Build Cache" unchecked** — that starves Nx of its cache, forcing the same real build. That is mitigation only; without this change the next cache hit breaks it again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)