### PR TITLE
fix(personal-calibre): declare the Next.js build output — workspace-wide cache-output audit

### DIFF
--- a/apps/personal-calibre/package.json
+++ b/apps/personal-calibre/package.json
@@ -43,6 +43,12 @@
         "options": {
           "port": 8080
         }
+      },
+      "build": {
+        "outputs": [
+          "{projectRoot}/.next/!(cache)/**/*",
+          "{projectRoot}/.next/!(cache)"
+        ]
       }
     }
   }


### PR DESCRIPTION
Follow-up to the `rainforest.tools` outage ([#296](https://github.com/rainforest-dev/rainforest-monorepo/pull/296)). That was caused by an Nx target whose declared `outputs` did not match what the build actually writes: a cache hit restored `dist/`, `.vercel/output` was never recreated, and Vercel served a routeless deployment — green build, 404 everywhere.

This audits all **46 cacheable targets** for the same shape and fixes the one other instance.

## The fix

`personal-calibre` defined no `build` config at all, so it inherited `nx.json`'s `targetDefaults` — `outputs: ["{projectRoot}/dist"]`, `cache: true`. It is a **Next.js app**: it writes `.next/`, and `dist` never exists. `personal-liff`, the workspace's other Next app, already declares the correct globs; this brings calibre in line.

## No production impact — stated plainly

calibre ships through Docker, and its Dockerfile runs `pnpm exec next build` **directly inside the image**, bypassing Nx and its cache entirely. CI runs lint/test/typecheck and never builds it.

So this is a latent correctness bug, not a live one. It is also the same bug that took the site down for six hours, sitting one consumer away from mattering.

## Verification

Same A/B as the outage — warm the cache with a normal run, delete every artefact, replay, diff:

```
803 artefacts | replay Cache: 1/1 hit (100%) | not restored: 3
```

The 3 are under `.next/cache`, which the `!(cache)` glob excludes deliberately — Next's own incremental cache, not build output.

## Audit results — everything else

All replays were genuine 100% cache hits:

| project | artefacts | not restored | verdict |
|---|---|---|---|
| personal-website | 524 | `.astro/`, `public/images/portfolio` | ✅ deployable output complete |
| personal-data | 16 | none | ✅ |
| loop-observatory | 37 | `.astro/` types | ✅ regenerable |
| rss-manager | 24 | `.astro/` types | ✅ regenerable |
| rainforest-ui | 45 | `out-tsc/storybook` | ✅ typecheck state |
| personal-calibre | 803 | `.next/cache` only | ✅ after this fix |

For `personal-website` specifically, the thing Vercel actually ships is complete on a cache hit: **23 routes**, `functions/`, `static/resume/index.html`, and all 8 portfolio images.

The `.astro/` type stubs and `out-tsc` tsbuildinfo files are regenerable intermediate state, not deliverables, and are left undeclared on purpose — the same reasoning that excludes `.next/cache`. `personal-data` and `personal-portfolio` typecheck emit nothing at all, so declaring no outputs is correct for them.

## Methodological note

The first pass used `--skip-nx-cache` to force a cold build. That skips the cache **write** as well as the read, so every "replay" missed and silently rebuilt — and all six projects looked clean. Warming with a normal run first is what made the hits real, and what surfaced calibre. Worth knowing before repeating this.

Gates: `nx run-many -t test --all` green (6 projects), `format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)