### PR TITLE
feat(loop): give the run ledger edges, not just measurements

### DIFF
--- a/tools/loop/engine/lib/loopctl/scan.py
+++ b/tools/loop/engine/lib/loopctl/scan.py
@@ -617,6 +617,9 @@ def _build_parser() -> argparse.ArgumentParser:
     run_parser.add_argument("--quota-week-before")
     run_parser.add_argument("--quota-week-after")
     run_parser.add_argument("--quota-pool", choices=["claude", "codex"])
+    run_parser.add_argument("--task-id", help="the human key, e.g. AG-298")
+    run_parser.add_argument("--branch")
+    run_parser.add_argument("--pr")
 
     sweep_parser = sub.add_parser("sweep")
     sweep_parser.add_argument("--machine", required=True)
@@ -712,6 +715,9 @@ def main(argv=None) -> int:
                     quota_week_before=args.quota_week_before,
                     quota_week_after=args.quota_week_after,
                     quota_pool=args.quota_pool,
+                    task_id=args.task_id,
+                    branch=args.branch,
+                    pr=args.pr,
                 )
             )
             return 0

--- a/tools/loop/engine/lib/loopctl/writeback.py
+++ b/tools/loop/engine/lib/loopctl/writeback.py
@@ -234,6 +234,36 @@ def _quota_block(before_5h, after_5h, before_week, after_week, pool=None) -> dic
     }
 
 
+def _last_run_id_for(machine: str, task: str) -> str | None:
+    """The most recent run_id already recorded for this task on this machine.
+
+    A fix round is not declared, it is simply the next run on a task that already
+    has one, so the edge can be read off the ledger instead of being threaded
+    through every caller. Reads the partition backwards and stops at the first
+    match: the file is append-only and one line per run, so the last hit is the
+    parent.
+
+    Best-effort by the same rule as the rest of this module -- a missing or
+    unreadable ledger means no parent, never a failed run.
+    """
+    path = usage_path(f"loop-runs.{machine}.jsonl")
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError):
+        return None
+    for line in reversed(lines):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        if row.get("task") == task:
+            return row.get("run_id")
+    return None
+
+
 def append_run(
     *,
     project: str,
@@ -253,11 +283,33 @@ def append_run(
     quota_week_before: str | float | None = None,
     quota_week_after: str | float | None = None,
     quota_pool: str | None = None,
+    task_id: str | None = None,
+    branch: str | None = None,
+    pr: str | None = None,
 ) -> dict:
-    """Append one structured iteration/retro record to a machine partition."""
+    """Append one structured iteration/retro record to a machine partition.
+
+    The row carries edges as well as measurements. Without them the ledger could
+    say what a run cost but not what it was working on, where the work went, or
+    which earlier run it was fixing -- so "did the second attempt close what the
+    first missed" was unanswerable from own data, which is the whole question a
+    fix round exists to answer. These are id fields on an existing row, which is
+    what OpenLineage's parent facet and Pydantic AI's step persistence both
+    reduce to; neither needs a graph store.
+    """
     ended = ended_ts or int(time.time())
     record = {
         "run_id": f"{machine}-{ended}-{task}",
+        # The human key (AG-298), alongside `task` which is the source URL. Every
+        # other surface -- greenlight, notes, config -- speaks the human key, so a
+        # ledger that only knows the URL cannot be joined against any of them.
+        "task_id": task_id,
+        "branch": branch,
+        "pr": pr,
+        # Derived rather than passed: the caller has no reason to know it, and a
+        # fix round is simply the next run on a task that already has one. Reading
+        # it here means every caller gets the edge for free.
+        "parent_run_id": _last_run_id_for(machine, task),
         "project": project,
         "task": task,
         "executor": executor,

--- a/tools/loop/engine/ralph.sh
+++ b/tools/loop/engine/ralph.sh
@@ -791,6 +791,23 @@ print("5h {}pp to {}%, weekly {}pp to {}%".format(
   # Observatory/retro mirror is append-only and best-effort. The executor's
   # loopctl set remains the authoritative task-state transition.
   run_fields=()
+  # Edges, not measurements. `task_id` is the human key every other surface uses
+  # -- greenlight, notes, config all speak AG-298, so a row that knows only the
+  # source URL cannot be joined against any of them. The branch is read after the
+  # executor ran, because the executor is what creates it. The PR comes from the
+  # task's own overlay, which the executor set when it reached pr-ready.
+  [ -n "${task_item_id:-}" ] && run_fields+=(--task-id "$task_item_id")
+  run_branch=$(git -C "$project_path" rev-parse --abbrev-ref HEAD 2>/dev/null || printf '')
+  [ -n "$run_branch" ] && [ "$run_branch" != "HEAD" ] && run_fields+=(--branch "$run_branch")
+  run_pr=$("$LOOPCTL" show "$slug" 2>/dev/null | "$PYTHON_BIN" -c \
+    'import json, sys
+rows = (json.load(sys.stdin) or {}).get("tasks") or []
+want = sys.argv[1]
+for row in rows:
+    if str((row.get("metadata") or {}).get("item_id") or "") == want:
+        print(row.get("pr") or "")
+        break' "${task_item_id:-}" 2>/dev/null || printf '')
+  [ -n "$run_pr" ] && run_fields+=(--pr "$run_pr")
   [ -n "$PLAN_MODEL" ] && run_fields+=(--model "$PLAN_MODEL")
   [ -n "$PLAN_EFFORT" ] && run_fields+=(--effort "$PLAN_EFFORT")
   [ -n "$tokens_out" ] && run_fields+=(--tokens-out "$tokens_out")

--- a/tools/loop/tests/execution-presets.sh
+++ b/tools/loop/tests/execution-presets.sh
@@ -568,6 +568,38 @@ printf '{"type":"turn.completed"}\n' > "$ROOT/no-thread.log"
 check "no thread id means no number" "$(cpp "$ROOT/fakehome" "$ROOT/no-thread.log")" ""
 check "a missing transcript is silent" "$(cpp "$ROOT/fakehome" /nonexistent.log)" ""
 
+# --- 15. the run row carries edges, not just measurements --------------------
+# The ledger could say what a run cost but not what it worked on, where the work
+# went, or which earlier run it was fixing. "Did the second attempt close what
+# the first missed" is the whole question a fix round exists to answer, and it was
+# unanswerable from own data.
+echo "  run rows carry edges:"
+write_quota 10 20
+cat > "$ROOT/agents.json" <<JSON
+{
+  "default_agent": "claude",
+  "presets": {"deep": {"provider": "claude", "model": "claude-opus-5", "effort": "high"}},
+  "tasks": {"$TASK_KEY": {"preset": "deep"}}
+}
+JSON
+export LOOP_AGENT_CONFIG="$ROOT/agents.json"
+run_ralph
+sandbox_branch=$(git -C "$VAULT" rev-parse --abbrev-ref HEAD)
+check "the row names the branch it worked on" "$(last_run_field branch)" "$sandbox_branch"
+# First run on this task: nothing to be a fix round for.
+check "a first run has no parent" "$(last_run_field parent_run_id)" ""
+first_run=$(last_run_field run_id)
+# Second run on the same task IS the fix round, and the edge is derived from the
+# ledger rather than threaded through every caller.
+: > "$RALPH_TEST_CALLS"
+"$HOME_DIR/ralph.sh" 1 10 >/dev/null 2>&1
+check "the next run points at the previous one" "$(last_run_field parent_run_id)" "$first_run"
+check "and is not its own parent" "$([ "$(last_run_field parent_run_id)" = "$(last_run_field run_id)" ] && echo same || echo distinct)" "distinct"
+# An unrelated task must not inherit a parent from a different one.
+other=$(PYTHONPATH="$HOME_DIR/lib" "$VENV/bin/python" -c \
+  'from loopctl.writeback import _last_run_id_for; print(_last_run_id_for("'"$MACHINE"'", "no-such-task") or "")')
+check "a different task gets no parent" "$other" ""
+
 printf '\n  %d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ] || exit 1
 rm -rf "$ROOT"


### PR DESCRIPTION
feat(loop): give the run ledger edges, not just measurements

Gap 2 of the graph-engineering survey. The row already said what a run cost —
model, effort, output tokens, quota pool and pp delta. It did not say what the run
was working on, where the work went, or which earlier run it was fixing. So "did
the second attempt close what the first missed" was unanswerable from own data,
and that is the entire question a fix round exists to answer: on 2026-07-30 a
model was handed three numbered defects, fixed one, and shipped — and the ledger
had no way to show it.

Four id fields on an existing row:

  task_id         the human key (AG-298). `task` is the source URL, and every
                  other surface — greenlight, notes, config — speaks the human
                  key, so a ledger that knows only the URL joins to nothing.
  branch          read after the executor ran, since the executor creates it
  pr              from the task's own overlay, set when it reached pr-ready
  parent_run_id   the previous run on the same task

`parent_run_id` is derived, not passed. A fix round is not declared; it is simply
the next run on a task that already has one, so `_last_run_id_for` reads the
partition backwards and stops at the first match. The file is append-only and one
line per run, so the last hit is the parent. Every caller gets the edge without
knowing it exists. Best-effort by the same rule as the rest of the module: an
unreadable ledger means no parent, never a failed run.

This is what OpenLineage's parent facet and Pydantic AI's step persistence both
reduce to — a run-id string. Neither needs a graph store, and the survey's own
verdict was that nothing here justifies one below ~50k entities.

  execution-presets.sh    74 passed, 0 failed (was 69)
  rate-limit-detection.sh 11 passed, 0 failed

Verified against the real ledger: the lookback finds AG-132's prior run and
returns nothing for an unknown task. The new assertions cover a first run having
no parent, the second pointing at the first, a run not being its own parent, and
an unrelated task not inheriting one.

Gap 3 of the survey — routing feedback — is a join against this ledger and is
deliberately not built yet; it had nothing to join to until now.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
